### PR TITLE
ci: cache node_modules to skip npm ci on warm runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Typecheck

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
 
       - name: Cache node_modules
         id: cache-node-modules
@@ -35,12 +36,23 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
-      - name: Package Windows .exe
-        run: npm run dist:win
+      - name: Build
+        run: npm run build
+
+      - name: Package (NSIS + portable)
+        if: github.event_name != 'pull_request'
+        run: npx electron-builder --win --publish never
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package (portable only)
+        if: github.event_name == 'pull_request'
+        run: npx electron-builder --win portable --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload installer artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: termhub-windows-installer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,23 +36,12 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
-      - name: Build
-        run: npm run build
-
-      - name: Package (NSIS + portable)
-        if: github.event_name != 'pull_request'
-        run: npx electron-builder --win --publish never
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Package (portable only)
-        if: github.event_name == 'pull_request'
-        run: npx electron-builder --win portable --publish never
+      - name: Package Windows .exe
+        run: npm run dist:win
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload installer artifact
-        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: termhub-windows-installer

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "build": {
     "appId": "com.alexdickerson.termhub",
     "productName": "TermHub",
-    "compression": "normal",
     "directories": {
       "output": "release"
     },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "build": {
     "appId": "com.alexdickerson.termhub",
     "productName": "TermHub",
+    "compression": "normal",
     "directories": {
       "output": "release"
     },


### PR DESCRIPTION
## Summary

Adds a direct `node_modules` cache keyed on `package-lock.json` so that `npm ci` (which takes ~21s even with a warm npm download cache) is skipped entirely on runs where the lockfile hasn't changed.

**Before (5-run median):** ~1m50s  
**After (cache-warm PR run):** ~1m37s (~13s, 12% faster)

The `cache: 'npm'` on `setup-node` is kept as a fallback so that runs after a lockfile change (node_modules cache miss) still benefit from the npm tarball cache and don't regress to full-internet-download speeds.

## What was investigated and why each idea was kept or dropped

**node_modules caching → kept.** `npm ci` wrote 566 packages to disk in ~21s every run even though the npm download cache was already warm. A 212 MB compressed `node_modules` archive restores in ~8s, for a net ~13s saving per cache-hit run.

**`compression: "normal"` in electron-builder config → reverted.** The installer size was identical (84.3 MB) before and after the change; the NSIS step still took 34–35s. The `compression` field in electron-builder v25 does not map to NSIS `SetCompressor` — it has no effect on NSIS packaging time.

**Portable-only packaging for PRs → reverted.** Building `--win portable` alone takes ~75s because electron-builder must run its own full LZMA compression pass. Building both NSIS and portable together takes ~50s total because the portable target reuses the already-packaged `win-unpacked/` directory from the NSIS step (portable itself only takes ~1s after NSIS). Splitting the steps made CI slower, not faster.

**NSIS bottleneck:** The remaining dominant cost is the 34–35s NSIS LZMA compression step. This cannot be addressed by the electron-builder `compression` config setting. Tracked in #22.

## Changes

- `build.yml`: keep `cache: 'npm'`; add `actions/cache@v4` for `node_modules` keyed on `package-lock.json`; skip `npm ci` on cache hit.

## Test plan

- [x] CI on this PR produced both `*-setup.exe` and `*-portable.exe` artifacts
- [x] Third push (cache warm) ran in 1m37s vs ~1m50s baseline

## Follow-ups

- #22 — investigate NSIS compression bottleneck (~34s per run)