### PR TITLE
feat(sidebar): right-click rename sessions with inline editing

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -693,6 +693,13 @@ app.whenReady().then(async () => {
     })),
   )
 
+  ipcMain.handle('session:rename', (_event, payload: { id: string; name: string }) => {
+    const s = sessions.get(payload.id)
+    if (!s) throw new Error(`Session not found: ${payload.id}`)
+    s.name = payload.name.trim() || undefined
+    persistSessions()
+  })
+
   ipcMain.handle('agents:list', () => listAgents())
 
   ipcMain.handle('agents:open', async (_event, filePath: string) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -97,6 +97,9 @@ const api = {
 
   openSkill: (path: string): Promise<void> =>
     ipcRenderer.invoke('skills:open', path),
+
+  renameSession: (id: string, name: string): Promise<void> =>
+    ipcRenderer.invoke('session:rename', { id, name }),
 }
 
 contextBridge.exposeInMainWorld('termhub', api)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,6 +86,17 @@ export default function App() {
     [removeSession],
   )
 
+  const renameSession = useCallback(async (id: string, name: string) => {
+    try {
+      await window.termhub.renameSession(id, name)
+      setSessions((prev) =>
+        prev.map((s) => (s.id === id ? { ...s, name: name.trim() || undefined } : s)),
+      )
+    } catch (err) {
+      console.error('[termhub] renameSession failed:', err)
+    }
+  }, [])
+
   const newSession = useCallback(async () => {
     try {
       const cwd = await window.termhub.pickFolder()
@@ -146,6 +157,7 @@ export default function App() {
         onNew={newSession}
         onSelect={setActiveId}
         onClose={closeSession}
+        onRename={renameSession}
       />
       <main className="main">
         {sessions.length === 0 ? (

--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -1,4 +1,11 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { Session } from './types'
+
+type ContextMenu = {
+  sessionId: string
+  x: number
+  y: number
+}
 
 type Props = {
   groups: Map<string, Session[]>
@@ -6,9 +13,62 @@ type Props = {
   onNew: () => void
   onSelect: (id: string) => void
   onClose: (id: string) => void
+  onRename: (id: string, name: string) => Promise<void>
 }
 
-export function Sidebar({ groups, activeId, onNew, onSelect, onClose }: Props) {
+export function Sidebar({ groups, activeId, onNew, onSelect, onClose, onRename }: Props) {
+  const [contextMenu, setContextMenu] = useState<ContextMenu | null>(null)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editValue, setEditValue] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Close context menu on outside click or Escape
+  useEffect(() => {
+    if (!contextMenu) return
+    const close = () => setContextMenu(null)
+    window.addEventListener('click', close)
+    window.addEventListener('keydown', (e) => { if (e.key === 'Escape') close() })
+    return () => {
+      window.removeEventListener('click', close)
+    }
+  }, [contextMenu])
+
+  // Focus the input when entering edit mode
+  useEffect(() => {
+    if (editingId) {
+      inputRef.current?.focus()
+      inputRef.current?.select()
+    }
+  }, [editingId])
+
+  const startRename = useCallback((session: Session) => {
+    setContextMenu(null)
+    setEditingId(session.id)
+    setEditValue(session.name ?? '')
+  }, [])
+
+  const commitRename = useCallback(async (id: string) => {
+    await onRename(id, editValue)
+    setEditingId(null)
+    setEditValue('')
+  }, [editValue, onRename])
+
+  const cancelRename = useCallback(() => {
+    setEditingId(null)
+    setEditValue('')
+  }, [])
+
+  const handleContextMenu = useCallback((e: React.MouseEvent, session: Session) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setContextMenu({ sessionId: session.id, x: e.clientX, y: e.clientY })
+  }, [])
+
+  // Find the session object from context menu id
+  const contextSession = contextMenu
+    ? [...groups.values()].flat().find((s) => s.id === contextMenu.sessionId) ?? null
+    : null
+
   return (
     <aside className="sidebar">
       <div className="sidebar-header">
@@ -29,17 +89,39 @@ export function Sidebar({ groups, activeId, onNew, onSelect, onClose }: Props) {
                   key={s.id}
                   className={`item ${s.id === activeId ? 'active' : ''}`}
                   onClick={() => onSelect(s.id)}
+                  onContextMenu={(e) => handleContextMenu(e, s)}
                 >
-                  <span className="item-label">
-                    {s.name ? (
-                      s.name
-                    ) : (
-                      <>
-                        {basename(s.cwd)}{' '}
-                        <span className="item-num">#{idx + 1}</span>
-                      </>
-                    )}
-                  </span>
+                  {editingId === s.id ? (
+                    <input
+                      ref={inputRef}
+                      className="item-rename-input"
+                      value={editValue}
+                      onChange={(e) => setEditValue(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault()
+                          void commitRename(s.id)
+                        } else if (e.key === 'Escape') {
+                          e.preventDefault()
+                          cancelRename()
+                        }
+                      }}
+                      onBlur={() => { void commitRename(s.id) }}
+                      onClick={(e) => e.stopPropagation()}
+                      placeholder={`${basename(s.cwd)} #${idx + 1}`}
+                    />
+                  ) : (
+                    <span className="item-label">
+                      {s.name ? (
+                        s.name
+                      ) : (
+                        <>
+                          {basename(s.cwd)}{' '}
+                          <span className="item-num">#{idx + 1}</span>
+                        </>
+                      )}
+                    </span>
+                  )}
                   <button
                     className="close-btn"
                     title="Close session"
@@ -56,6 +138,21 @@ export function Sidebar({ groups, activeId, onNew, onSelect, onClose }: Props) {
           </div>
         ))}
       </div>
+
+      {contextMenu && contextSession && (
+        <div
+          className="context-menu"
+          style={{ position: 'fixed', top: contextMenu.y, left: contextMenu.x }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <button
+            className="context-menu-item"
+            onClick={() => startRename(contextSession)}
+          >
+            Rename
+          </button>
+        </div>
+      )}
     </aside>
   )
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,7 @@ export type TermhubApi = {
   openAgent: (path: string) => Promise<void>
   listSkills: () => Promise<SkillDef[]>
   openSkill: (path: string) => Promise<void>
+  renameSession: (id: string, name: string) => Promise<void>
 }
 
 declare global {


### PR DESCRIPTION
## Summary
Adds a right-click context menu to session items in the sidebar. Selecting "Rename" switches the item label into an inline text input. Committing (Enter or blur) or cancelling (Escape) the edit calls the new `renameSession` IPC method, which updates the in-memory session map and re-persists `sessions.json` — so the name survives an app restart.

The `name` field on `Session` was already optional and present in the persisted shape, so there is no backward-incompatible change to the sessions file format.

## Changes
- `src/types.ts` — extends `TermhubApi` with `renameSession(id, name): Promise<void>`
- `electron/preload.ts` — exposes `session:rename` invoke via `contextBridge`
- `electron/main.ts` — adds `session:rename` IPC handler; mutates `s.name` and calls `persistSessions()`
- `src/App.tsx` — adds `renameSession` callback; passes `onRename` prop to `Sidebar`
- `src/Sidebar.tsx` — context menu on right-click, inline `<input>` editing with Enter/Escape/blur handling

## Test plan
- [ ] Right-click a session in the sidebar — context menu with "Rename" appears
- [ ] Click "Rename" — label replaced by a focused input pre-filled with the current name
- [ ] Type a new name and press Enter — label updates immediately
- [ ] Press Escape — edit cancelled, original label restored
- [ ] Click outside (blur) — commits the current input value
- [ ] Restart the app — renamed session shows the new name (persisted to `sessions.json`)
- [ ] Clear the name (blank input) and commit — falls back to the default `<dir> #N` label