### PR TITLE
fix: correct bottom terminal sizing and FitAddon wiring

### DIFF
--- a/src/BottomTerminal.tsx
+++ b/src/BottomTerminal.tsx
@@ -144,9 +144,10 @@ export function BottomTerminal({
 
   return (
     <div
-      ref={containerRef}
-      className="terminal-container"
-      style={{ display: isActive ? 'block' : 'none' }}
-    />
+      className="terminal-pane"
+      style={{ display: isActive ? 'flex' : 'none' }}
+    >
+      <div ref={containerRef} className="terminal-container" />
+    </div>
   )
 }


### PR DESCRIPTION
## Summary

The docked bottom terminal was rendering with no usable height — only ~3 lines were ever visible because the xterm canvas had nothing to fill. The root cause was a missing wrapper `div` in `BottomTerminal.tsx`: the component rendered `.terminal-container` directly as the outermost element with `display: block`, whereas the CSS layout expects a `.terminal-pane` parent (`position: absolute; inset: 0; display: flex; flex-direction: column`) to anchor the container inside `.main-bottom` (which is `position: relative; height: 220px`).

## Changes

- `src/BottomTerminal.tsx`: wrap the `ref`-attached container `div` in a `.terminal-pane` div with `display: flex`, matching the structure of `TerminalView.tsx` exactly

## Test plan

- [ ] Open termhub with an active session — the bottom shell pane should fill its 220px allotment and show ~12–13 terminal rows
- [ ] Type commands in the bottom terminal; new lines should scroll into view rather than being hidden
- [ ] Resize the window — `fit.fit()` fires via the existing `window.resize` handler in `App.tsx` and the bottom terminal reflows correctly