### PR TITLE
fix: restore Ctrl+V paste in xterm sessions

### DIFF
--- a/src/BottomTerminal.tsx
+++ b/src/BottomTerminal.tsx
@@ -94,9 +94,13 @@ export function BottomTerminal({
           return true
         }
 
-        void window.termhub.readClipboard().then((text) => {
-          if (text) term.paste(text)
-        })
+        // Ctrl+V: return false so xterm doesn't convert the keystroke into
+        // the SYN control char \x16 (and call preventDefault, which would
+        // suppress the textarea's native paste pipeline).  xterm's own
+        // built-in 'paste' listener on the textarea then handles writing
+        // the clipboard contents to the PTY with bracketed-paste-mode
+        // framing.  Calling readClipboard().then(term.paste()) here in
+        // addition produces a double paste.
         return false
       })
 

--- a/src/TerminalView.tsx
+++ b/src/TerminalView.tsx
@@ -76,59 +76,42 @@ export function TerminalView({ session, isActive, termsRef, pendingDataRef }: Pr
 
       // Single handler — xterm only keeps the last registered handler, so
       // all key interception must live in one call to attachCustomKeyEventHandler.
-      //
-      // Shift+Enter is intentionally NOT intercepted here.  Claude Code enables
-      // modifyOtherKeys mode (or the kitty keyboard protocol) in xterm.js by
-      // writing the appropriate escape sequence to the PTY as part of its
-      // startup.  In that mode xterm natively encodes Shift+Enter as the CSI
-      // sequence Claude Code expects (e.g. \x1b[27;2;13~) and emits it via
-      // onData, where it travels through sendInput to the PTY.
-      //
-      // Intercepting the key here and returning false suppresses that encoding
-      // and substitutes a custom byte sequence that Claude Code does not
-      // recognise, causing it to submit instead of inserting a newline.
       term.attachCustomKeyEventHandler((e) => {
+        // Shift+Enter: send the kitty keyboard-protocol encoding (\x1b[13;2u).
+        // xterm.js is in normal terminal mode (Claude Code does not enable
+        // modifyOtherKeys or kitty protocol on this xterm instance), so without
+        // interception xterm emits bare CR (0d) which Claude Code treats as
+        // "submit".  The kitty form is what Claude Code maps to "insert newline"
+        // in Kitty / WezTerm.
         if (e.type === 'keydown' && e.shiftKey && e.key === 'Enter') {
-          // Kitty keyboard-protocol encoding for Shift+Enter (\x1b[13;2u).
-          // xterm.js is in normal terminal mode (Claude Code does not enable
-          // modifyOtherKeys or kitty protocol on this xterm instance), so
-          // without interception xterm emits bare CR (0d) which Claude Code
-          // treats as "submit".  The kitty form is what Claude Code receives
-          // in Kitty / WezTerm and maps to "insert newline".
           e.preventDefault()
           window.termhub.sendInput(session.id, '\x1b[13;2u')
           return false
         }
 
-        // Ctrl+C / Ctrl+V: clipboard copy and paste.
-        if (e.type === 'keydown' && e.ctrlKey) {
-          const isC = e.code === 'KeyC'
-          const isV = e.code === 'KeyV'
-
-          if (isC) {
-            const hasSelection = term.hasSelection()
-            if (e.shiftKey || hasSelection) {
-              const text = term.getSelection()
-              if (text) {
-                window.termhub.writeClipboard(text)
-                term.clearSelection()
-              }
-              return false
+        if (e.type === 'keydown' && e.ctrlKey && e.code === 'KeyC') {
+          const hasSelection = term.hasSelection()
+          if (e.shiftKey || hasSelection) {
+            const text = term.getSelection()
+            if (text) {
+              window.termhub.writeClipboard(text)
+              term.clearSelection()
             }
-            return true
-          }
-
-          if (isV) {
-            // Prevent the browser from also firing a native 'paste' ClipboardEvent
-            // on the xterm textarea. Without this, xterm's own paste listener
-            // (registered on the textarea) fires after our term.paste() call,
-            // writing the clipboard text a second time.
-            e.preventDefault()
-            void window.termhub.readClipboard().then((text) => {
-              if (text) term.paste(text)
-            })
             return false
           }
+        }
+
+        // Ctrl+V: returning false stops xterm's _keyDown from converting
+        // the keystroke into the SYN control char \x16 and calling
+        // preventDefault on the keydown.  That preventDefault is what
+        // suppresses the browser's native textarea paste pipeline; with it
+        // gone, the textarea fires a real 'paste' ClipboardEvent and
+        // xterm's own paste listener handles it (calling term.paste() with
+        // bracketed-paste-mode framing).  No custom readClipboard call is
+        // needed — adding one produces a double paste because xterm's
+        // listener writes the same text again.
+        if (e.type === 'keydown' && e.ctrlKey && e.code === 'KeyV') {
+          return false
         }
 
         return true


### PR DESCRIPTION
## Summary

Restore Ctrl+V in both `TerminalView.tsx` (Claude session terminals) and `BottomTerminal.tsx` (the docked shell) by deleting the custom `readClipboard().then(term.paste(text))` call and letting xterm's own textarea `paste` listener handle the clipboard. The custom `e.preventDefault()` on Ctrl+V keydown — added by PR #7 — is also removed; it was the cause of the original regression.

## Why this regressed and why several attempts didn't fix it

xterm's `_keyDown` handler converts Ctrl+V into the SYN control char (`\x16`) and calls `preventDefault()` on the keydown. That preventDefault is what suppresses the browser's native textarea paste pipeline — meaning xterm's own `paste` event listener (registered on the textarea inside `term.open()`) never fires when xterm processes the keydown.

To get xterm's paste listener to actually run, the `customKeyEventHandler` must `return false` for Ctrl+V keydown without calling `preventDefault()`. Then the textarea processes Ctrl+V natively, fires a `paste` ClipboardEvent, and xterm's listener writes the clipboard text via `term.paste()` (with bracketed-paste-mode framing).

Calling `window.termhub.readClipboard().then(term.paste)` *in addition* to that — which both `TerminalView.tsx` and `BottomTerminal.tsx` were doing — produces a double paste, because xterm's textarea listener writes the same text via the native flow. (xterm's `_inputEvent` does *not* duplicate further: it only handles `inputType === "insertText"`, and paste fires `inputType === "insertFromPaste"`.)

PR #7 ("fix: prevent duplicate paste by calling `preventDefault` on Ctrl+V keydown") tried to suppress the duplicate by `preventDefault`-ing the keydown. That blocked the textarea paste pipeline entirely (same effect xterm's own `preventDefault` would have had), leaving **no** writer — Ctrl+V silently did nothing in claude sessions.

Earlier iterations on this branch tried two other fixes that don't actually work:

1. A capture-phase `paste` listener on `term.textarea`. Listeners on the *target* element fire in registration order regardless of capture flag, and xterm's listener is registered first inside `term.open()` — so the capture listener fired *after* xterm and couldn't suppress it.
2. Removing the custom Ctrl+V branch entirely and trusting xterm. That returned `true` from the keydown handler, so xterm processed Ctrl+V → emitted `\x16` → preventDefault'd → paste event never fired → no paste at all.

Verified empirically with debug logging on `keydown`, `onData`, and `paste@*` on multiple targets. The single `return false` on Ctrl+V keydown produces exactly one `onData` chunk per paste in both terminals.

## Test plan

- [x] `npm run typecheck` — clean
- [x] Manual: Ctrl+V in a Claude Code session — single paste
- [x] Manual: Ctrl+V in the docked bottom terminal — single paste
- [ ] Manual: Ctrl+Shift+C / Ctrl+C copy still works
- [ ] Manual: Shift+Enter still inserts a newline in Claude's input box

🤖 Generated with [Claude Code](https://claude.com/claude-code)