### PR TITLE
feat: add Claude Usage modal with persistent webview

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -547,6 +547,7 @@ function createWindow() {
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: false,
+      webviewTag: true,
     },
   })
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Sidebar } from './Sidebar'
 import { TerminalView } from './TerminalView'
 import { BottomTerminal } from './BottomTerminal'
 import { RightPanel } from './RightPanel'
+import { UsageModal } from './UsageModal'
 import type { Session } from './types'
 
 export type TerminalEntry = { term: Terminal; fit: FitAddon }
@@ -12,6 +13,7 @@ export type TerminalEntry = { term: Terminal; fit: FitAddon }
 export default function App() {
   const [sessions, setSessions] = useState<Session[]>([])
   const [activeId, setActiveId] = useState<string | null>(null)
+  const [showUsage, setShowUsage] = useState(false)
   // Primary (claude) PTY xterm instances, keyed by session id.
   const termsRef = useRef(new Map<string, TerminalEntry>())
   const pendingDataRef = useRef(new Map<string, string[]>())
@@ -246,7 +248,8 @@ export default function App() {
           </>
         )}
       </main>
-      <RightPanel activeSession={activeSession} />
+      <RightPanel activeSession={activeSession} onOpenUsage={() => setShowUsage(true)} />
+      {showUsage && <UsageModal onClose={() => setShowUsage(false)} />}
     </div>
   )
 }

--- a/src/RightPanel.tsx
+++ b/src/RightPanel.tsx
@@ -6,13 +6,35 @@ import type { Session } from './types'
 
 type Props = {
   activeSession: Session | null
+  onOpenUsage: () => void
 }
 
-export function RightPanel({ activeSession }: Props) {
+export function RightPanel({ activeSession, onOpenUsage }: Props) {
   return (
     <aside className="right-panel">
       <div className="right-panel-header">
         <span className="brand">menus</span>
+        <button
+          onClick={onOpenUsage}
+          title="Claude Usage"
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            color: 'var(--text-muted, #888)',
+            padding: '2px 4px',
+            borderRadius: '4px',
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          {/* Bar-chart icon */}
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <rect x="1" y="9" width="3" height="6" rx="1" />
+            <rect x="6" y="5" width="3" height="10" rx="1" />
+            <rect x="11" y="1" width="3" height="14" rx="1" />
+          </svg>
+        </button>
       </div>
       <div className="right-panel-body">
         <CollapsibleSection title="Agents">

--- a/src/UsageModal.tsx
+++ b/src/UsageModal.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef } from 'react'
+
+type Props = {
+  onClose: () => void
+}
+
+export function UsageModal({ onClose }: Props) {
+  const overlayRef = useRef<HTMLDivElement>(null)
+
+  // Close on Escape key
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [onClose])
+
+  // Close when clicking the backdrop (not the modal content)
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === overlayRef.current) onClose()
+  }
+
+  return (
+    <div
+      ref={overlayRef}
+      onClick={handleOverlayClick}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 1000,
+        background: 'rgba(0, 0, 0, 0.6)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div
+        style={{
+          position: 'relative',
+          width: '860px',
+          height: '640px',
+          maxWidth: 'calc(100vw - 48px)',
+          maxHeight: 'calc(100vh - 48px)',
+          background: '#1e1e1e',
+          borderRadius: '8px',
+          border: '1px solid rgba(255,255,255,0.12)',
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        {/* Header bar */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '8px 12px',
+            borderBottom: '1px solid rgba(255,255,255,0.1)',
+            flexShrink: 0,
+          }}
+        >
+          <span style={{ fontSize: '13px', fontWeight: 600, color: 'var(--text, #ccc)', letterSpacing: '0.04em' }}>
+            Claude Usage
+          </span>
+          <button
+            onClick={onClose}
+            title="Close (Esc)"
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              color: 'var(--text-muted, #888)',
+              padding: '2px 6px',
+              borderRadius: '4px',
+              fontSize: '16px',
+              lineHeight: 1,
+            }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* webview — uses a named partition so cookies persist across restarts */}
+        <webview
+          src="https://claude.ai/settings/usage"
+          partition="persist:claude-usage"
+          style={{ flex: 1, width: '100%' }}
+        />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Adds a bar-chart icon button to the RightPanel header that opens a modal overlay embedding `https://claude.ai/settings/usage` via Electron's `<webview>` tag. Once the user signs in, cookies persist across app restarts via `partition="persist:claude-usage"`.

## Embedding mechanism
Used `<webview>` (not `<iframe>`) because `claude.ai` sets `X-Frame-Options: DENY`, which blocks iframes even in Electron. Electron's out-of-process `<webview>` tag bypasses host-site anti-framing headers. Required enabling `webviewTag: true` in the main `BrowserWindow` `webPreferences`.

Cookie persistence is handled by the named session partition `persist:claude-usage` — Electron stores this session's cookies on disk and restores them on next launch.

## Changes
- `electron/main.ts` — add `webviewTag: true` to `webPreferences`
- `src/UsageModal.tsx` — new overlay component; closes on Esc, click-outside, or close button; embeds the usage page via `<webview>`
- `src/RightPanel.tsx` — add `onOpenUsage` prop and inline-SVG bar-chart icon button in the panel header
- `src/App.tsx` — track `showUsage` boolean state; render `<UsageModal>` conditionally; wire `onOpenUsage` to `RightPanel`

## Test plan
- [ ] Click bar-chart icon in RightPanel header → modal opens, usage page loads
- [ ] Sign in to Claude in the webview; close and reopen the modal → still signed in (cookies persisted)
- [ ] Press Esc → modal closes
- [ ] Click the backdrop outside the modal → modal closes
- [ ] Click the X close button → modal closes
- [ ] `npm run typecheck` passes clean