### PR TITLE
feat: Shift+Enter inserts line break in input bar

### DIFF
--- a/src/TerminalView.tsx
+++ b/src/TerminalView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type MutableRefObject } from 'react'
+import { useCallback, useEffect, useRef, useState, type MutableRefObject } from 'react'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import type { Session } from './types'
@@ -13,6 +13,36 @@ type Props = {
 
 export function TerminalView({ session, isActive, termsRef, pendingDataRef }: Props) {
   const containerRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const [inputValue, setInputValue] = useState('')
+
+  // Auto-resize the textarea height to fit its content, up to the CSS max-height
+  useEffect(() => {
+    const el = textareaRef.current
+    if (!el) return
+    el.style.height = 'auto'
+    el.style.height = `${el.scrollHeight}px`
+  }, [inputValue])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key !== 'Enter') return
+      if (e.shiftKey) {
+        // Shift+Enter: insert a newline — let default textarea behaviour handle it
+        return
+      }
+      // Plain Enter: submit input to the PTY
+      e.preventDefault()
+      const text = inputValue
+      if (text === '') return
+      window.termhub.sendInput(session.id, text + '\n')
+      setInputValue('')
+      // Return focus to the terminal after submitting
+      const entry = termsRef.current.get(session.id)
+      if (entry) entry.term.focus()
+    },
+    [inputValue, session.id, termsRef],
+  )
 
   // Lazy-init: only create the xterm instance when the session first becomes
   // visible. xterm's renderer needs a non-zero-size container at open() time
@@ -152,9 +182,21 @@ export function TerminalView({ session, isActive, termsRef, pendingDataRef }: Pr
 
   return (
     <div
-      ref={containerRef}
-      className="terminal-container"
-      style={{ display: isActive ? 'block' : 'none' }}
-    />
+      className="terminal-pane"
+      style={{ display: isActive ? 'flex' : 'none' }}
+    >
+      <div ref={containerRef} className="terminal-container" />
+      <div className="input-bar">
+        <textarea
+          ref={textareaRef}
+          className="input-bar-textarea"
+          value={inputValue}
+          rows={1}
+          placeholder="Type input… Enter to send, Shift+Enter for new line"
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+      </div>
+    </div>
   )
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -318,10 +318,50 @@ body,
   background: var(--bg);
 }
 
-.terminal-container {
+.terminal-pane {
   position: absolute;
   inset: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.terminal-container {
+  flex: 1;
+  min-height: 0;
   padding: 6px;
+  overflow: hidden;
+}
+
+.input-bar {
+  flex-shrink: 0;
+  border-top: 1px solid var(--border);
+  padding: 6px 8px;
+  background: var(--bg-elev);
+}
+
+.input-bar-textarea {
+  width: 100%;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 5px 8px;
+  font-family: inherit;
+  font-size: 13px;
+  resize: none;
+  overflow-y: auto;
+  max-height: 120px;
+  line-height: 1.4;
+  outline: none;
+  display: block;
+}
+
+.input-bar-textarea:focus {
+  border-color: var(--accent);
+}
+
+.input-bar-textarea::placeholder {
+  color: var(--text-dim);
 }
 
 .terminal-container .xterm,


### PR DESCRIPTION
## Summary
Adds a textarea input bar below each terminal pane. Users can now compose multi-line input before sending: Shift+Enter inserts a newline into the buffer, while plain Enter submits the full text to the PTY. This makes it practical to paste or write multi-line shell commands and prompts without them firing on every newline.

## Changes
- Add `textarea` input bar rendered below the xterm container in `TerminalView.tsx`
- `onKeyDown` handler: Shift+Enter lets the default textarea newline behaviour through; plain Enter calls `window.termhub.sendInput(id, text + '\n')` and clears the field
- Auto-grow effect resets textarea height on each keystroke so it expands to fit content (capped at 120 px via CSS, then scrolls)
- After submit, focus returns to the xterm terminal
- New CSS classes: `.terminal-pane` (flex column wrapper), `.input-bar`, `.input-bar-textarea`
- Converted `.terminal-container` from `position: absolute; inset: 0` to `flex: 1; min-height: 0` to coexist with the input bar in the flex layout

## Test plan
- [ ] Open a session; type text and press Enter — text is sent to the PTY and field clears
- [ ] Type text, press Shift+Enter — a newline is inserted without submitting; field grows
- [ ] Submit a multi-line value with plain Enter — full text including newlines reaches the PTY
- [ ] Terminal fills remaining vertical space; input bar sits at the bottom
- [ ] xterm resize still works correctly after layout change