### PR TITLE
fix: prevent duplicate paste by calling preventDefault on Ctrl+V keydown

### DIFF
--- a/src/TerminalView.tsx
+++ b/src/TerminalView.tsx
@@ -94,6 +94,11 @@ export function TerminalView({ session, isActive, termsRef, pendingDataRef }: Pr
           return true
         }
 
+        // Prevent the browser from also firing a native 'paste' ClipboardEvent
+        // on the xterm textarea. Without this, xterm's own paste listener
+        // (registered on the textarea) fires after our term.paste() call,
+        // writing the clipboard text a second time.
+        e.preventDefault()
         void window.termhub.readClipboard().then((text) => {
           if (text) term.paste(text)
         })


### PR DESCRIPTION
## Summary
Pressing Ctrl+V in the terminal pasted the clipboard content twice. The custom key handler in `TerminalView` called `term.paste()` and returned `false` to suppress xterm's own keydown processing, but did not call `preventDefault()` on the keyboard event. The browser therefore still fired a native `paste` ClipboardEvent on the xterm textarea, which xterm's own `handlePasteEvent` listener consumed — writing the clipboard content a second time. Adding `e.preventDefault()` before the async `readClipboard` call stops the browser from generating that secondary event.

## Changes
- `src/TerminalView.tsx`: call `e.preventDefault()` on the Ctrl+V keydown event before invoking `readClipboard` so the browser does not subsequently fire a native `paste` ClipboardEvent on the xterm textarea

## Test plan
- [ ] Open a terminal session, copy some text, press Ctrl+V — confirm it appears exactly once
- [ ] Confirm multi-line paste still works correctly
- [ ] Confirm Ctrl+C still copies selected text and sends SIGINT when nothing is selected