### PR TITLE
fix: restore Ctrl+V paste in claude session terminals

### DIFF
--- a/src/BottomTerminal.tsx
+++ b/src/BottomTerminal.tsx
@@ -108,6 +108,14 @@ export function BottomTerminal({
       })
 
       term.open(container)
+
+      // Block xterm's built-in paste handler so our custom readClipboard path
+      // is the only one that writes to the PTY. Mirrors the same fix applied
+      // in TerminalView.tsx — without this, Ctrl+V writes the clipboard text
+      // twice: once by term.paste() in the custom key handler above, and once
+      // by xterm's own handlePasteEvent listener on the textarea.
+      term.textarea?.addEventListener('paste', (ev) => ev.preventDefault(), true)
+
       try {
         fit.fit()
       } catch (err) {

--- a/src/TerminalView.tsx
+++ b/src/TerminalView.tsx
@@ -94,11 +94,6 @@ export function TerminalView({ session, isActive, termsRef, pendingDataRef }: Pr
           return true
         }
 
-        // Prevent the browser from also firing a native 'paste' ClipboardEvent
-        // on the xterm textarea. Without this, xterm's own paste listener
-        // (registered on the textarea) fires after our term.paste() call,
-        // writing the clipboard text a second time.
-        e.preventDefault()
         void window.termhub.readClipboard().then((text) => {
           if (text) term.paste(text)
         })
@@ -128,6 +123,16 @@ export function TerminalView({ session, isActive, termsRef, pendingDataRef }: Pr
       })
 
       term.open(container)
+
+      // Block xterm's built-in paste handler so our custom readClipboard path
+      // is the only one that writes to the PTY. xterm registers a 'paste'
+      // listener on its textarea; calling preventDefault() here stops that
+      // listener from also firing when the browser dispatches the ClipboardEvent
+      // after Ctrl+V. Without this, clipboard text is written twice: once by
+      // term.paste() in the custom key handler above, and once by xterm's own
+      // handlePasteEvent.
+      term.textarea?.addEventListener('paste', (ev) => ev.preventDefault(), true)
+
       try {
         fit.fit()
       } catch (err) {


### PR DESCRIPTION
## Summary

Follow-up to PR #27. Termhub renders two xterm.js hosts per session — `TerminalView.tsx` (top pane, primary PTY running `claude`) and `BottomTerminal.tsx` (bottom pane, shell PTY). PR #27 fixes the dead-paste bug only in `TerminalView.tsx` and is **still open** as of this PR — so on latest `main`, Ctrl+V is dead in the claude session pane.

This PR replays PR #27's fix in `TerminalView.tsx` so it lands on `main` regardless of whether PR #27 is merged or closed in favor of this one. It also applies the same capture-phase paste blocker to `BottomTerminal.tsx` for symmetry — that file did not have the dead-paste bug (no `preventDefault` in its keydown branch), but it was silently double-writing pasted clipboard text because xterm's built-in `handlePasteEvent` was still firing alongside our custom `readClipboard().then(term.paste())` path.

## Changes

- `src/TerminalView.tsx` — remove `e.preventDefault()` from the Ctrl+V keydown branch; install a capture-phase `paste` listener on `term.textarea` that calls `preventDefault()` to stop xterm's own `handlePasteEvent` from double-writing. Identical to PR #27's fix.
- `src/BottomTerminal.tsx` — install the same capture-phase `paste` listener on `term.textarea`. Eliminates the latent double-paste in the docked shell pane.

## Test plan

- [ ] Ctrl+V pastes clipboard text into the **claude session** (top pane) exactly once
- [ ] Ctrl+V pastes clipboard text into the **docked shell** (bottom pane) exactly once
- [ ] Ctrl+C with text selected in either pane copies to clipboard (unaffected path)
- [ ] Shift+Enter in the claude session still sends ESC+CR (unaffected handler)

Refs #27.