### PR TITLE
feat: dock a per-session shell terminal at the bottom of the window

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -14,8 +14,14 @@ type Session = {
   model?: string
   permissionMode?: string
   dangerouslySkipPermissions?: boolean
+  // Primary PTY — runs claude (or whatever command the caller asked for).
+  // This is what the MCP tools target.
   term: pty.IPty
   outputBuffer: string
+  // Secondary "shell" PTY — a plain interactive shell rooted at `cwd`,
+  // docked at the bottom of the UI for the user's own manual work. Not
+  // exposed via MCP, not persisted. Lifetime is bound to the session.
+  shellTerm: pty.IPty
 }
 
 const MAX_OUTPUT_BUFFER_BYTES = 256 * 1024
@@ -404,6 +410,30 @@ function createSessionInternal(opts: {
   }
   console.log(`[termhub] pty.spawn returned (pid=${term.pid})`)
 
+  // Secondary shell PTY — same executable + cwd as the primary, but holds a
+  // plain interactive prompt for the user's own work. We mirror the primary's
+  // shell choice so the bottom pane matches what the user sees by default.
+  let shellTerm: pty.IPty
+  try {
+    shellTerm = pty.spawn(shell, [], {
+      name: 'xterm-color',
+      cols: 80,
+      rows: 10,
+      cwd: opts.cwd,
+      env: cleanEnv(),
+    })
+  } catch (err) {
+    console.error('[termhub] pty.spawn (shell) failed:', err)
+    // Roll back the primary so we don't leak a dangling PTY.
+    try {
+      term.kill()
+    } catch {
+      // ignore
+    }
+    throw err
+  }
+  console.log(`[termhub] shell pty.spawn returned (pid=${shellTerm.pid})`)
+
   const session: Session = {
     id,
     cwd: opts.cwd,
@@ -414,6 +444,7 @@ function createSessionInternal(opts: {
     dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
     term,
     outputBuffer: '',
+    shellTerm,
   }
   sessions.set(id, session)
   persistSessions()
@@ -431,8 +462,30 @@ function createSessionInternal(opts: {
   term.onExit(({ exitCode }) => {
     console.log(`[termhub] session ${id.slice(0, 8)} exited (code=${exitCode})`)
     mainWindow?.webContents.send('session:exit', { id, exitCode })
+    // The session is going away — tear down the shell PTY too so we don't
+    // leak it.
+    try {
+      shellTerm.kill()
+    } catch {
+      // already dead
+    }
     sessions.delete(id)
     persistSessions()
+  })
+
+  // Shell PTY data/exit live on a parallel IPC channel. We deliberately do
+  // NOT mirror into outputBuffer (that's the MCP read_output surface for
+  // the primary) and we do NOT destroy the session when the shell exits —
+  // the user can close the primary to tear the whole session down.
+  shellTerm.onData((data) => {
+    mainWindow?.webContents.send('session:shell:data', { id, data })
+  })
+
+  shellTerm.onExit(({ exitCode }) => {
+    console.log(
+      `[termhub] session ${id.slice(0, 8)} shell exited (code=${exitCode})`,
+    )
+    mainWindow?.webContents.send('session:shell:exit', { id, exitCode })
   })
 
   if (opts.command && opts.command.trim().length > 0) {
@@ -513,6 +566,11 @@ function killAllSessions() {
   for (const s of sessions.values()) {
     try {
       s.term.kill()
+    } catch {
+      // already dead
+    }
+    try {
+      s.shellTerm.kill()
     } catch {
       // already dead
     }
@@ -680,9 +738,37 @@ app.whenReady().then(async () => {
     } catch {
       // already dead
     }
+    try {
+      s.shellTerm.kill()
+    } catch {
+      // already dead
+    }
     sessions.delete(payload.id)
     persistSessions()
   })
+
+  ipcMain.on(
+    'session:shell:input',
+    (_event, payload: { id: string; data: string }) => {
+      sessions.get(payload.id)?.shellTerm.write(payload.data)
+    },
+  )
+
+  ipcMain.on(
+    'session:shell:resize',
+    (_event, payload: { id: string; cols: number; rows: number }) => {
+      const s = sessions.get(payload.id)
+      if (!s) return
+      if (!Number.isFinite(payload.cols) || !Number.isFinite(payload.rows)) return
+      const cols = Math.max(1, Math.floor(payload.cols))
+      const rows = Math.max(1, Math.floor(payload.rows))
+      try {
+        s.shellTerm.resize(cols, rows)
+      } catch {
+        // pty may have exited between resize requests
+      }
+    },
+  )
 
   ipcMain.handle('sessions:list', () =>
     Array.from(sessions.values()).map((s) => ({

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -31,6 +31,14 @@ const api = {
     ipcRenderer.send('session:close', { id })
   },
 
+  sendShellInput: (id: string, data: string): void => {
+    ipcRenderer.send('session:shell:input', { id, data })
+  },
+
+  resizeShell: (id: string, cols: number, rows: number): void => {
+    ipcRenderer.send('session:shell:resize', { id, cols, rows })
+  },
+
   pickFolder: (): Promise<string | null> => ipcRenderer.invoke('dialog:pickFolder'),
 
   home: (): Promise<string> => ipcRenderer.invoke('app:home'),
@@ -60,6 +68,24 @@ const api = {
     ipcRenderer.on('session:exit', handler)
     return () => {
       ipcRenderer.off('session:exit', handler)
+    }
+  },
+
+  onShellData: (cb: (id: string, data: string) => void): (() => void) => {
+    const handler = (_e: Electron.IpcRendererEvent, p: DataPayload) =>
+      cb(p.id, p.data)
+    ipcRenderer.on('session:shell:data', handler)
+    return () => {
+      ipcRenderer.off('session:shell:data', handler)
+    }
+  },
+
+  onShellExit: (cb: (id: string, exitCode: number) => void): (() => void) => {
+    const handler = (_e: Electron.IpcRendererEvent, p: ExitPayload) =>
+      cb(p.id, p.exitCode)
+    ipcRenderer.on('session:shell:exit', handler)
+    return () => {
+      ipcRenderer.off('session:shell:exit', handler)
     }
   },
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import type { Terminal } from '@xterm/xterm'
 import type { FitAddon } from '@xterm/addon-fit'
 import { Sidebar } from './Sidebar'
 import { TerminalView } from './TerminalView'
+import { BottomTerminal } from './BottomTerminal'
 import { RightPanel } from './RightPanel'
 import type { Session } from './types'
 
@@ -11,8 +12,13 @@ export type TerminalEntry = { term: Terminal; fit: FitAddon }
 export default function App() {
   const [sessions, setSessions] = useState<Session[]>([])
   const [activeId, setActiveId] = useState<string | null>(null)
+  // Primary (claude) PTY xterm instances, keyed by session id.
   const termsRef = useRef(new Map<string, TerminalEntry>())
   const pendingDataRef = useRef(new Map<string, string[]>())
+  // Parallel state for the docked bottom shell terminals. Same map shape,
+  // keyed by the same session id, but wired to the shell PTY channel.
+  const shellTermsRef = useRef(new Map<string, TerminalEntry>())
+  const shellPendingDataRef = useRef(new Map<string, string[]>())
 
   useEffect(() => {
     const offData = window.termhub.onData((id, data) => {
@@ -25,8 +31,29 @@ export default function App() {
         pendingDataRef.current.set(id, queue)
       }
     })
+    const offShellData = window.termhub.onShellData((id, data) => {
+      const entry = shellTermsRef.current.get(id)
+      if (entry) {
+        entry.term.write(data)
+      } else {
+        const queue = shellPendingDataRef.current.get(id) ?? []
+        queue.push(data)
+        shellPendingDataRef.current.set(id, queue)
+      }
+    })
     const offExit = window.termhub.onExit((id) => {
       removeSession(id)
+    })
+    // Shell PTY exiting independently (user typed `exit`) doesn't tear the
+    // session down — only the primary exit does. We still drop the xterm
+    // instance so a future re-init could replace it, but v1 doesn't respawn.
+    const offShellExit = window.termhub.onShellExit((id) => {
+      const entry = shellTermsRef.current.get(id)
+      if (entry) {
+        entry.term.dispose()
+        shellTermsRef.current.delete(id)
+      }
+      shellPendingDataRef.current.delete(id)
     })
     const offAdded = window.termhub.onSessionAdded(
       (id, cwd, autoActivate, command, name) => {
@@ -57,7 +84,9 @@ export default function App() {
 
     return () => {
       offData()
+      offShellData()
       offExit()
+      offShellExit()
       offAdded()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -69,6 +98,12 @@ export default function App() {
       entry.term.dispose()
       termsRef.current.delete(id)
     }
+    const shellEntry = shellTermsRef.current.get(id)
+    if (shellEntry) {
+      shellEntry.term.dispose()
+      shellTermsRef.current.delete(id)
+    }
+    shellPendingDataRef.current.delete(id)
     setSessions((prev) => prev.filter((s) => s.id !== id))
     setActiveId((curr) => {
       if (curr !== id) return curr
@@ -99,34 +134,52 @@ export default function App() {
     }
   }, [])
 
-  // Refit the active terminal when window resizes
+  // Refit both terminals for the active session when the window resizes.
   useEffect(() => {
     const onResize = () => {
       if (!activeId) return
       const entry = termsRef.current.get(activeId)
-      if (!entry) return
-      try {
-        entry.fit.fit()
-      } catch {
-        // container may not be mounted yet
+      if (entry) {
+        try {
+          entry.fit.fit()
+        } catch {
+          // container may not be mounted yet
+        }
+      }
+      const shellEntry = shellTermsRef.current.get(activeId)
+      if (shellEntry) {
+        try {
+          shellEntry.fit.fit()
+        } catch {
+          // container may not be mounted yet
+        }
       }
     }
     window.addEventListener('resize', onResize)
     return () => window.removeEventListener('resize', onResize)
   }, [activeId])
 
-  // Refit when active session changes (its container just became visible)
+  // Refit both when active session changes (their containers just became visible)
   useEffect(() => {
     if (!activeId) return
     const id = activeId
     const raf = requestAnimationFrame(() => {
       const entry = termsRef.current.get(id)
-      if (!entry) return
-      try {
-        entry.fit.fit()
-        entry.term.focus()
-      } catch {
-        // ignore — container not ready
+      if (entry) {
+        try {
+          entry.fit.fit()
+          entry.term.focus()
+        } catch {
+          // ignore — container not ready
+        }
+      }
+      const shellEntry = shellTermsRef.current.get(id)
+      if (shellEntry) {
+        try {
+          shellEntry.fit.fit()
+        } catch {
+          // ignore
+        }
       }
     })
     return () => cancelAnimationFrame(raf)
@@ -154,15 +207,31 @@ export default function App() {
             <button onClick={newSession}>+ New Session</button>
           </div>
         ) : (
-          sessions.map((s) => (
-            <TerminalView
-              key={s.id}
-              session={s}
-              isActive={s.id === activeId}
-              termsRef={termsRef}
-              pendingDataRef={pendingDataRef}
-            />
-          ))
+          <>
+            <div className="main-top">
+              {sessions.map((s) => (
+                <TerminalView
+                  key={s.id}
+                  session={s}
+                  isActive={s.id === activeId}
+                  termsRef={termsRef}
+                  pendingDataRef={pendingDataRef}
+                />
+              ))}
+            </div>
+            <div className="main-divider" />
+            <div className="main-bottom">
+              {sessions.map((s) => (
+                <BottomTerminal
+                  key={s.id}
+                  session={s}
+                  isActive={s.id === activeId}
+                  termsRef={shellTermsRef}
+                  pendingDataRef={shellPendingDataRef}
+                />
+              ))}
+            </div>
+          </>
         )}
       </main>
       <RightPanel activeSession={activeSession} />

--- a/src/BottomTerminal.tsx
+++ b/src/BottomTerminal.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useRef, type MutableRefObject } from 'react'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import type { Session } from './types'
+import type { TerminalEntry } from './App'
+
+type Props = {
+  session: Session
+  isActive: boolean
+  termsRef: MutableRefObject<Map<string, TerminalEntry>>
+  pendingDataRef: MutableRefObject<Map<string, string[]>>
+}
+
+// Docked shell terminal rendered under the primary TerminalView. Parallels
+// TerminalView almost line-for-line but wires input/resize to the shell PTY
+// channel (sendShellInput / resizeShell) instead of the primary one.
+export function BottomTerminal({
+  session,
+  isActive,
+  termsRef,
+  pendingDataRef,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!isActive) return
+
+    const existing = termsRef.current.get(session.id)
+    if (existing) {
+      const raf = requestAnimationFrame(() => {
+        try {
+          existing.fit.fit()
+        } catch {
+          // ignore
+        }
+      })
+      return () => cancelAnimationFrame(raf)
+    }
+
+    const container = containerRef.current
+    if (!container) return
+
+    let cancelled = false
+    const raf = requestAnimationFrame(() => {
+      if (cancelled) return
+      if (termsRef.current.has(session.id)) return
+
+      const rect = container.getBoundingClientRect()
+      if (rect.width <= 0 || rect.height <= 0) {
+        console.warn(
+          `[termhub] bottom container has zero size for session ${session.id.slice(0, 8)}; skipping init`,
+        )
+        return
+      }
+
+      const cols = Math.max(20, Math.floor((rect.width - 12) / 8.5))
+      const rows = Math.max(3, Math.floor((rect.height - 12) / 17))
+
+      const term = new Terminal({
+        cols,
+        rows,
+        cursorBlink: true,
+        fontFamily:
+          '"Cascadia Mono", "JetBrains Mono", "Fira Code", Consolas, "Courier New", monospace',
+        fontSize: 13,
+        theme: {
+          background: '#1e1e1e',
+          foreground: '#e6e6e6',
+          cursor: '#d4d4d4',
+          selectionBackground: '#264f78',
+        },
+        scrollback: 5000,
+        allowProposedApi: true,
+      })
+      const fit = new FitAddon()
+      term.loadAddon(fit)
+
+      term.attachCustomKeyEventHandler((e) => {
+        if (e.type !== 'keydown' || !e.ctrlKey) return true
+        const isC = e.code === 'KeyC'
+        const isV = e.code === 'KeyV'
+        if (!isC && !isV) return true
+
+        if (isC) {
+          const hasSelection = term.hasSelection()
+          if (e.shiftKey || hasSelection) {
+            const text = term.getSelection()
+            if (text) {
+              window.termhub.writeClipboard(text)
+              term.clearSelection()
+            }
+            return false
+          }
+          return true
+        }
+
+        void window.termhub.readClipboard().then((text) => {
+          if (text) term.paste(text)
+        })
+        return false
+      })
+
+      term.onData((data) => {
+        window.termhub.sendShellInput(session.id, data)
+      })
+      term.onResize(({ cols, rows }) => {
+        window.termhub.resizeShell(session.id, cols, rows)
+      })
+
+      term.open(container)
+      try {
+        fit.fit()
+      } catch (err) {
+        console.warn('[termhub] bottom fit.fit() failed:', err)
+      }
+
+      window.termhub.resizeShell(session.id, term.cols, term.rows)
+
+      termsRef.current.set(session.id, { term, fit })
+
+      const queue = pendingDataRef.current.get(session.id)
+      if (queue && queue.length > 0) {
+        for (const data of queue) term.write(data)
+        pendingDataRef.current.delete(session.id)
+      }
+    })
+
+    return () => {
+      cancelled = true
+      cancelAnimationFrame(raf)
+    }
+  }, [isActive, session.id, termsRef, pendingDataRef])
+
+  useEffect(() => {
+    return () => {
+      const entry = termsRef.current.get(session.id)
+      if (entry) {
+        entry.term.dispose()
+        termsRef.current.delete(session.id)
+      }
+      pendingDataRef.current.delete(session.id)
+    }
+  }, [session.id, termsRef, pendingDataRef])
+
+  return (
+    <div
+      ref={containerRef}
+      className="terminal-container"
+      style={{ display: isActive ? 'block' : 'none' }}
+    />
+  )
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -316,6 +316,34 @@ body,
   position: relative;
   overflow: hidden;
   background: var(--bg);
+  display: flex;
+  flex-direction: column;
+}
+
+/* Primary (claude) pane — fills remaining space above the bottom shell. */
+.main-top {
+  flex: 1 1 auto;
+  position: relative;
+  overflow: hidden;
+  min-height: 0;
+}
+
+/* Horizontal rule between the two stacked terminals. Fixed height; a
+   draggable resizer is future work. */
+.main-divider {
+  flex: 0 0 auto;
+  height: 4px;
+  background: var(--border);
+  cursor: row-resize;
+}
+
+/* Bottom shell pane — fixed v1 height. */
+.main-bottom {
+  flex: 0 0 220px;
+  position: relative;
+  overflow: hidden;
+  min-height: 0;
+  border-top: 1px solid var(--border);
 }
 
 .terminal-container {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,11 @@ export type TermhubApi = {
   sendInput: (id: string, data: string) => void
   resize: (id: string, cols: number, rows: number) => void
   close: (id: string) => void
+  // Parallel channel for the per-session docked bottom shell terminal.
+  // Distinct from the primary (claude) PTY; these target the user's
+  // interactive shell rooted in the session's cwd.
+  sendShellInput: (id: string, data: string) => void
+  resizeShell: (id: string, cols: number, rows: number) => void
   pickFolder: () => Promise<string | null>
   home: () => Promise<string>
   getConfig: () => Promise<Config>
@@ -48,6 +53,8 @@ export type TermhubApi = {
   writeClipboard: (text: string) => void
   onData: (cb: (id: string, data: string) => void) => () => void
   onExit: (cb: (id: string, exitCode: number) => void) => () => void
+  onShellData: (cb: (id: string, data: string) => void) => () => void
+  onShellExit: (cb: (id: string, exitCode: number) => void) => () => void
   onSessionAdded: (
     cb: (
       id: string,


### PR DESCRIPTION
## Summary

Adds a second terminal pane docked at the bottom of the main area. Every session now owns **two** PTYs — the existing primary (claude / user command) and a new secondary shell rooted in the same cwd for the user's own work. Switching sessions in the sidebar swaps both terminals in lockstep.

## Architecture

**Two PTYs per session, parallel IPC channel.** No generalization to an N-PTY list yet — scope is exactly one primary + one shell, and the types stay explicit.

- **Main (`electron/main.ts`)** — `Session` gains a `shellTerm: pty.IPty` field spawned alongside the primary in `createSessionInternal`. Same executable (`COMSPEC`), same cwd, cleaned env. Shell PTY is killed on session close, on primary exit, and in `killAllSessions`. Shell data is **not** mirrored into `outputBuffer`, so MCP `read_output` continues to reflect only the claude session. Independent shell exit (user types `exit`) does not tear the session down.
- **IPC channels** — parallel to the primary: `session:shell:data` / `session:shell:exit` (main → renderer) and `session:shell:input` / `session:shell:resize` (renderer → main). The existing MCP tools (`open_session`, `read_output`, `send_input`) are untouched and still target the primary.
- **Preload / `TermhubApi`** — four new additive methods: `sendShellInput`, `resizeShell`, `onShellData`, `onShellExit`. No existing fields reshaped, so other in-flight branches merge cleanly.
- **Renderer** — `App.tsx` owns a second `Map<sessionId, TerminalEntry>` for shell xterms with its own pending-data queue. The main pane splits into `.main-top` (flex: 1) + `.main-divider` + `.main-bottom` (fixed 220px). A new `BottomTerminal.tsx` mirrors `TerminalView.tsx`'s lazy-init / display-toggle pattern but wires data/resize to the shell channel.

## Out of scope for v1

- **No persistence of shell buffer state** across restarts. Resumed sessions spawn a fresh shell PTY at the session's cwd; prior shell output is gone.
- **No draggable divider** — bottom pane is a fixed 220px. Resizer can come later.
- **No MCP exposure** of the shell PTY. It's for manual user work only.
- **No shell-exit respawn** — if the user types `exit` in the bottom pane, the pane goes dead until the session itself is recreated.

## Test plan

- [ ] `npm run typecheck` passes both tsconfigs
- [ ] `npm run build` succeeds
- [ ] `npm run dev`: create a new session → bottom terminal appears rooted in the chosen cwd
- [ ] Switching active session in the sidebar swaps both the claude terminal and the bottom shell to the new session's instances
- [ ] Closing a session via the sidebar kills both PTYs (no orphaned processes)
- [ ] Typing `exit` in the bottom terminal does not close the session
- [ ] MCP `read_output` for a session still returns only primary (claude) output, not shell output
- [ ] Startup/resume: bottom terminal spawns for each resumed session at its persisted cwd

🤖 Generated with [Claude Code](https://claude.com/claude-code)