### PR TITLE
feat: group sidebar sessions by repo root

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -12,6 +12,8 @@ type Session = {
   cwd: string
   command?: string
   name?: string
+  repoRoot?: string
+  repoLabel?: string
   model?: string
   permissionMode?: string
   dangerouslySkipPermissions?: boolean
@@ -44,6 +46,53 @@ function stripAnsi(s: string): string {
     .replace(/\x1b[PX^_][\s\S]*?\x1b\\/g, '')
     .replace(/\x1b[=>()*+\-.\/]./g, '')
     .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '')
+}
+
+// Walk upward from cwd looking for a .git entry (file or directory).
+// If found as a file (worktree), parse the `gitdir:` line to resolve the
+// main checkout root (two dirname()s up from the worktree-specific gitdir).
+// Returns { repoRoot, repoLabel } or null when no repo is found.
+function detectRepoRoot(cwd: string): { repoRoot: string; repoLabel: string } | null {
+  let current = path.resolve(cwd)
+  while (true) {
+    const gitEntry = path.join(current, '.git')
+    let stat: fs.Stats | null = null
+    try {
+      stat = fs.statSync(gitEntry)
+    } catch {
+      // not found at this level — keep walking
+    }
+    if (stat !== null) {
+      if (stat.isDirectory()) {
+        // Normal checkout: .git directory means this directory IS the repo root
+        return { repoRoot: current, repoLabel: path.basename(current) }
+      }
+      if (stat.isFile()) {
+        // Git worktree: .git file contains "gitdir: <path>"
+        try {
+          const contents = fs.readFileSync(gitEntry, 'utf8')
+          const m = /^gitdir:\s*(.+)$/m.exec(contents)
+          if (m) {
+            // Typically: <main-checkout>/.git/worktrees/<name>
+            // Two dirname()s up: strip /<name> then /worktrees → <main-checkout>/.git
+            // One more dirname(): the main checkout root
+            const worktreeGitDir = path.resolve(current, m[1].trim())
+            const mainGit = path.dirname(path.dirname(worktreeGitDir))
+            const mainCheckout = path.dirname(mainGit)
+            return { repoRoot: mainCheckout, repoLabel: path.basename(mainCheckout) }
+          }
+        } catch {
+          // unreadable .git file — treat as no-repo
+        }
+      }
+    }
+    const parent = path.dirname(current)
+    if (parent === current) {
+      // Reached filesystem root — no repo found
+      return null
+    }
+    current = parent
+  }
 }
 
 type FindSessionResult =
@@ -435,11 +484,14 @@ function createSessionInternal(opts: {
   }
   console.log(`[termhub] shell pty.spawn returned (pid=${shellTerm.pid})`)
 
+  const repoInfo = detectRepoRoot(opts.cwd)
   const session: Session = {
     id,
     cwd: opts.cwd,
     command: opts.command,
     name: opts.name,
+    repoRoot: repoInfo?.repoRoot,
+    repoLabel: repoInfo?.repoLabel,
     model: opts.model,
     permissionMode: opts.permissionMode,
     dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
@@ -527,6 +579,8 @@ function createSessionInternal(opts: {
       cwd: opts.cwd,
       command: opts.command,
       name: opts.name,
+      repoRoot: repoInfo?.repoRoot,
+      repoLabel: repoInfo?.repoLabel,
       autoActivate,
     })
   }
@@ -777,6 +831,8 @@ app.whenReady().then(async () => {
       cwd: s.cwd,
       command: s.command,
       name: s.name,
+      repoRoot: s.repoRoot,
+      repoLabel: s.repoLabel,
     })),
   )
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -8,6 +8,8 @@ type AddedPayload = {
   autoActivate?: boolean
   command?: string
   name?: string
+  repoRoot?: string
+  repoLabel?: string
 }
 type AgentDef = { name: string; path: string; description?: string }
 
