### PR TITLE
feat: add Open in VS Code context menu action

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3,6 +3,7 @@ import * as pty from '@lydell/node-pty'
 import * as path from 'node:path'
 import * as os from 'node:os'
 import * as fs from 'node:fs'
+import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { startMcpServer, type McpHandle } from './mcp'
 
@@ -809,6 +810,23 @@ app.whenReady().then(async () => {
     }
     const err = await shell.openPath(resolved)
     if (err) throw new Error(err)
+  })
+
+  ipcMain.handle('vscode:open', (_event, cwd: string) => {
+    return new Promise<void>((resolve, reject) => {
+      const proc = spawn('code', [cwd], {
+        shell: true,
+        detached: true,
+        stdio: 'ignore',
+      })
+      proc.unref()
+      proc.on('error', (err) => {
+        console.error('[termhub] failed to open VS Code:', err)
+        reject(err)
+      })
+      // Resolve immediately — we don't wait for the editor to close
+      resolve()
+    })
   })
 
   ipcMain.handle('dialog:pickFolder', async () => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -126,6 +126,9 @@ const api = {
 
   renameSession: (id: string, name: string): Promise<void> =>
     ipcRenderer.invoke('session:rename', { id, name }),
+
+  openInVSCode: (cwd: string): Promise<void> =>
+    ipcRenderer.invoke('vscode:open', cwd),
 }
 
 contextBridge.exposeInMainWorld('termhub', api)

--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -21,15 +21,29 @@ export function Sidebar({ groups, activeId, onNew, onSelect, onClose, onRename }
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editValue, setEditValue] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // Find the session object from context menu id
+  const contextSession = contextMenu
+    ? [...groups.values()].flat().find((s) => s.id === contextMenu.sessionId) ?? null
+    : null
 
   // Close context menu on outside click or Escape
   useEffect(() => {
     if (!contextMenu) return
-    const close = () => setContextMenu(null)
-    window.addEventListener('click', close)
-    window.addEventListener('keydown', (e) => { if (e.key === 'Escape') close() })
+    const onMouseDown = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setContextMenu(null)
+      }
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setContextMenu(null)
+    }
+    document.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('keydown', onKeyDown)
     return () => {
-      window.removeEventListener('click', close)
+      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('keydown', onKeyDown)
     }
   }, [contextMenu])
 
@@ -64,10 +78,16 @@ export function Sidebar({ groups, activeId, onNew, onSelect, onClose, onRename }
     setContextMenu({ sessionId: session.id, x: e.clientX, y: e.clientY })
   }, [])
 
-  // Find the session object from context menu id
-  const contextSession = contextMenu
-    ? [...groups.values()].flat().find((s) => s.id === contextMenu.sessionId) ?? null
-    : null
+  const handleOpenInVSCode = useCallback(async () => {
+    if (!contextSession) return
+    const { cwd } = contextSession
+    setContextMenu(null)
+    try {
+      await window.termhub.openInVSCode(cwd)
+    } catch (err) {
+      console.error('[termhub] openInVSCode failed:', err)
+    }
+  }, [contextSession])
 
   return (
     <aside className="sidebar">
@@ -141,10 +161,17 @@ export function Sidebar({ groups, activeId, onNew, onSelect, onClose, onRename }
 
       {contextMenu && contextSession && (
         <div
+          ref={menuRef}
           className="context-menu"
           style={{ position: 'fixed', top: contextMenu.y, left: contextMenu.x }}
           onClick={(e) => e.stopPropagation()}
         >
+          <button
+            className="context-menu-item"
+            onClick={() => void handleOpenInVSCode()}
+          >
+            Open in VS Code
+          </button>
           <button
             className="context-menu-item"
             onClick={() => startRename(contextSession)}

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ export type TermhubApi = {
   listSkills: () => Promise<SkillDef[]>
   openSkill: (path: string) => Promise<void>
   renameSession: (id: string, name: string) => Promise<void>
+  openInVSCode: (cwd: string) => Promise<void>
 }
 
 declare global {


### PR DESCRIPTION
## Summary
Adds a right-click context menu to sidebar session items with an "Open in VS Code" action. Selecting it spawns `code <cwd>` via Node's `child_process` in the Electron main process, opening the session's working directory in VS Code. Errors are logged to the console without crashing the app.

## Changes
- `src/types.ts` — extend `TermhubApi` with `openInVSCode(cwd: string): Promise<void>`
- `electron/preload.ts` — expose `vscode:open` IPC invoke as `openInVSCode`
- `electron/main.ts` — implement `vscode:open` handler using detached `child_process.spawn('code', [cwd], { shell: true, detached: true, stdio: 'ignore' })`
- `src/Sidebar.tsx` — add `onContextMenu` handler and context menu overlay with "Open in VS Code" item; clicking outside or pressing Escape dismisses it

## Test plan
- [ ] Right-click a session in the sidebar — context menu appears with "Open in VS Code"
- [ ] Clicking the item opens the session's cwd in VS Code
- [ ] Clicking outside the menu or pressing Escape dismisses it without action
- [ ] If `code` is not on PATH, error is logged to the console; no crash