### PR TITLE
ci: add baseline CI and repo hygiene

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    name: Typecheck & build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * 1'  # Weekly on Mondays at 03:00 UTC
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript-typescript'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: Dependency review
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4


### PR DESCRIPTION
## Summary

Establishes a minimal but complete CI and repo hygiene baseline for termhub. Adds a fast ubuntu typecheck/build gate, CodeQL code scanning, dependency vulnerability review on PRs, and automated dependency updates via Dependabot. The existing Windows packaging workflow is unchanged.

## Changes

- **`.github/workflows/ci.yml`** — lightweight ubuntu-latest job (Node 20, `npm ci`, `npm run typecheck`, `npm run build`) that runs on every push to `main` and every PR. Faster feedback than the Windows packaging job for catching type errors and build regressions.
- **`.github/workflows/codeql.yml`** — GitHub CodeQL scanning for JavaScript/TypeScript. Runs on push to `main`, PRs, and weekly (Mondays). Uses only `GITHUB_TOKEN` — no secrets needed.
- **`.github/workflows/dependency-review.yml`** — flags newly-added npm packages with known CVEs on every PR, using `actions/dependency-review-action@v4`. No secrets needed.
- **`.github/dependabot.yml`** — weekly Dependabot updates for both `npm` and `github-actions`. Minor and patch npm bumps are grouped into a single PR to reduce noise.

## Test plan

- [ ] CI workflow runs green on this PR (typecheck + build on ubuntu)
- [ ] CodeQL analysis completes without errors
- [ ] Dependency review runs on this PR (no vulnerabilities expected)
- [ ] Existing `Build Windows .exe` workflow is unaffected