### PR TITLE
Session persistence, right-panel UI, and MCP orchestration tools

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -18,6 +18,7 @@ type StartupSession = {
   command?: string
   prompt?: string
   agent?: string
+  model?: string
 }
 
 type Config = {
@@ -235,17 +236,24 @@ function quoteForCmd(s: string): string {
 function buildClaudeCommand(opts: {
   sessionId: string
   agent?: string
+  model?: string
   userPrompt?: string
   resume?: boolean
 }): string {
   const flags: string[] = [`--mcp-config "${mcpConfigPath}"`]
   if (opts.resume) {
     flags.push(`--resume "${opts.sessionId}"`)
+    if (opts.model && opts.model.length > 0) {
+      flags.push(`--model "${opts.model}"`)
+    }
     return `claude ${flags.join(' ')}`
   }
   flags.push(`--session-id "${opts.sessionId}"`)
   if (opts.agent && opts.agent.length > 0) {
     flags.push(`--agent "${opts.agent}"`)
+  }
+  if (opts.model && opts.model.length > 0) {
+    flags.push(`--model "${opts.model}"`)
   }
   let cmd = `claude ${flags.join(' ')}`
   if (opts.userPrompt && opts.userPrompt.length > 0) {
@@ -268,6 +276,7 @@ function createSessionInternal(opts: {
   command?: string
   prompt?: string
   agent?: string
+  model?: string
   source: 'ipc' | 'mcp' | 'startup' | 'resume'
 }): { id: string; cwd: string } {
   const id = opts.id ?? randomUUID()
@@ -315,6 +324,7 @@ function createSessionInternal(opts: {
       finalCommand = buildClaudeCommand({
         sessionId: id,
         agent: opts.source !== 'resume' ? opts.agent : undefined,
+        model: opts.model,
         userPrompt: opts.source !== 'resume' ? opts.prompt : undefined,
         resume: opts.source === 'resume',
       })
@@ -417,6 +427,7 @@ function bootstrapSessions(config: Config) {
         command: entry.command,
         prompt: entry.prompt,
         agent: entry.agent,
+        model: entry.model,
         source: 'startup',
       })
       occupiedCwds.add(entry.cwd)
@@ -434,12 +445,13 @@ app.whenReady().then(async () => {
     mcpHandle = await startMcpServer({
       port: config.mcpPort,
       hooks: {
-        openClaudeSession: ({ cwd, prompt, agent }) =>
+        openClaudeSession: ({ cwd, prompt, agent, model }) =>
           createSessionInternal({
             cwd,
             command: 'claude',
             prompt,
             agent,
+            model,
             source: 'mcp',
           }),
       },

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -9,6 +9,7 @@ import { startMcpServer, type McpHandle } from './mcp'
 type Session = {
   id: string
   cwd: string
+  command?: string
   term: pty.IPty
 }
 
@@ -17,6 +18,12 @@ type StartupSession = { cwd: string; command?: string; prompt?: string }
 type Config = {
   mcpPort: number
   startupSessions: StartupSession[]
+}
+
+type PersistedSession = {
+  id: string
+  cwd: string
+  command?: string
 }
 
 const DEFAULT_CONFIG: Config = {
@@ -35,6 +42,44 @@ function getConfigPath(): string {
 
 function getMcpConfigPath(): string {
   return path.join(app.getPath('userData'), 'mcp-config.json')
+}
+
+function getSessionsPath(): string {
+  return path.join(app.getPath('userData'), 'sessions.json')
+}
+
+function loadPersistedSessions(): PersistedSession[] {
+  try {
+    const raw = fs.readFileSync(getSessionsPath(), 'utf8')
+    const arr = JSON.parse(raw)
+    if (!Array.isArray(arr)) return []
+    return arr.filter(
+      (s): s is PersistedSession =>
+        s != null &&
+        typeof s.id === 'string' &&
+        typeof s.cwd === 'string' &&
+        (s.command === undefined || typeof s.command === 'string'),
+    )
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.error('[termhub] failed to load persisted sessions:', err)
+    }
+    return []
+  }
+}
+
+function persistSessions() {
+  const list: PersistedSession[] = Array.from(sessions.values()).map((s) => ({
+    id: s.id,
+    cwd: s.cwd,
+    command: s.command,
+  }))
+  try {
+    fs.mkdirSync(path.dirname(getSessionsPath()), { recursive: true })
+    fs.writeFileSync(getSessionsPath(), JSON.stringify(list, null, 2))
+  } catch (err) {
+    console.error('[termhub] failed to persist sessions:', err)
+  }
 }
 
 function loadConfig(): Config {
@@ -87,14 +132,23 @@ function writeMcpConfigFile(port: number): string {
   return configPath
 }
 
-function injectMcpConfig(rawCommand: string): string {
+function injectClaudeFlags(
+  rawCommand: string,
+  sessionId: string,
+  opts: { resume?: boolean } = {},
+): string {
   const trimmed = rawCommand.trim()
   // Match `claude` as the leading word (with or without trailing args)
   const m = /^claude(?:\s+([\s\S]*))?$/.exec(trimmed)
   if (!m) return rawCommand
   const args = m[1]
-  const flag = `--mcp-config "${mcpConfigPath}"`
-  return args ? `claude ${flag} ${args}` : `claude ${flag}`
+  if (opts.resume) {
+    // On resume, drop user-provided args (a positional prompt would be sent
+    // again, double-posting the user's first message).
+    return `claude --mcp-config "${mcpConfigPath}" --resume "${sessionId}"`
+  }
+  const flags = `--mcp-config "${mcpConfigPath}" --session-id "${sessionId}"`
+  return args ? `claude ${flags} ${args}` : `claude ${flags}`
 }
 
 function cleanEnv(): Record<string, string> {
@@ -106,12 +160,13 @@ function cleanEnv(): Record<string, string> {
 }
 
 function createSessionInternal(opts: {
+  id?: string
   cwd: string
   command?: string
   prompt?: string
-  source: 'ipc' | 'mcp' | 'startup'
+  source: 'ipc' | 'mcp' | 'startup' | 'resume'
 }): { id: string; cwd: string } {
-  const id = randomUUID()
+  const id = opts.id ?? randomUUID()
   const shell = process.env.COMSPEC || 'cmd.exe'
   console.log(
     `[termhub] spawning ${shell} in ${opts.cwd} (id=${id.slice(0, 8)}, source=${opts.source})`,
@@ -144,27 +199,33 @@ function createSessionInternal(opts: {
     console.log(`[termhub] session ${id.slice(0, 8)} exited (code=${exitCode})`)
     mainWindow?.webContents.send('session:exit', { id, exitCode })
     sessions.delete(id)
+    persistSessions()
   })
 
-  sessions.set(id, { id, cwd: opts.cwd, term })
+  sessions.set(id, { id, cwd: opts.cwd, command: opts.command, term })
+  persistSessions()
 
   if (opts.command && opts.command.trim().length > 0) {
-    const finalCommand = injectMcpConfig(opts.command)
+    const finalCommand = injectClaudeFlags(opts.command, id, {
+      resume: opts.source === 'resume',
+    })
     setTimeout(() => {
       if (sessions.has(id)) term.write(`${finalCommand}\r`)
     }, 150)
   }
 
-  if (opts.prompt && opts.prompt.length > 0) {
-    // Wait for the launched program (claude) to be ready to accept input
+  // Don't replay prompts on resume — the original user message is already
+  // in claude's session history and would be double-posted.
+  if (opts.source !== 'resume' && opts.prompt && opts.prompt.length > 0) {
     const sanitized = opts.prompt.replace(/\r?\n/g, ' ')
     setTimeout(() => {
       if (sessions.has(id)) term.write(`${sanitized}\r`)
     }, 2500)
   }
 
-  if (opts.source === 'mcp') {
-    mainWindow?.webContents.send('session:added', { id, cwd: opts.cwd })
+  if (opts.source !== 'ipc') {
+    const autoActivate = opts.source === 'startup' || opts.source === 'resume'
+    mainWindow?.webContents.send('session:added', { id, cwd: opts.cwd, autoActivate })
   }
 
   return { id, cwd: opts.cwd }
@@ -210,6 +271,52 @@ function killAllSessions() {
   sessions.clear()
 }
 
+// Renderer signals readiness via 'app:ready' once it has subscribed to
+// session:data / session:added / session:exit. We defer creating the
+// startup + resume sessions until after that, otherwise early pty output
+// would be sent before any listener exists.
+let rendererReadyResolve: (() => void) | null = null
+const rendererReady = new Promise<void>((resolve) => {
+  rendererReadyResolve = resolve
+})
+
+function bootstrapSessions(config: Config) {
+  const persisted = loadPersistedSessions()
+  const occupiedCwds = new Set<string>()
+
+  for (const s of persisted) {
+    try {
+      createSessionInternal({
+        id: s.id,
+        cwd: s.cwd,
+        command: s.command,
+        source: 'resume',
+      })
+      occupiedCwds.add(s.cwd)
+    } catch (err) {
+      console.error(`[termhub] failed to resume session ${s.id.slice(0, 8)}:`, err)
+    }
+  }
+
+  for (const entry of config.startupSessions) {
+    if (occupiedCwds.has(entry.cwd)) {
+      console.log(`[termhub] skipping startup entry ${entry.cwd} (resumed from persistence)`)
+      continue
+    }
+    try {
+      createSessionInternal({
+        cwd: entry.cwd,
+        command: entry.command,
+        prompt: entry.prompt,
+        source: 'startup',
+      })
+      occupiedCwds.add(entry.cwd)
+    } catch (err) {
+      console.error('[termhub] startup session failed for', entry.cwd, err)
+    }
+  }
+}
+
 app.whenReady().then(async () => {
   const config = loadConfig()
   mcpConfigPath = writeMcpConfigFile(config.mcpPort)
@@ -231,7 +338,14 @@ app.whenReady().then(async () => {
     console.error('[termhub] failed to start MCP server:', err)
   }
 
+  ipcMain.once('app:ready', () => {
+    rendererReadyResolve?.()
+  })
+
   createWindow()
+
+  // Bootstrap once the renderer is listening
+  rendererReady.then(() => bootstrapSessions(config))
 
   ipcMain.handle(
     'session:create',
@@ -273,7 +387,12 @@ app.whenReady().then(async () => {
       // already dead
     }
     sessions.delete(payload.id)
+    persistSessions()
   })
+
+  ipcMain.handle('sessions:list', () =>
+    Array.from(sessions.values()).map((s) => ({ id: s.id, cwd: s.cwd })),
+  )
 
   ipcMain.handle('dialog:pickFolder', async () => {
     if (!mainWindow) return null

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -267,20 +267,10 @@ function isClaudeCommand(cmd: string): boolean {
   return /^claude(\s|$)/.test(cmd.trim())
 }
 
-// Quote a string so cmd.exe passes it as a single argument to claude.
-// - collapse whitespace (cmd doesn't allow embedded newlines in args)
-// - escape internal double-quotes by doubling them (cmd.exe convention)
-function quoteForCmd(s: string): string {
-  const cleaned = s.replace(/\r?\n+/g, ' ').replace(/\s+/g, ' ').trim()
-  const escaped = cleaned.replace(/"/g, '""')
-  return `"${escaped}"`
-}
-
 function buildClaudeCommand(opts: {
   sessionId: string
   agent?: string
   model?: string
-  userPrompt?: string
   resume?: boolean
   dangerouslySkipPermissions?: boolean
 }): string {
@@ -305,11 +295,14 @@ function buildClaudeCommand(opts: {
   if (opts.dangerouslySkipPermissions) {
     flags.push('--dangerously-skip-permissions')
   }
-  let cmd = `claude ${flags.join(' ')}`
-  if (opts.userPrompt && opts.userPrompt.length > 0) {
-    cmd += ` ${quoteForCmd(opts.userPrompt)}`
-  }
-  return cmd
+  return `claude ${flags.join(' ')}`
+}
+
+// Wrap text in bracketed-paste markers + Enter. Claude's TUI (Ink) handles
+// bracketed paste atomically, so arbitrarily long / shell-special content
+// can be injected without cmd.exe seeing or trying to parse it.
+function bracketedPasteWithSubmit(text: string): string {
+  return `\x1b[200~${text}\x1b[201~\r`
 }
 
 function cleanEnv(): Record<string, string> {
@@ -385,7 +378,6 @@ function createSessionInternal(opts: {
         agent: opts.source !== 'resume' ? opts.agent : undefined,
         model: opts.model,
         dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
-        userPrompt: opts.source !== 'resume' ? opts.prompt : undefined,
         resume: opts.source === 'resume',
       })
     } else {
@@ -394,6 +386,18 @@ function createSessionInternal(opts: {
     setTimeout(() => {
       if (sessions.has(id)) term.write(`${finalCommand}\r`)
     }, 150)
+  }
+
+  // Send the prompt to claude's TUI as a bracketed paste, after it's had
+  // time to start. This avoids cmd.exe's quoting limits for prompts with
+  // embedded quotes, backticks, $(), <>, etc.
+  if (opts.source !== 'resume' && opts.prompt && opts.prompt.length > 0) {
+    const text = opts.prompt
+    setTimeout(() => {
+      if (sessions.has(id)) {
+        session.term.write(bracketedPasteWithSubmit(text))
+      }
+    }, 2500)
   }
 
   if (opts.source !== 'ipc') {
@@ -519,9 +523,8 @@ app.whenReady().then(async () => {
         sendInput: ({ sessionId, text }) => {
           const result = findSessionByIdOrPrefix(sessionId)
           if (!result.found) return { ok: false, error: result.error }
-          const sanitized = text.replace(/\r?\n+/g, ' ')
           try {
-            result.session.term.write(`${sanitized}\r`)
+            result.session.term.write(bracketedPasteWithSubmit(text))
             return { ok: true }
           } catch (err) {
             return {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -11,6 +11,48 @@ type Session = {
   cwd: string
   command?: string
   term: pty.IPty
+  outputBuffer: string
+}
+
+const MAX_OUTPUT_BUFFER_BYTES = 256 * 1024
+
+function appendToBuffer(buf: string, chunk: string): string {
+  const combined = buf + chunk
+  if (combined.length <= MAX_OUTPUT_BUFFER_BYTES) return combined
+  return combined.slice(combined.length - MAX_OUTPUT_BUFFER_BYTES)
+}
+
+// Lossy but adequate ANSI/control-char stripper for read_output. Captures
+// CSI/OSC/DCS sequences and stray control bytes; doesn't replay cursor
+// movement, so heavy TUI output (e.g. claude's input box) won't reconstruct
+// perfectly — but plain text and message bodies come through cleanly.
+function stripAnsi(s: string): string {
+  return s
+    .replace(/\x1b\[[\d;?]*[a-zA-Z]/g, '')
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '')
+    .replace(/\x1b[PX^_][\s\S]*?\x1b\\/g, '')
+    .replace(/\x1b[=>()*+\-.\/]./g, '')
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '')
+}
+
+type FindSessionResult =
+  | { found: true; session: Session }
+  | { found: false; error: string }
+
+function findSessionByIdOrPrefix(idOrPrefix: string): FindSessionResult {
+  const direct = sessions.get(idOrPrefix)
+  if (direct) return { found: true, session: direct }
+  const matches = Array.from(sessions.values()).filter((s) =>
+    s.id.startsWith(idOrPrefix),
+  )
+  if (matches.length === 1) return { found: true, session: matches[0] }
+  if (matches.length === 0) {
+    return { found: false, error: `No session found for "${idOrPrefix}"` }
+  }
+  return {
+    found: false,
+    error: `Ambiguous prefix "${idOrPrefix}" — matches ${matches.length} sessions`,
+  }
 }
 
 type StartupSession = {
@@ -308,12 +350,23 @@ function createSessionInternal(opts: {
   }
   console.log(`[termhub] pty.spawn returned (pid=${term.pid})`)
 
+  const session: Session = {
+    id,
+    cwd: opts.cwd,
+    command: opts.command,
+    term,
+    outputBuffer: '',
+  }
+  sessions.set(id, session)
+  persistSessions()
+
   let firstData = true
   term.onData((data) => {
     if (firstData) {
       firstData = false
       console.log(`[termhub] first data from ${id.slice(0, 8)} (${data.length} bytes)`)
     }
+    session.outputBuffer = appendToBuffer(session.outputBuffer, data)
     mainWindow?.webContents.send('session:data', { id, data })
   })
 
@@ -323,9 +376,6 @@ function createSessionInternal(opts: {
     sessions.delete(id)
     persistSessions()
   })
-
-  sessions.set(id, { id, cwd: opts.cwd, command: opts.command, term })
-  persistSessions()
 
   if (opts.command && opts.command.trim().length > 0) {
     let finalCommand: string
@@ -466,6 +516,30 @@ app.whenReady().then(async () => {
             dangerouslySkipPermissions,
             source: 'mcp',
           }),
+        sendInput: ({ sessionId, text }) => {
+          const result = findSessionByIdOrPrefix(sessionId)
+          if (!result.found) return { ok: false, error: result.error }
+          const sanitized = text.replace(/\r?\n+/g, ' ')
+          try {
+            result.session.term.write(`${sanitized}\r`)
+            return { ok: true }
+          } catch (err) {
+            return {
+              ok: false,
+              error: err instanceof Error ? err.message : String(err),
+            }
+          }
+        },
+        readOutput: ({ sessionId, maxChars, raw }) => {
+          const result = findSessionByIdOrPrefix(sessionId)
+          if (!result.found) return { error: result.error }
+          let text = result.session.outputBuffer
+          if (!raw) text = stripAnsi(text)
+          if (typeof maxChars === 'number' && maxChars > 0 && text.length > maxChars) {
+            text = text.slice(text.length - maxChars)
+          }
+          return { text }
+        },
       },
     })
   } catch (err) {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -305,10 +305,21 @@ function bracketedPasteWithSubmit(text: string): string {
   return `\x1b[200~${text}\x1b[201~\r`
 }
 
+// CLAUDE_* / CLAUDECODE / similar vars from a parent claude session leak
+// into spawned child claudes and confuse them — e.g.
+// CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1 trips the sandbox preflight and
+// makes claude refuse to start. Always strip these so the child boots
+// from a clean baseline.
+const PARENT_CLAUDE_ENV_PREFIXES = ['CLAUDE_', 'CLAUDECODE']
+const PARENT_CLAUDE_ENV_EXACT = new Set(['DEFAULT_LLM_MODEL'])
+
 function cleanEnv(): Record<string, string> {
   const out: Record<string, string> = {}
   for (const [k, v] of Object.entries(process.env)) {
-    if (typeof v === 'string') out[k] = v
+    if (typeof v !== 'string') continue
+    if (PARENT_CLAUDE_ENV_EXACT.has(k)) continue
+    if (PARENT_CLAUDE_ENV_PREFIXES.some((p) => k.startsWith(p))) continue
+    out[k] = v
   }
   return out
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -155,18 +155,6 @@ function listSkills(): SkillDef[] {
   return out
 }
 
-function loadAgentBody(name: string): string | null {
-  const filePath = path.join(getAgentsDir(), `${name}.md`)
-  try {
-    const content = fs.readFileSync(filePath, 'utf8')
-    const m = /^---\r?\n[\s\S]*?\r?\n---\r?\n([\s\S]*)$/.exec(content)
-    return (m ? m[1] : content).trim()
-  } catch (err) {
-    console.error(`[termhub] failed to load agent "${name}":`, err)
-    return null
-  }
-}
-
 function persistSessions() {
   const list: PersistedSession[] = Array.from(sessions.values()).map((s) => ({
     id: s.id,
@@ -246,7 +234,7 @@ function quoteForCmd(s: string): string {
 
 function buildClaudeCommand(opts: {
   sessionId: string
-  agentBody?: string
+  agent?: string
   userPrompt?: string
   resume?: boolean
 }): string {
@@ -256,8 +244,8 @@ function buildClaudeCommand(opts: {
     return `claude ${flags.join(' ')}`
   }
   flags.push(`--session-id "${opts.sessionId}"`)
-  if (opts.agentBody && opts.agentBody.length > 0) {
-    flags.push(`--append-system-prompt ${quoteForCmd(opts.agentBody)}`)
+  if (opts.agent && opts.agent.length > 0) {
+    flags.push(`--agent "${opts.agent}"`)
   }
   let cmd = `claude ${flags.join(' ')}`
   if (opts.userPrompt && opts.userPrompt.length > 0) {
@@ -324,18 +312,9 @@ function createSessionInternal(opts: {
   if (opts.command && opts.command.trim().length > 0) {
     let finalCommand: string
     if (isClaudeCommand(opts.command)) {
-      let agentBody: string | undefined
-      if (opts.source !== 'resume' && opts.agent) {
-        const body = loadAgentBody(opts.agent)
-        if (body) {
-          agentBody = body
-        } else {
-          console.warn(`[termhub] agent "${opts.agent}" not found in ${getAgentsDir()}`)
-        }
-      }
       finalCommand = buildClaudeCommand({
         sessionId: id,
-        agentBody,
+        agent: opts.source !== 'resume' ? opts.agent : undefined,
         userPrompt: opts.source !== 'resume' ? opts.prompt : undefined,
         resume: opts.source === 'resume',
       })

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -72,6 +72,10 @@ function getAgentsDir(): string {
   return path.join(os.homedir(), '.claude', 'agents')
 }
 
+function getSkillsDir(): string {
+  return path.join(os.homedir(), '.claude', 'skills')
+}
+
 type AgentDef = { name: string; path: string; description?: string }
 
 function listAgents(): AgentDef[] {
@@ -114,6 +118,36 @@ function parseAgentDescription(filePath: string): string | undefined {
   } catch {
     return undefined
   }
+}
+
+type SkillDef = { name: string; path: string; description?: string }
+
+function listSkills(): SkillDef[] {
+  const dir = getSkillsDir()
+  let entries: fs.Dirent[]
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true })
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return []
+    console.error('[termhub] failed to list skills:', err)
+    return []
+  }
+  const out: SkillDef[] = []
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const skillMdPath = path.join(dir, entry.name, 'SKILL.md')
+    let stat
+    try {
+      stat = fs.statSync(skillMdPath)
+    } catch {
+      continue
+    }
+    if (!stat.isFile()) continue
+    const description = parseAgentDescription(skillMdPath)
+    out.push({ name: entry.name, path: skillMdPath, description })
+  }
+  out.sort((a, b) => a.name.localeCompare(b.name))
+  return out
 }
 
 function loadAgentBody(name: string): string | null {
@@ -483,6 +517,18 @@ app.whenReady().then(async () => {
     const agentsDir = path.resolve(getAgentsDir())
     if (!resolved.startsWith(agentsDir + path.sep) && resolved !== agentsDir) {
       throw new Error('Refusing to open path outside agents dir')
+    }
+    const err = await shell.openPath(resolved)
+    if (err) throw new Error(err)
+  })
+
+  ipcMain.handle('skills:list', () => listSkills())
+
+  ipcMain.handle('skills:open', async (_event, filePath: string) => {
+    const resolved = path.resolve(filePath)
+    const skillsDir = path.resolve(getSkillsDir())
+    if (!resolved.startsWith(skillsDir + path.sep) && resolved !== skillsDir) {
+      throw new Error('Refusing to open path outside skills dir')
     }
     const err = await shell.openPath(resolved)
     if (err) throw new Error(err)

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -231,23 +231,39 @@ function writeMcpConfigFile(port: number): string {
   return configPath
 }
 
-function injectClaudeFlags(
-  rawCommand: string,
-  sessionId: string,
-  opts: { resume?: boolean } = {},
-): string {
-  const trimmed = rawCommand.trim()
-  // Match `claude` as the leading word (with or without trailing args)
-  const m = /^claude(?:\s+([\s\S]*))?$/.exec(trimmed)
-  if (!m) return rawCommand
-  const args = m[1]
+function isClaudeCommand(cmd: string): boolean {
+  return /^claude(\s|$)/.test(cmd.trim())
+}
+
+// Quote a string so cmd.exe passes it as a single argument to claude.
+// - collapse whitespace (cmd doesn't allow embedded newlines in args)
+// - escape internal double-quotes by doubling them (cmd.exe convention)
+function quoteForCmd(s: string): string {
+  const cleaned = s.replace(/\r?\n+/g, ' ').replace(/\s+/g, ' ').trim()
+  const escaped = cleaned.replace(/"/g, '""')
+  return `"${escaped}"`
+}
+
+function buildClaudeCommand(opts: {
+  sessionId: string
+  agentBody?: string
+  userPrompt?: string
+  resume?: boolean
+}): string {
+  const flags: string[] = [`--mcp-config "${mcpConfigPath}"`]
   if (opts.resume) {
-    // On resume, drop user-provided args (a positional prompt would be sent
-    // again, double-posting the user's first message).
-    return `claude --mcp-config "${mcpConfigPath}" --resume "${sessionId}"`
+    flags.push(`--resume "${opts.sessionId}"`)
+    return `claude ${flags.join(' ')}`
   }
-  const flags = `--mcp-config "${mcpConfigPath}" --session-id "${sessionId}"`
-  return args ? `claude ${flags} ${args}` : `claude ${flags}`
+  flags.push(`--session-id "${opts.sessionId}"`)
+  if (opts.agentBody && opts.agentBody.length > 0) {
+    flags.push(`--append-system-prompt ${quoteForCmd(opts.agentBody)}`)
+  }
+  let cmd = `claude ${flags.join(' ')}`
+  if (opts.userPrompt && opts.userPrompt.length > 0) {
+    cmd += ` ${quoteForCmd(opts.userPrompt)}`
+  }
+  return cmd
 }
 
 function cleanEnv(): Record<string, string> {
@@ -306,31 +322,29 @@ function createSessionInternal(opts: {
   persistSessions()
 
   if (opts.command && opts.command.trim().length > 0) {
-    const finalCommand = injectClaudeFlags(opts.command, id, {
-      resume: opts.source === 'resume',
-    })
+    let finalCommand: string
+    if (isClaudeCommand(opts.command)) {
+      let agentBody: string | undefined
+      if (opts.source !== 'resume' && opts.agent) {
+        const body = loadAgentBody(opts.agent)
+        if (body) {
+          agentBody = body
+        } else {
+          console.warn(`[termhub] agent "${opts.agent}" not found in ${getAgentsDir()}`)
+        }
+      }
+      finalCommand = buildClaudeCommand({
+        sessionId: id,
+        agentBody,
+        userPrompt: opts.source !== 'resume' ? opts.prompt : undefined,
+        resume: opts.source === 'resume',
+      })
+    } else {
+      finalCommand = opts.command
+    }
     setTimeout(() => {
       if (sessions.has(id)) term.write(`${finalCommand}\r`)
     }, 150)
-  }
-
-  // Build the first user message: agent body (if any) + user prompt.
-  let firstMessage = opts.source !== 'resume' ? opts.prompt ?? '' : ''
-  if (opts.source !== 'resume' && opts.agent) {
-    const body = loadAgentBody(opts.agent)
-    if (body) {
-      firstMessage = firstMessage
-        ? `${body}\n\nUser request: ${firstMessage}`
-        : body
-    } else {
-      console.warn(`[termhub] agent "${opts.agent}" not found in ${getAgentsDir()}`)
-    }
-  }
-  if (firstMessage.length > 0) {
-    const sanitized = firstMessage.replace(/\r?\n+/g, ' ').replace(/\s+/g, ' ').trim()
-    setTimeout(() => {
-      if (sessions.has(id)) term.write(`${sanitized}\r`)
-    }, 2500)
   }
 
   if (opts.source !== 'ipc') {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -13,7 +13,12 @@ type Session = {
   term: pty.IPty
 }
 
-type StartupSession = { cwd: string; command?: string; prompt?: string }
+type StartupSession = {
+  cwd: string
+  command?: string
+  prompt?: string
+  agent?: string
+}
 
 type Config = {
   mcpPort: number
@@ -28,7 +33,7 @@ type PersistedSession = {
 
 const DEFAULT_CONFIG: Config = {
   mcpPort: 7787,
-  startupSessions: [{ cwd: 'E:/', command: 'claude' }],
+  startupSessions: [{ cwd: 'E:/', command: 'claude', agent: 'orchestrator' }],
 }
 
 const sessions = new Map<string, Session>()
@@ -418,6 +423,7 @@ function bootstrapSessions(config: Config) {
         cwd: entry.cwd,
         command: entry.command,
         prompt: entry.prompt,
+        agent: entry.agent,
         source: 'startup',
       })
       occupiedCwds.add(entry.cwd)

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -19,6 +19,7 @@ type StartupSession = {
   prompt?: string
   agent?: string
   model?: string
+  dangerouslySkipPermissions?: boolean
 }
 
 type Config = {
@@ -239,12 +240,16 @@ function buildClaudeCommand(opts: {
   model?: string
   userPrompt?: string
   resume?: boolean
+  dangerouslySkipPermissions?: boolean
 }): string {
   const flags: string[] = [`--mcp-config "${mcpConfigPath}"`]
   if (opts.resume) {
     flags.push(`--resume "${opts.sessionId}"`)
     if (opts.model && opts.model.length > 0) {
       flags.push(`--model "${opts.model}"`)
+    }
+    if (opts.dangerouslySkipPermissions) {
+      flags.push('--dangerously-skip-permissions')
     }
     return `claude ${flags.join(' ')}`
   }
@@ -254,6 +259,9 @@ function buildClaudeCommand(opts: {
   }
   if (opts.model && opts.model.length > 0) {
     flags.push(`--model "${opts.model}"`)
+  }
+  if (opts.dangerouslySkipPermissions) {
+    flags.push('--dangerously-skip-permissions')
   }
   let cmd = `claude ${flags.join(' ')}`
   if (opts.userPrompt && opts.userPrompt.length > 0) {
@@ -277,6 +285,7 @@ function createSessionInternal(opts: {
   prompt?: string
   agent?: string
   model?: string
+  dangerouslySkipPermissions?: boolean
   source: 'ipc' | 'mcp' | 'startup' | 'resume'
 }): { id: string; cwd: string } {
   const id = opts.id ?? randomUUID()
@@ -325,6 +334,7 @@ function createSessionInternal(opts: {
         sessionId: id,
         agent: opts.source !== 'resume' ? opts.agent : undefined,
         model: opts.model,
+        dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
         userPrompt: opts.source !== 'resume' ? opts.prompt : undefined,
         resume: opts.source === 'resume',
       })
@@ -428,6 +438,7 @@ function bootstrapSessions(config: Config) {
         prompt: entry.prompt,
         agent: entry.agent,
         model: entry.model,
+        dangerouslySkipPermissions: entry.dangerouslySkipPermissions,
         source: 'startup',
       })
       occupiedCwds.add(entry.cwd)
@@ -445,13 +456,14 @@ app.whenReady().then(async () => {
     mcpHandle = await startMcpServer({
       port: config.mcpPort,
       hooks: {
-        openClaudeSession: ({ cwd, prompt, agent, model }) =>
+        openClaudeSession: ({ cwd, prompt, agent, model, dangerouslySkipPermissions }) =>
           createSessionInternal({
             cwd,
             command: 'claude',
             prompt,
             agent,
             model,
+            dangerouslySkipPermissions,
             source: 'mcp',
           }),
       },

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, dialog, clipboard } from 'electron'
+import { app, BrowserWindow, ipcMain, dialog, clipboard, shell } from 'electron'
 import * as pty from '@lydell/node-pty'
 import * as path from 'node:path'
 import * as os from 'node:os'
@@ -65,6 +65,66 @@ function loadPersistedSessions(): PersistedSession[] {
       console.error('[termhub] failed to load persisted sessions:', err)
     }
     return []
+  }
+}
+
+function getAgentsDir(): string {
+  return path.join(os.homedir(), '.claude', 'agents')
+}
+
+type AgentDef = { name: string; path: string; description?: string }
+
+function listAgents(): AgentDef[] {
+  const dir = getAgentsDir()
+  let entries: string[]
+  try {
+    entries = fs.readdirSync(dir)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return []
+    console.error('[termhub] failed to list agents:', err)
+    return []
+  }
+  const out: AgentDef[] = []
+  for (const entry of entries) {
+    if (!entry.toLowerCase().endsWith('.md')) continue
+    const filePath = path.join(dir, entry)
+    let stat
+    try {
+      stat = fs.statSync(filePath)
+    } catch {
+      continue
+    }
+    if (!stat.isFile()) continue
+    const name = entry.replace(/\.md$/i, '')
+    const description = parseAgentDescription(filePath)
+    out.push({ name, path: filePath, description })
+  }
+  out.sort((a, b) => a.name.localeCompare(b.name))
+  return out
+}
+
+function parseAgentDescription(filePath: string): string | undefined {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8')
+    const m = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content)
+    if (!m) return undefined
+    const desc = /^description:\s*(.+)$/im.exec(m[1])
+    if (!desc) return undefined
+    return desc[1].trim().replace(/^["']|["']$/g, '')
+  } catch {
+    return undefined
+  }
+}
+
+function loadAgentBody(name: string): string | null {
+  const filePath = path.join(getAgentsDir(), `${name}.md`)
+  try {
+    const content = fs.readFileSync(filePath, 'utf8')
+    const m = /^---\r?\n[\s\S]*?\r?\n---\r?\n([\s\S]*)$/.exec(content)
+    return (m ? m[1] : content).trim()
+  } catch (err) {
+    console.error(`[termhub] failed to load agent "${name}":`, err)
+    return null
   }
 }
 
@@ -164,6 +224,7 @@ function createSessionInternal(opts: {
   cwd: string
   command?: string
   prompt?: string
+  agent?: string
   source: 'ipc' | 'mcp' | 'startup' | 'resume'
 }): { id: string; cwd: string } {
   const id = opts.id ?? randomUUID()
@@ -214,10 +275,20 @@ function createSessionInternal(opts: {
     }, 150)
   }
 
-  // Don't replay prompts on resume — the original user message is already
-  // in claude's session history and would be double-posted.
-  if (opts.source !== 'resume' && opts.prompt && opts.prompt.length > 0) {
-    const sanitized = opts.prompt.replace(/\r?\n/g, ' ')
+  // Build the first user message: agent body (if any) + user prompt.
+  let firstMessage = opts.source !== 'resume' ? opts.prompt ?? '' : ''
+  if (opts.source !== 'resume' && opts.agent) {
+    const body = loadAgentBody(opts.agent)
+    if (body) {
+      firstMessage = firstMessage
+        ? `${body}\n\nUser request: ${firstMessage}`
+        : body
+    } else {
+      console.warn(`[termhub] agent "${opts.agent}" not found in ${getAgentsDir()}`)
+    }
+  }
+  if (firstMessage.length > 0) {
+    const sanitized = firstMessage.replace(/\r?\n+/g, ' ').replace(/\s+/g, ' ').trim()
     setTimeout(() => {
       if (sessions.has(id)) term.write(`${sanitized}\r`)
     }, 2500)
@@ -225,7 +296,12 @@ function createSessionInternal(opts: {
 
   if (opts.source !== 'ipc') {
     const autoActivate = opts.source === 'startup' || opts.source === 'resume'
-    mainWindow?.webContents.send('session:added', { id, cwd: opts.cwd, autoActivate })
+    mainWindow?.webContents.send('session:added', {
+      id,
+      cwd: opts.cwd,
+      command: opts.command,
+      autoActivate,
+    })
   }
 
   return { id, cwd: opts.cwd }
@@ -325,11 +401,12 @@ app.whenReady().then(async () => {
     mcpHandle = await startMcpServer({
       port: config.mcpPort,
       hooks: {
-        openClaudeSession: ({ cwd, prompt }) =>
+        openClaudeSession: ({ cwd, prompt, agent }) =>
           createSessionInternal({
             cwd,
             command: 'claude',
             prompt,
+            agent,
             source: 'mcp',
           }),
       },
@@ -391,8 +468,25 @@ app.whenReady().then(async () => {
   })
 
   ipcMain.handle('sessions:list', () =>
-    Array.from(sessions.values()).map((s) => ({ id: s.id, cwd: s.cwd })),
+    Array.from(sessions.values()).map((s) => ({
+      id: s.id,
+      cwd: s.cwd,
+      command: s.command,
+    })),
   )
+
+  ipcMain.handle('agents:list', () => listAgents())
+
+  ipcMain.handle('agents:open', async (_event, filePath: string) => {
+    // Only open files inside our agents dir, no traversal.
+    const resolved = path.resolve(filePath)
+    const agentsDir = path.resolve(getAgentsDir())
+    if (!resolved.startsWith(agentsDir + path.sep) && resolved !== agentsDir) {
+      throw new Error('Refusing to open path outside agents dir')
+    }
+    const err = await shell.openPath(resolved)
+    if (err) throw new Error(err)
+  })
 
   ipcMain.handle('dialog:pickFolder', async () => {
     if (!mainWindow) return null

--- a/electron/mcp-bridge.ts
+++ b/electron/mcp-bridge.ts
@@ -92,7 +92,7 @@ async function main() {
           content: [
             {
               type: 'text',
-              text: `Opened session ${result.id.slice(0, 8)} in ${result.cwd}`,
+              text: `Opened session ${result.id} in ${result.cwd}`,
             },
           ],
         }
@@ -102,6 +102,107 @@ async function main() {
           content: [
             { type: 'text', text: `Failed to reach termhub at ${baseUrl}: ${msg}` },
           ],
+          isError: true,
+        }
+      }
+    },
+  )
+
+  server.registerTool(
+    'send_input',
+    {
+      title: 'Send input to a running termhub session',
+      description:
+        'Writes text to the pty of an existing session, as if the user typed it. ' +
+        "Trailing Enter is added automatically. Newlines in `text` are flattened to " +
+        'spaces — for multi-line content, send multiple calls or paste-style input.',
+      inputSchema: {
+        sessionId: z
+          .string()
+          .describe('Full session id (or unambiguous prefix) returned by open_session'),
+        text: z.string().describe('Text to send to the session'),
+      },
+    },
+    async (args) => {
+      try {
+        const response = await fetch(`${baseUrl}/internal/send_input`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sessionId: args.sessionId, text: args.text }),
+        })
+        const json = (await response.json().catch(() => ({}))) as {
+          ok?: boolean
+          error?: string
+        }
+        if (!response.ok || !json.ok) {
+          return {
+            content: [
+              { type: 'text', text: `Failed: ${json.error ?? `HTTP ${response.status}`}` },
+            ],
+            isError: true,
+          }
+        }
+        return { content: [{ type: 'text', text: `Sent to ${args.sessionId}.` }] }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        return {
+          content: [{ type: 'text', text: `Failed to reach termhub: ${msg}` }],
+          isError: true,
+        }
+      }
+    },
+  )
+
+  server.registerTool(
+    'read_output',
+    {
+      title: 'Read recent output from a termhub session',
+      description:
+        'Returns the most recent output buffered for a session (rolling, last ~256KB). ' +
+        'ANSI escape sequences are stripped by default for readability; pass raw: true to ' +
+        'get the original byte stream.',
+      inputSchema: {
+        sessionId: z
+          .string()
+          .describe('Full session id (or unambiguous prefix) returned by open_session'),
+        maxChars: z
+          .number()
+          .optional()
+          .describe('Cap on returned characters (returns the most recent)'),
+        raw: z
+          .boolean()
+          .optional()
+          .describe('If true, return raw output including ANSI escape codes'),
+      },
+    },
+    async (args) => {
+      try {
+        const response = await fetch(`${baseUrl}/internal/read_output`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            sessionId: args.sessionId,
+            maxChars: args.maxChars,
+            raw: args.raw,
+          }),
+        })
+        const json = (await response.json().catch(() => ({}))) as {
+          text?: string
+          error?: string
+        }
+        if (json.error) {
+          return {
+            content: [{ type: 'text', text: `Failed: ${json.error}` }],
+            isError: true,
+          }
+        }
+        return {
+          content: [{ type: 'text', text: json.text ?? '(no output)' }],
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        return {
+          content: [{ type: 'text', text: `Failed to reach termhub: ${msg}` }],
           isError: true,
         }
       }

--- a/electron/mcp-bridge.ts
+++ b/electron/mcp-bridge.ts
@@ -42,8 +42,15 @@ async function main() {
           .string()
           .optional()
           .describe(
-            'Name of an agent definition (filename in ~/.claude/agents/ without .md). When provided, ' +
-              "the agent's system prompt is prepended to the first user message so the new session adopts that role.",
+            'Name of an agent definition (filename in ~/.claude/agents/ without .md). ' +
+              'Passed to claude as --agent so the new session adopts that role.',
+          ),
+        model: z
+          .string()
+          .optional()
+          .describe(
+            'Model to use for the new session, e.g. "claude-opus-4-7" or "claude-sonnet-4-6". ' +
+              'Passed to claude as --model. Omit to use the user\'s default.',
           ),
       },
     },
@@ -52,7 +59,12 @@ async function main() {
         const response = await fetch(`${baseUrl}/internal/open_session`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ cwd: args.cwd, prompt: args.prompt, agent: args.agent }),
+          body: JSON.stringify({
+            cwd: args.cwd,
+            prompt: args.prompt,
+            agent: args.agent,
+            model: args.model,
+          }),
         })
         if (!response.ok) {
           const text = await response.text().catch(() => '')

--- a/electron/mcp-bridge.ts
+++ b/electron/mcp-bridge.ts
@@ -52,6 +52,14 @@ async function main() {
             'Model to use for the new session, e.g. "claude-opus-4-7" or "claude-sonnet-4-6". ' +
               'Passed to claude as --model. Omit to use the user\'s default.',
           ),
+        dangerouslySkipPermissions: z
+          .boolean()
+          .optional()
+          .describe(
+            'When true, passes --dangerously-skip-permissions to claude, bypassing all per-tool ' +
+              'approval prompts. Use only for autonomous workers where you trust the prompt and ' +
+              'agent definition; the worker can take any action without confirmation.',
+          ),
       },
     },
     async (args) => {
@@ -64,6 +72,7 @@ async function main() {
             prompt: args.prompt,
             agent: args.agent,
             model: args.model,
+            dangerouslySkipPermissions: args.dangerouslySkipPermissions,
           }),
         })
         if (!response.ok) {

--- a/electron/mcp-bridge.ts
+++ b/electron/mcp-bridge.ts
@@ -38,6 +38,13 @@ async function main() {
           .string()
           .optional()
           .describe('Initial prompt to feed to the new Claude session as its first user message'),
+        agent: z
+          .string()
+          .optional()
+          .describe(
+            'Name of an agent definition (filename in ~/.claude/agents/ without .md). When provided, ' +
+              "the agent's system prompt is prepended to the first user message so the new session adopts that role.",
+          ),
       },
     },
     async (args) => {
@@ -45,7 +52,7 @@ async function main() {
         const response = await fetch(`${baseUrl}/internal/open_session`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ cwd: args.cwd, prompt: args.prompt }),
+          body: JSON.stringify({ cwd: args.cwd, prompt: args.prompt, agent: args.agent }),
         })
         if (!response.ok) {
           const text = await response.text().catch(() => '')

--- a/electron/mcp.ts
+++ b/electron/mcp.ts
@@ -12,6 +12,7 @@ export type McpHooks = {
     cwd: string
     prompt?: string
     agent?: string
+    model?: string
   }) => OpenSessionResult
 }
 
@@ -53,7 +54,12 @@ export async function startMcpServer(opts: {
       req.method === 'POST'
     ) {
       const body = await readBody(req).catch(() => '')
-      let parsed: { cwd?: unknown; prompt?: unknown; agent?: unknown }
+      let parsed: {
+        cwd?: unknown
+        prompt?: unknown
+        agent?: unknown
+        model?: unknown
+      }
       try {
         parsed = body ? JSON.parse(body) : {}
       } catch (err) {
@@ -66,8 +72,9 @@ export async function startMcpServer(opts: {
       }
       const prompt = typeof parsed.prompt === 'string' ? parsed.prompt : undefined
       const agent = typeof parsed.agent === 'string' ? parsed.agent : undefined
+      const model = typeof parsed.model === 'string' ? parsed.model : undefined
       try {
-        const result = opts.hooks.openClaudeSession({ cwd: parsed.cwd, prompt, agent })
+        const result = opts.hooks.openClaudeSession({ cwd: parsed.cwd, prompt, agent, model })
         respondJson(res, 200, result)
       } catch (err) {
         respondJson(res, 500, {

--- a/electron/mcp.ts
+++ b/electron/mcp.ts
@@ -13,6 +13,7 @@ export type McpHooks = {
     prompt?: string
     agent?: string
     model?: string
+    dangerouslySkipPermissions?: boolean
   }) => OpenSessionResult
 }
 
@@ -59,6 +60,7 @@ export async function startMcpServer(opts: {
         prompt?: unknown
         agent?: unknown
         model?: unknown
+        dangerouslySkipPermissions?: unknown
       }
       try {
         parsed = body ? JSON.parse(body) : {}
@@ -73,8 +75,18 @@ export async function startMcpServer(opts: {
       const prompt = typeof parsed.prompt === 'string' ? parsed.prompt : undefined
       const agent = typeof parsed.agent === 'string' ? parsed.agent : undefined
       const model = typeof parsed.model === 'string' ? parsed.model : undefined
+      const dangerouslySkipPermissions =
+        typeof parsed.dangerouslySkipPermissions === 'boolean'
+          ? parsed.dangerouslySkipPermissions
+          : undefined
       try {
-        const result = opts.hooks.openClaudeSession({ cwd: parsed.cwd, prompt, agent, model })
+        const result = opts.hooks.openClaudeSession({
+          cwd: parsed.cwd,
+          prompt,
+          agent,
+          model,
+          dangerouslySkipPermissions,
+        })
         respondJson(res, 200, result)
       } catch (err) {
         respondJson(res, 500, {

--- a/electron/mcp.ts
+++ b/electron/mcp.ts
@@ -8,7 +8,11 @@ import { createServer, type IncomingMessage, type ServerResponse } from 'node:ht
 export type OpenSessionResult = { id: string; cwd: string }
 
 export type McpHooks = {
-  openClaudeSession: (req: { cwd: string; prompt?: string }) => OpenSessionResult
+  openClaudeSession: (req: {
+    cwd: string
+    prompt?: string
+    agent?: string
+  }) => OpenSessionResult
 }
 
 export type McpHandle = {
@@ -49,7 +53,7 @@ export async function startMcpServer(opts: {
       req.method === 'POST'
     ) {
       const body = await readBody(req).catch(() => '')
-      let parsed: { cwd?: unknown; prompt?: unknown }
+      let parsed: { cwd?: unknown; prompt?: unknown; agent?: unknown }
       try {
         parsed = body ? JSON.parse(body) : {}
       } catch (err) {
@@ -61,8 +65,9 @@ export async function startMcpServer(opts: {
         return
       }
       const prompt = typeof parsed.prompt === 'string' ? parsed.prompt : undefined
+      const agent = typeof parsed.agent === 'string' ? parsed.agent : undefined
       try {
-        const result = opts.hooks.openClaudeSession({ cwd: parsed.cwd, prompt })
+        const result = opts.hooks.openClaudeSession({ cwd: parsed.cwd, prompt, agent })
         respondJson(res, 200, result)
       } catch (err) {
         respondJson(res, 500, {

--- a/electron/mcp.ts
+++ b/electron/mcp.ts
@@ -15,6 +15,14 @@ export type McpHooks = {
     model?: string
     dangerouslySkipPermissions?: boolean
   }) => OpenSessionResult
+  sendInput: (req: { sessionId: string; text: string }) => {
+    ok: boolean
+    error?: string
+  }
+  readOutput: (req: { sessionId: string; maxChars?: number; raw?: boolean }) => {
+    text?: string
+    error?: string
+  }
 }
 
 export type McpHandle = {
@@ -94,6 +102,50 @@ export async function startMcpServer(opts: {
           detail: err instanceof Error ? err.message : String(err),
         })
       }
+      return
+    }
+
+    if (req.url === '/internal/send_input' && req.method === 'POST') {
+      const body = await readBody(req).catch(() => '')
+      let parsed: { sessionId?: unknown; text?: unknown }
+      try {
+        parsed = body ? JSON.parse(body) : {}
+      } catch (err) {
+        respondJson(res, 400, { error: 'invalid_json', detail: String(err) })
+        return
+      }
+      if (typeof parsed.sessionId !== 'string' || typeof parsed.text !== 'string') {
+        respondJson(res, 400, { error: 'sessionId and text must be strings' })
+        return
+      }
+      const result = opts.hooks.sendInput({
+        sessionId: parsed.sessionId,
+        text: parsed.text,
+      })
+      respondJson(res, result.ok ? 200 : 400, result)
+      return
+    }
+
+    if (req.url === '/internal/read_output' && req.method === 'POST') {
+      const body = await readBody(req).catch(() => '')
+      let parsed: { sessionId?: unknown; maxChars?: unknown; raw?: unknown }
+      try {
+        parsed = body ? JSON.parse(body) : {}
+      } catch (err) {
+        respondJson(res, 400, { error: 'invalid_json', detail: String(err) })
+        return
+      }
+      if (typeof parsed.sessionId !== 'string') {
+        respondJson(res, 400, { error: 'sessionId must be a string' })
+        return
+      }
+      const result = opts.hooks.readOutput({
+        sessionId: parsed.sessionId,
+        maxChars:
+          typeof parsed.maxChars === 'number' ? parsed.maxChars : undefined,
+        raw: typeof parsed.raw === 'boolean' ? parsed.raw : undefined,
+      })
+      respondJson(res, result.error ? 400 : 200, result)
       return
     }
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -79,6 +79,11 @@ const api = {
 
   openAgent: (path: string): Promise<void> =>
     ipcRenderer.invoke('agents:open', path),
+
+  listSkills: (): Promise<AgentDef[]> => ipcRenderer.invoke('skills:list'),
+
+  openSkill: (path: string): Promise<void> =>
+    ipcRenderer.invoke('skills:open', path),
 }
 
 contextBridge.exposeInMainWorld('termhub', api)

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -2,7 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron'
 
 type DataPayload = { id: string; data: string }
 type ExitPayload = { id: string; exitCode: number }
-type AddedPayload = { id: string; cwd: string }
+type AddedPayload = { id: string; cwd: string; autoActivate?: boolean }
 
 const api = {
   createSession: (
@@ -56,13 +56,22 @@ const api = {
     }
   },
 
-  onSessionAdded: (cb: (id: string, cwd: string) => void): (() => void) => {
+  onSessionAdded: (
+    cb: (id: string, cwd: string, autoActivate: boolean) => void,
+  ): (() => void) => {
     const handler = (_e: Electron.IpcRendererEvent, p: AddedPayload) =>
-      cb(p.id, p.cwd)
+      cb(p.id, p.cwd, p.autoActivate ?? false)
     ipcRenderer.on('session:added', handler)
     return () => {
       ipcRenderer.off('session:added', handler)
     }
+  },
+
+  listSessions: (): Promise<Array<{ id: string; cwd: string }>> =>
+    ipcRenderer.invoke('sessions:list'),
+
+  appReady: (): void => {
+    ipcRenderer.send('app:ready')
   },
 }
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -2,7 +2,8 @@ import { contextBridge, ipcRenderer } from 'electron'
 
 type DataPayload = { id: string; data: string }
 type ExitPayload = { id: string; exitCode: number }
-type AddedPayload = { id: string; cwd: string; autoActivate?: boolean }
+type AddedPayload = { id: string; cwd: string; autoActivate?: boolean; command?: string }
+type AgentDef = { name: string; path: string; description?: string }
 
 const api = {
   createSession: (
@@ -57,22 +58,27 @@ const api = {
   },
 
   onSessionAdded: (
-    cb: (id: string, cwd: string, autoActivate: boolean) => void,
+    cb: (id: string, cwd: string, autoActivate: boolean, command?: string) => void,
   ): (() => void) => {
     const handler = (_e: Electron.IpcRendererEvent, p: AddedPayload) =>
-      cb(p.id, p.cwd, p.autoActivate ?? false)
+      cb(p.id, p.cwd, p.autoActivate ?? false, p.command)
     ipcRenderer.on('session:added', handler)
     return () => {
       ipcRenderer.off('session:added', handler)
     }
   },
 
-  listSessions: (): Promise<Array<{ id: string; cwd: string }>> =>
+  listSessions: (): Promise<Array<{ id: string; cwd: string; command?: string }>> =>
     ipcRenderer.invoke('sessions:list'),
 
   appReady: (): void => {
     ipcRenderer.send('app:ready')
   },
+
+  listAgents: (): Promise<AgentDef[]> => ipcRenderer.invoke('agents:list'),
+
+  openAgent: (path: string): Promise<void> =>
+    ipcRenderer.invoke('agents:open', path),
 }
 
 contextBridge.exposeInMainWorld('termhub', api)

--- a/src/AgentList.tsx
+++ b/src/AgentList.tsx
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { AgentDef } from './types'
+
+export function AgentList() {
+  const [agents, setAgents] = useState<AgentDef[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const list = await window.termhub.listAgents()
+      setAgents(list)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  if (loading && agents.length === 0) {
+    return <p className="hint">Loading…</p>
+  }
+  if (error) {
+    return <p className="hint error">{error}</p>
+  }
+  if (agents.length === 0) {
+    return (
+      <p className="hint">
+        No agents found. Drop <code>.md</code> files into <code>~/.claude/agents/</code>.
+      </p>
+    )
+  }
+
+  return (
+    <ul className="agent-list">
+      {agents.map((a) => (
+        <li
+          key={a.path}
+          className="agent-item"
+          onClick={() => window.termhub.openAgent(a.path)}
+          title={a.path}
+        >
+          <div className="agent-name">{a.name}</div>
+          {a.description ? <div className="agent-description">{a.description}</div> : null}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,46 +27,35 @@ export default function App() {
     const offExit = window.termhub.onExit((id) => {
       removeSession(id)
     })
-    const offAdded = window.termhub.onSessionAdded((id, cwd) => {
-      // MCP-initiated session: main has already created the pty.
-      setSessions((prev) => (prev.some((s) => s.id === id) ? prev : [...prev, { id, cwd }]))
+    const offAdded = window.termhub.onSessionAdded((id, cwd, autoActivate) => {
+      setSessions((prev) =>
+        prev.some((s) => s.id === id) ? prev : [...prev, { id, cwd }],
+      )
+      if (autoActivate) {
+        setActiveId((curr) => curr ?? id)
+      }
     })
+
+    // Catch up with any sessions main already created (resumed/startup) before
+    // our listeners were attached, then signal that we're ready so main can
+    // create the rest.
+    void window.termhub.listSessions().then((existing) => {
+      if (existing.length > 0) {
+        setSessions((prev) => {
+          const seen = new Set(prev.map((s) => s.id))
+          return [...prev, ...existing.filter((s) => !seen.has(s.id))]
+        })
+        setActiveId((curr) => curr ?? existing[0].id)
+      }
+      window.termhub.appReady()
+    })
+
     return () => {
       offData()
       offExit()
       offAdded()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  // Open startup sessions from config.json
-  useEffect(() => {
-    let cancelled = false
-    ;(async () => {
-      try {
-        const config = await window.termhub.getConfig()
-        for (const entry of config.startupSessions) {
-          if (cancelled) return
-          try {
-            const s = await window.termhub.createSession(
-              entry.cwd,
-              entry.command,
-              entry.prompt,
-            )
-            if (cancelled) return
-            setSessions((prev) => [...prev, s])
-            setActiveId((curr) => curr ?? s.id)
-          } catch (err) {
-            console.error('[termhub] startup session failed for', entry.cwd, err)
-          }
-        }
-      } catch (err) {
-        console.error('[termhub] failed to load config:', err)
-      }
-    })()
-    return () => {
-      cancelled = true
-    }
   }, [])
 
   const removeSession = useCallback((id: string) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import type { Terminal } from '@xterm/xterm'
 import type { FitAddon } from '@xterm/addon-fit'
 import { Sidebar } from './Sidebar'
 import { TerminalView } from './TerminalView'
+import { RightPanel } from './RightPanel'
 import type { Session } from './types'
 
 export type TerminalEntry = { term: Terminal; fit: FitAddon }
@@ -27,9 +28,9 @@ export default function App() {
     const offExit = window.termhub.onExit((id) => {
       removeSession(id)
     })
-    const offAdded = window.termhub.onSessionAdded((id, cwd, autoActivate) => {
+    const offAdded = window.termhub.onSessionAdded((id, cwd, autoActivate, command) => {
       setSessions((prev) =>
-        prev.some((s) => s.id === id) ? prev : [...prev, { id, cwd }],
+        prev.some((s) => s.id === id) ? prev : [...prev, { id, cwd, command }],
       )
       if (autoActivate) {
         setActiveId((curr) => curr ?? id)
@@ -128,6 +129,10 @@ export default function App() {
   }, [activeId])
 
   const grouped = useMemo(() => groupByCwd(sessions), [sessions])
+  const activeSession = useMemo(
+    () => sessions.find((s) => s.id === activeId) ?? null,
+    [sessions, activeId],
+  )
 
   return (
     <div className="app">
@@ -156,6 +161,7 @@ export default function App() {
           ))
         )}
       </main>
+      <RightPanel activeSession={activeSession} />
     </div>
   )
 }

--- a/src/CollapsibleSection.tsx
+++ b/src/CollapsibleSection.tsx
@@ -1,0 +1,28 @@
+import { useState, type ReactNode } from 'react'
+
+type Props = {
+  title: string
+  defaultOpen?: boolean
+  action?: ReactNode
+  children: ReactNode
+}
+
+export function CollapsibleSection({ title, defaultOpen = true, action, children }: Props) {
+  const [open, setOpen] = useState(defaultOpen)
+  return (
+    <div className={`section ${open ? 'open' : 'closed'}`}>
+      <div className="section-header">
+        <button
+          className="section-toggle"
+          onClick={() => setOpen((o) => !o)}
+          aria-expanded={open}
+        >
+          <span className="section-chevron">{open ? '▾' : '▸'}</span>
+          <span className="section-title">{title}</span>
+        </button>
+        {action ? <div className="section-action">{action}</div> : null}
+      </div>
+      {open ? <div className="section-body">{children}</div> : null}
+    </div>
+  )
+}

--- a/src/McpList.tsx
+++ b/src/McpList.tsx
@@ -1,0 +1,25 @@
+import type { Session } from './types'
+
+type Props = {
+  session: Session | null
+}
+
+export function McpList({ session }: Props) {
+  if (!session) {
+    return <p className="hint">No active session.</p>
+  }
+
+  const isClaudeSession = session.command?.trim().startsWith('claude') ?? false
+  if (!isClaudeSession) {
+    return <p className="hint">Active session isn't running claude.</p>
+  }
+
+  return (
+    <ul className="mcp-list">
+      <li className="mcp-item">
+        <span className="mcp-name">termhub</span>
+        <span className="mcp-status mcp-status-active">configured</span>
+      </li>
+    </ul>
+  )
+}

--- a/src/RightPanel.tsx
+++ b/src/RightPanel.tsx
@@ -1,0 +1,26 @@
+import { CollapsibleSection } from './CollapsibleSection'
+import { AgentList } from './AgentList'
+import { McpList } from './McpList'
+import type { Session } from './types'
+
+type Props = {
+  activeSession: Session | null
+}
+
+export function RightPanel({ activeSession }: Props) {
+  return (
+    <aside className="right-panel">
+      <div className="right-panel-header">
+        <span className="brand">menus</span>
+      </div>
+      <div className="right-panel-body">
+        <CollapsibleSection title="Agents">
+          <AgentList />
+        </CollapsibleSection>
+        <CollapsibleSection title="MCP">
+          <McpList session={activeSession} />
+        </CollapsibleSection>
+      </div>
+    </aside>
+  )
+}

--- a/src/RightPanel.tsx
+++ b/src/RightPanel.tsx
@@ -1,5 +1,6 @@
 import { CollapsibleSection } from './CollapsibleSection'
 import { AgentList } from './AgentList'
+import { SkillList } from './SkillList'
 import { McpList } from './McpList'
 import type { Session } from './types'
 
@@ -16,6 +17,9 @@ export function RightPanel({ activeSession }: Props) {
       <div className="right-panel-body">
         <CollapsibleSection title="Agents">
           <AgentList />
+        </CollapsibleSection>
+        <CollapsibleSection title="Skills">
+          <SkillList />
         </CollapsibleSection>
         <CollapsibleSection title="MCP">
           <McpList session={activeSession} />

--- a/src/SkillList.tsx
+++ b/src/SkillList.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from 'react'
-import type { AgentDef } from './types'
+import type { SkillDef } from './types'
 
-export function AgentList() {
-  const [agents, setAgents] = useState<AgentDef[]>([])
+export function SkillList() {
+  const [skills, setSkills] = useState<SkillDef[]>([])
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
 
@@ -10,8 +10,8 @@ export function AgentList() {
     setLoading(true)
     setError(null)
     try {
-      const list = await window.termhub.listAgents()
-      setAgents(list)
+      const list = await window.termhub.listSkills()
+      setSkills(list)
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
@@ -23,31 +23,31 @@ export function AgentList() {
     void refresh()
   }, [refresh])
 
-  if (loading && agents.length === 0) {
+  if (loading && skills.length === 0) {
     return <p className="hint">Loading…</p>
   }
   if (error) {
     return <p className="hint error">{error}</p>
   }
-  if (agents.length === 0) {
+  if (skills.length === 0) {
     return (
       <p className="hint">
-        No agents found. Drop <code>.md</code> files into <code>~/.claude/agents/</code>.
+        No skills found. Each skill lives in <code>~/.claude/skills/&lt;name&gt;/SKILL.md</code>.
       </p>
     )
   }
 
   return (
     <ul className="entry-list">
-      {agents.map((a) => (
+      {skills.map((s) => (
         <li
-          key={a.path}
+          key={s.path}
           className="entry-item"
-          onClick={() => window.termhub.openAgent(a.path)}
-          title={a.path}
+          onClick={() => window.termhub.openSkill(s.path)}
+          title={s.path}
         >
-          <div className="entry-name">{a.name}</div>
-          {a.description ? <div className="entry-description">{a.description}</div> : null}
+          <div className="entry-name">{s.name}</div>
+          {s.description ? <div className="entry-description">{s.description}</div> : null}
         </li>
       ))}
     </ul>

--- a/src/styles.css
+++ b/src/styles.css
@@ -330,6 +330,26 @@ body,
   height: 100% !important;
 }
 
+/* Slim, themed scrollbar so it doesn't crowd the rightmost glyphs.
+   Default Windows scrollbars are wider than xterm's FitAddon assumes,
+   which causes the rightmost characters to render under the scrollbar. */
+.terminal-container .xterm-viewport::-webkit-scrollbar {
+  width: 10px;
+}
+.terminal-container .xterm-viewport::-webkit-scrollbar-track {
+  background: transparent;
+}
+.terminal-container .xterm-viewport::-webkit-scrollbar-thumb {
+  background: rgba(150, 150, 150, 0.3);
+  border-radius: 5px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+.terminal-container .xterm-viewport::-webkit-scrollbar-thumb:hover {
+  background: rgba(150, 150, 150, 0.55);
+  background-clip: padding-box;
+}
+
 .empty {
   height: 100%;
   display: flex;

--- a/src/styles.css
+++ b/src/styles.css
@@ -148,6 +148,167 @@ body,
   color: var(--text);
 }
 
+/* ---------- Right panel ---------- */
+
+.right-panel {
+  width: 240px;
+  flex-shrink: 0;
+  background: var(--bg-sidebar);
+  border-left: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.right-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.right-panel-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+/* ---------- Collapsible section ---------- */
+
+.section {
+  border-bottom: 1px solid var(--border);
+}
+
+.section:last-child {
+  border-bottom: none;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0;
+  background: transparent;
+}
+
+.section-toggle {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  cursor: pointer;
+  padding: 8px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  text-align: left;
+}
+
+.section-toggle:hover {
+  background: var(--hover);
+}
+
+.section-chevron {
+  display: inline-block;
+  width: 10px;
+  color: var(--text-dim);
+  font-size: 10px;
+}
+
+.section-action {
+  padding-right: 8px;
+}
+
+.section-body {
+  padding: 4px 12px 10px 12px;
+}
+
+.hint {
+  margin: 4px 0;
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.hint.error {
+  color: #f48771;
+}
+
+.hint code {
+  background: rgba(255, 255, 255, 0.06);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+
+/* ---------- Agent list ---------- */
+
+.agent-list,
+.mcp-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.agent-item {
+  padding: 6px 8px;
+  margin: 2px -8px;
+  border-radius: 4px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.agent-item:hover {
+  background: var(--hover);
+}
+
+.agent-name {
+  font-size: 13px;
+  color: var(--text);
+}
+
+.agent-description {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ---------- MCP list ---------- */
+
+.mcp-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 8px;
+  margin: 2px -8px;
+  border-radius: 4px;
+}
+
+.mcp-name {
+  font-size: 13px;
+  color: var(--text);
+}
+
+.mcp-status {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+.mcp-status-active {
+  background: rgba(35, 134, 54, 0.25);
+  color: #7ee787;
+}
+
 /* ---------- Main pane ---------- */
 
 .main {

--- a/src/styles.css
+++ b/src/styles.css
@@ -245,16 +245,16 @@ body,
   font-size: 11px;
 }
 
-/* ---------- Agent list ---------- */
+/* ---------- Generic entry list (agents, skills, etc.) ---------- */
 
-.agent-list,
+.entry-list,
 .mcp-list {
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-.agent-item {
+.entry-item {
   padding: 6px 8px;
   margin: 2px -8px;
   border-radius: 4px;
@@ -262,16 +262,16 @@ body,
   user-select: none;
 }
 
-.agent-item:hover {
+.entry-item:hover {
   background: var(--hover);
 }
 
-.agent-name {
+.entry-name {
   font-size: 13px;
   color: var(--text);
 }
 
-.agent-description {
+.entry-description {
   font-size: 11px;
   color: var(--text-dim);
   margin-top: 2px;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,13 @@
 export type Session = {
   id: string
   cwd: string
+  command?: string
+}
+
+export type AgentDef = {
+  name: string
+  path: string
+  description?: string
 }
 
 export type Config = {
@@ -26,10 +33,12 @@ export type TermhubApi = {
   onData: (cb: (id: string, data: string) => void) => () => void
   onExit: (cb: (id: string, exitCode: number) => void) => () => void
   onSessionAdded: (
-    cb: (id: string, cwd: string, autoActivate: boolean) => void,
+    cb: (id: string, cwd: string, autoActivate: boolean, command?: string) => void,
   ) => () => void
-  listSessions: () => Promise<Array<{ id: string; cwd: string }>>
+  listSessions: () => Promise<Array<{ id: string; cwd: string; command?: string }>>
   appReady: () => void
+  listAgents: () => Promise<AgentDef[]>
+  openAgent: (path: string) => Promise<void>
 }
 
 declare global {

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export type Config = {
     prompt?: string
     agent?: string
     model?: string
+    dangerouslySkipPermissions?: boolean
   }>
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,12 @@ export type AgentDef = {
   description?: string
 }
 
+export type SkillDef = {
+  name: string
+  path: string
+  description?: string
+}
+
 export type Config = {
   mcpPort: number
   startupSessions: Array<{ cwd: string; command?: string; prompt?: string }>
@@ -39,6 +45,8 @@ export type TermhubApi = {
   appReady: () => void
   listAgents: () => Promise<AgentDef[]>
   openAgent: (path: string) => Promise<void>
+  listSkills: () => Promise<SkillDef[]>
+  openSkill: (path: string) => Promise<void>
 }
 
 declare global {

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,11 @@ export type TermhubApi = {
   writeClipboard: (text: string) => void
   onData: (cb: (id: string, data: string) => void) => () => void
   onExit: (cb: (id: string, exitCode: number) => void) => () => void
-  onSessionAdded: (cb: (id: string, cwd: string) => void) => () => void
+  onSessionAdded: (
+    cb: (id: string, cwd: string, autoActivate: boolean) => void,
+  ) => () => void
+  listSessions: () => Promise<Array<{ id: string; cwd: string }>>
+  appReady: () => void
 }
 
 declare global {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,12 @@ export type SkillDef = {
 
 export type Config = {
   mcpPort: number
-  startupSessions: Array<{ cwd: string; command?: string; prompt?: string }>
+  startupSessions: Array<{
+    cwd: string
+    command?: string
+    prompt?: string
+    agent?: string
+  }>
 }
 
 export type TermhubApi = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export type Config = {
     command?: string
     prompt?: string
     agent?: string
+    model?: string
   }>
 }
 


### PR DESCRIPTION
## Summary

This branch grew well beyond its name. In addition to the original session-persistence work, it adds a right-side panel (Agents / MCP / Skills), expands the MCP `open_session` tool with `agent` / `model` / `dangerouslySkipPermissions`, introduces two new MCP tools (`send_input`, `read_output`) for orchestrator → worker control, and ships two reliability fixes for spawning child claude processes. A single PR so all of this lands together rather than as a stream of small follow-ups.

12 commits, ~1059 / -67 across `electron/*` and `src/*`. No new dependencies.

## Session persistence (`2a0bab0`)

- Open sessions are persisted to `%APPDATA%/termhub/sessions.json` on create and on close.
- On app launch, each persisted session is resumed with `claude --resume <id>`. This works because we now also inject `--session-id <id>` when *first* spawning claude, so the id we persist is the same id claude knows about.
- Bootstrap moved from the renderer into the main process, gated on an `app:ready` signal from the renderer so early pty output isn't dropped before the UI is listening.
- Startup-config entries are deduped against resumed sessions by `cwd`, so launching with an existing `E:/` session won't open it twice.

## Right panel UI (`15fcbeb`, `12cf8e0`)

A new collapsible right-side panel hosts three lists:

- **Agents** — `.md` files in `~/.claude/agents/`. Click opens the file in the user's default `.md` editor.
- **MCP** — per-active-session list of configured MCP servers. For now shows the termhub MCP for any claude-running session (renderer `Session` type now carries `command` so the panel can tell which sessions are running claude).
- **Skills** — subdirectories of `~/.claude/skills/` containing a `SKILL.md`, with the description pulled from the SKILL.md frontmatter. Click opens the SKILL.md.

`CollapsibleSection` is a thin reusable wrapper. Agent-list styles were generalised to `.entry-*` so future list-style menus drop in without new CSS.

## `open_session` gains `agent`, `model`, `dangerouslySkipPermissions`

The MCP `open_session` tool can now spawn workers with a specific role, model, and permission posture. All three params thread through the same path: MCP tool → `/internal` HTTP endpoint → `createSessionInternal` → `buildClaudeCommand`. They're also accepted on `startup-session` config entries for parity, and `dangerouslySkipPermissions` is forwarded on resume so a worker keeps its skip-perms posture across restarts.

The `agent` wiring took a couple of iterations worth flagging for reviewers:

- `092740b` first wired `agent` through by typing the agent body into claude's input field as the first user message — but claude treated the role description as user text, not instructions.
- `f19bfb8` switched to building the full claude command line with `--append-system-prompt <body>` plus the user prompt as a positional arg, so claude actually adopts the role.
- `cc28531` is the final form: `--append-system-prompt` has a CLI length limit and was truncating longer agent bodies, so we now just pass the agent name with `--agent` and let claude do the lookup from `~/.claude/agents/`. `loadAgentBody` was dropped — main no longer reads the file content at all.

`9d6065c` adds `model` (e.g. `claude-opus-4-7`, `claude-sonnet-4-6`) and `3b91ba5` adds `dangerouslySkipPermissions` (`--dangerously-skip-permissions`).

## New MCP tools: `send_input` and `read_output` (`7426d02`)

Lets the orchestrator follow up with workers mid-stream:

- `send_input(sessionId, text)` — writes to a running session's pty as if the user typed it.
- `read_output(sessionId, maxChars?, raw?)` — returns the most recent ~256KB of output buffered per session. ANSI escape codes are stripped by default for readability; `raw: true` returns the byte stream.

Sessions now carry a rolling 256KB output buffer populated from the existing `onData` callback. `sessionId` accepts the full UUID or any unambiguous prefix. `open_session` also now returns the full session id in its result text so the orchestrator has something to address.

## Prompt delivery via bracketed paste (`b4fab55`) — most important reliability fix

Long or shell-special prompts (embedded quotes, backticks, `$()`, `<>`, etc.) were breaking cmd.exe's quoting and chopping up the spawn command line. Worth reviewing carefully — this changes how every prompt is delivered.

- `buildClaudeCommand` no longer takes a positional `userPrompt`. The string typed into cmd is just `claude --flags...` with no user-controlled text on the command line.
- ~2.5s after spawn (claude's TUI is ready), the prompt is delivered to the running claude via a bracketed-paste sequence: `\x1b[200~ <prompt> \x1b[201~\r`. Ink-based TUIs handle bracketed paste atomically regardless of length or content.
- `send_input` was switched to the same bracketed-paste mechanism, so multi-line / shell-special follow-ups also flow through cleanly (replacing the previous "flatten newlines, append `\r`" approach).

## Strip parent-claude env vars (`19b19f4`)

When termhub is launched from inside a parent claude session, vars like `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1`, `CLAUDECODE=1`, and `CLAUDE_CODE_OAUTH_TOKEN` were bleeding through to the child claude we spawn. The `MANAGED_BY_HOST` signal in particular trips claude's sandbox preflight, which then refuses to start with *\"sandbox required but unavailable\"*. `cleanEnv()` now drops anything starting with `CLAUDE_` or `CLAUDECODE` plus `DEFAULT_LLM_MODEL` so child claudes boot from a clean baseline.

## Polish (`f49337a`)

Default Windows scrollbar is wider than xterm's `FitAddon` assumes, so the rightmost glyphs were rendering under the scrollbar. A 10px webkit scrollbar with a translucent thumb fixes the overlap and matches the dark theme.

## Test plan

- [ ] Quit and relaunch with a few sessions open; confirm each one comes back via `claude --resume <id>` and the `E:/` startup entry doesn't double up.
- [ ] Spawn a worker via MCP `open_session` with `agent` set; confirm the spawned claude actually adopts the role (look for role-specific behavior, not just the agent name in the title bar).
- [ ] Spawn a worker via MCP `open_session` with `model` set; confirm claude reports the chosen model.
- [ ] Spawn a worker via MCP `open_session` with `dangerouslySkipPermissions: true`; confirm it doesn't pause for tool approvals. Quit and relaunch; confirm the resumed session is still permission-skipping.
- [ ] Send a prompt containing backticks, `$()`, embedded `\"quotes\"`, and multiple newlines via `send_input`; confirm claude receives it as one atomic input.
- [ ] Send a long prompt (a few KB) on `open_session`; confirm it lands intact, not truncated by cmd quoting.
- [ ] Click an agent in the right panel — opens the `.md` in the default editor. Same for a skill.
- [ ] Open a session running claude; confirm the MCP list shows the termhub MCP for that session and not for non-claude sessions.
- [ ] Visual: open a session and confirm the rightmost terminal column isn't clipped by the scrollbar.
- [ ] Launch termhub from inside a parent claude session; confirm the spawned child claude starts cleanly (no \"sandbox required but unavailable\").