### PR TITLE
fix: render context menu items as vertical stack

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -179,6 +179,37 @@ body,
   color: var(--text);
 }
 
+/* ---------- Context menu ---------- */
+
+.context-menu {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 0;
+  min-width: 160px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+}
+
+.context-menu-item {
+  display: block;
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  text-align: left;
+  padding: 6px 14px;
+  cursor: pointer;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.context-menu-item:hover {
+  background: var(--hover);
+}
+
 /* ---------- Right panel ---------- */
 
 .right-panel {


### PR DESCRIPTION
## Summary
Right-click context menus in the sidebar were rendering their items horizontally (side by side) instead of as a vertical list. The `.context-menu` and `.context-menu-item` CSS classes had no rules defined, so buttons defaulted to `display: inline-block` and flowed left-to-right.

## Changes
- Add `.context-menu` rule with `display: flex; flex-direction: column` plus border, shadow, and z-index for correct popup appearance
- Add `.context-menu-item` rule with `display: block; width: 100%` and hover state so items stack as full-width rows

## Test plan
- [ ] Right-click a session in the sidebar — "Open in VS Code" and "Rename" should appear stacked vertically in a dark popup menu