@@ -96,10 +98,12 @@ const api = {
       autoActivate: boolean,
       command?: string,
       name?: string,
+      repoRoot?: string,
+      repoLabel?: string,
     ) => void,
   ): (() => void) => {
     const handler = (_e: Electron.IpcRendererEvent, p: AddedPayload) =>
-      cb(p.id, p.cwd, p.autoActivate ?? false, p.command, p.name)
+      cb(p.id, p.cwd, p.autoActivate ?? false, p.command, p.name, p.repoRoot, p.repoLabel)
     ipcRenderer.on('session:added', handler)
     return () => {
       ipcRenderer.off('session:added', handler)
@@ -107,7 +111,7 @@ const api = {
   },
 
   listSessions: (): Promise<
-    Array<{ id: string; cwd: string; command?: string; name?: string }>
+    Array<{ id: string; cwd: string; command?: string; name?: string; repoRoot?: string; repoLabel?: string }>
   > => ipcRenderer.invoke('sessions:list'),
 
   appReady: (): void => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,11 +56,11 @@ export default function App() {
       shellPendingDataRef.current.delete(id)
     })
     const offAdded = window.termhub.onSessionAdded(
-      (id, cwd, autoActivate, command, name) => {
+      (id, cwd, autoActivate, command, name, repoRoot, repoLabel) => {
         setSessions((prev) =>
           prev.some((s) => s.id === id)
             ? prev
-            : [...prev, { id, cwd, command, name }],
+            : [...prev, { id, cwd, command, name, repoRoot, repoLabel }],
         )
         if (autoActivate) {
           setActiveId((curr) => curr ?? id)
@@ -75,7 +75,14 @@ export default function App() {
       if (existing.length > 0) {
         setSessions((prev) => {
           const seen = new Set(prev.map((s) => s.id))
-          return [...prev, ...existing.filter((s) => !seen.has(s.id))]
+          return [...prev, ...existing.filter((s) => !seen.has(s.id)).map((s) => ({
+            id: s.id,
+            cwd: s.cwd,
+            command: s.command,
+            name: s.name,
+            repoRoot: s.repoRoot,
+            repoLabel: s.repoLabel,
+          }))]
         })
         setActiveId((curr) => curr ?? existing[0].id)
       }
@@ -196,7 +203,7 @@ export default function App() {
     return () => cancelAnimationFrame(raf)
   }, [activeId])
 
-  const grouped = useMemo(() => groupByCwd(sessions), [sessions])
+  const grouped = useMemo(() => groupSessions(sessions), [sessions])
   const activeSession = useMemo(
     () => sessions.find((s) => s.id === activeId) ?? null,
     [sessions, activeId],
@@ -251,12 +258,17 @@ export default function App() {
   )
 }
 
-function groupByCwd(sessions: Session[]): Map<string, Session[]> {
+// Group sessions by repo root when available, falling back to cwd.
+// The map key is the group key (repoRoot or cwd); Sidebar reads the label
+// from the first session in the group via session.repoLabel or derives it
+// from the cwd.
+function groupSessions(sessions: Session[]): Map<string, Session[]> {
   const m = new Map<string, Session[]>()
   for (const s of sessions) {
-    const list = m.get(s.cwd) ?? []
+    const key = s.repoRoot ?? s.cwd
+    const list = m.get(key) ?? []
     list.push(s)
-    m.set(s.cwd, list)
+    m.set(key, list)
   }
   return m
 }

--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -98,10 +98,14 @@ export function Sidebar({ groups, activeId, onNew, onSelect, onClose, onRename }
         </button>
       </div>
       <div className="groups">
-        {[...groups.entries()].map(([cwd, list]) => (
-          <div className="group" key={cwd}>
-            <div className="group-title" title={cwd}>
-              {shortenPath(cwd)}
+        {[...groups.entries()].map(([groupKey, list]) => {
+          const first = list[0]
+          const label = first?.repoLabel ?? shortenPath(first?.cwd ?? groupKey)
+          const titleAttr = first?.repoRoot ?? first?.cwd ?? groupKey
+          return (
+          <div className="group" key={groupKey}>
+            <div className="group-title" title={titleAttr}>
+              {label}
             </div>
             <ul className="group-list">
               {list.map((s, idx) => (
@@ -156,7 +160,8 @@ export function Sidebar({ groups, activeId, onNew, onSelect, onClose, onRename }
               ))}
             </ul>
           </div>
-        ))}
+          )
+        })}
       </div>
 
       {contextMenu && contextSession && (

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,8 @@ export type Session = {
   cwd: string
   command?: string
   name?: string
+  repoRoot?: string
+  repoLabel?: string
 }
 
 export type AgentDef = {
@@ -62,10 +64,12 @@ export type TermhubApi = {
       autoActivate: boolean,
       command?: string,
       name?: string,
+      repoRoot?: string,
+      repoLabel?: string,
     ) => void,
   ) => () => void
   listSessions: () => Promise<
-    Array<{ id: string; cwd: string; command?: string; name?: string }>
+    Array<{ id: string; cwd: string; command?: string; name?: string; repoRoot?: string; repoLabel?: string }>
   >
   appReady: () => void
   listAgents: () => Promise<AgentDef[]>


### PR DESCRIPTION
## Summary

Sessions whose cwd lives inside a git repo (including worktrees) are now grouped under a single header labelled with the repo's directory name rather than one header per cwd. For example, nine worktrees of the same repo each show up under one **termhub** group instead of nine separate separators.

Grouping uses a synchronous upward walk from the session's cwd, checking for a `.git` directory (normal checkout) or a `.git` file (git worktree). When a `.git` file is found, its `gitdir:` line is parsed to resolve the main checkout root (two `dirname()` calls up from the worktree-specific gitdir path). Sessions with no detectable git repo fall back to the existing cwd-based grouping.

## Changes

- `electron/main.ts` — add `detectRepoRoot(cwd)` function; stash `repoRoot`/`repoLabel` on session objects; include both in `session:added` events and `sessions:list` responses
- `src/types.ts` — extend `Session`, `onSessionAdded`, and `listSessions` with optional `repoRoot`/`repoLabel` fields (additive only)
- `electron/preload.ts` — forward new fields through `AddedPayload` and `onSessionAdded` callback
- `src/App.tsx` — pass `repoRoot`/`repoLabel` when building session state; replace `groupByCwd` with `groupSessions` that keys by `repoRoot ?? cwd`
- `src/Sidebar.tsx` — use `session.repoLabel` as group header when present, fall back to `shortenPath(cwd)`

## Test plan

- [ ] Open termhub with multiple sessions whose cwds are worktrees of the same repo — confirm they appear under one group labelled with the repo name
- [ ] Open a session in a normal (non-worktree) checkout — confirm it groups under the repo name
- [ ] Open a session in a directory with no git repo — confirm it falls back to the cwd-based header as before