### PR TITLE
feat: expose --allow-dangerously-skip-permissions on open_session MCP

### DIFF
--- a/electron/main.test.ts
+++ b/electron/main.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+// buildClaudeArgs is a pure helper exported from main.ts. We import it
+// directly; Electron and node-pty are not available in the test runner so
+// we mock the modules that main.ts imports at the top level.
+// vi.mock factories are hoisted, so all values must be defined inline.
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp',
+    // Return a promise that never resolves so the whenReady callbacks
+    // never fire and we avoid unhandled errors from incomplete mocks.
+    whenReady: () => new Promise(() => {}),
+    on: () => {},
+    quit: () => {},
+  },
+  BrowserWindow: class {
+    on() {}
+    once() {}
+    loadURL() {}
+    loadFile() {}
+    webContents = { send: () => {}, openDevTools: () => {} }
+    isMaximized() { return false }
+    minimize() {}
+    maximize() {}
+    unmaximize() {}
+    close() {}
+    static getAllWindows() { return [] }
+  },
+  ipcMain: { handle: () => {}, on: () => {}, once: () => {} },
+  dialog: {},
+  clipboard: { readText: () => '', writeText: () => {} },
+  shell: { openPath: async () => '' },
+  Menu: { setApplicationMenu: () => {} },
+}))
+vi.mock('@lydell/node-pty', () => ({ spawn: () => ({}) }))
+vi.mock('node:child_process', () => ({ spawn: () => ({}) }))
+
+import { buildClaudeArgs } from './main'
+
+const BASE = {
+  sessionId: 'test-session-id',
+  mcpConfigPath: '/path/to/mcp.json',
+}
+
+describe('buildClaudeArgs', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('neither flag — no skip-permissions flags emitted', () => {
+    const flags = buildClaudeArgs({ ...BASE })
+    expect(flags.join(' ')).not.toContain('--dangerously-skip-permissions')
+    expect(flags.join(' ')).not.toContain('--allow-dangerously-skip-permissions')
+  })
+
+  it('only dangerouslySkipPermissions — emits --dangerously-skip-permissions', () => {
+    const flags = buildClaudeArgs({ ...BASE, dangerouslySkipPermissions: true })
+    expect(flags).toContain('--dangerously-skip-permissions')
+    expect(flags.join(' ')).not.toContain('--allow-dangerously-skip-permissions')
+  })
+
+  it('only allowDangerouslySkipPermissions — emits --allow-dangerously-skip-permissions', () => {
+    const flags = buildClaudeArgs({ ...BASE, allowDangerouslySkipPermissions: true })
+    expect(flags).toContain('--allow-dangerously-skip-permissions')
+    expect(flags.join(' ')).not.toContain(' --dangerously-skip-permissions')
+  })
+
+  it('both flags — dangerouslySkipPermissions wins, allow flag omitted, warning logged', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const flags = buildClaudeArgs({
+      ...BASE,
+      dangerouslySkipPermissions: true,
+      allowDangerouslySkipPermissions: true,
+    })
+    expect(flags).toContain('--dangerously-skip-permissions')
+    expect(flags.join(' ')).not.toContain('--allow-dangerously-skip-permissions')
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn.mock.calls[0][0]).toContain('dangerouslySkipPermissions takes precedence')
+  })
+
+  it('includes --session-id for a non-resume call', () => {
+    const flags = buildClaudeArgs({ ...BASE })
+    expect(flags.some((f) => f.includes('--session-id'))).toBe(true)
+    expect(flags.join(' ')).not.toContain('--resume')
+  })
+
+  it('includes --resume for a resume call', () => {
+    const flags = buildClaudeArgs({ ...BASE, resume: true })
+    expect(flags.some((f) => f.includes('--resume'))).toBe(true)
+    expect(flags.join(' ')).not.toContain('--session-id')
+  })
+
+  it('includes --permission-mode with provided value', () => {
+    const flags = buildClaudeArgs({ ...BASE, permissionMode: 'plan' })
+    expect(flags.some((f) => f.includes('--permission-mode') && f.includes('plan'))).toBe(true)
+  })
+
+  it('defaults --permission-mode to bypassPermissions when omitted', () => {
+    const flags = buildClaudeArgs({ ...BASE })
+    expect(flags.some((f) => f.includes('--permission-mode') && f.includes('bypassPermissions'))).toBe(true)
+  })
+
+  it('includes --mcp-config with the provided path', () => {
+    const flags = buildClaudeArgs({ ...BASE })
+    expect(flags.some((f) => f.includes('--mcp-config') && f.includes('/path/to/mcp.json'))).toBe(true)
+  })
+})

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -21,6 +21,7 @@ type Session = {
   model?: string
   permissionMode?: string
   dangerouslySkipPermissions?: boolean
+  allowDangerouslySkipPermissions?: boolean
   // Primary PTY — runs claude (or whatever command the caller asked for).
   // This is what the MCP tools target.
   term: pty.IPty
@@ -203,6 +204,7 @@ type StartupSession = {
   agent?: string
   model?: string
   dangerouslySkipPermissions?: boolean
+  allowDangerouslySkipPermissions?: boolean
   permissionMode?: string
   name?: string
 }
@@ -220,6 +222,7 @@ type PersistedSession = {
   model?: string
   permissionMode?: string
   dangerouslySkipPermissions?: boolean
+  allowDangerouslySkipPermissions?: boolean
 }
 
 const DEFAULT_CONFIG: Config = {
@@ -272,7 +275,9 @@ function loadPersistedSessions(): PersistedSession[] {
         (s.model === undefined || typeof s.model === 'string') &&
         (s.permissionMode === undefined || typeof s.permissionMode === 'string') &&
         (s.dangerouslySkipPermissions === undefined ||
-          typeof s.dangerouslySkipPermissions === 'boolean'),
+          typeof s.dangerouslySkipPermissions === 'boolean') &&
+        (s.allowDangerouslySkipPermissions === undefined ||
+          typeof s.allowDangerouslySkipPermissions === 'boolean'),
     )
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
@@ -373,6 +378,7 @@ function persistSessions() {
     model: s.model,
     permissionMode: s.permissionMode,
     dangerouslySkipPermissions: s.dangerouslySkipPermissions,
+    allowDangerouslySkipPermissions: s.allowDangerouslySkipPermissions,
   }))
   try {
     fs.mkdirSync(path.dirname(getSessionsPath()), { recursive: true })
@@ -444,41 +450,66 @@ function isClaudeCommand(cmd: string): boolean {
 // want stricter behavior.
 const DEFAULT_PERMISSION_MODE = 'bypassPermissions'
 
+// Pure helper — builds the flag list for a `claude` invocation. Exported for
+// unit testing; contains no side effects.
+export function buildClaudeArgs(opts: {
+  sessionId: string
+  mcpConfigPath: string
+  agent?: string
+  model?: string
+  resume?: boolean
+  dangerouslySkipPermissions?: boolean
+  allowDangerouslySkipPermissions?: boolean
+  permissionMode?: string
+}): string[] {
+  const permissionMode =
+    opts.permissionMode && opts.permissionMode.length > 0
+      ? opts.permissionMode
+      : DEFAULT_PERMISSION_MODE
+
+  const flags: string[] = [`--mcp-config "${opts.mcpConfigPath}"`]
+
+  if (opts.resume) {
+    flags.push(`--resume "${opts.sessionId}"`)
+    if (opts.model && opts.model.length > 0) {
+      flags.push(`--model "${opts.model}"`)
+    }
+  } else {
+    flags.push(`--session-id "${opts.sessionId}"`)
+    if (opts.agent && opts.agent.length > 0) {
+      flags.push(`--agent "${opts.agent}"`)
+    }
+    if (opts.model && opts.model.length > 0) {
+      flags.push(`--model "${opts.model}"`)
+    }
+  }
+
+  if (opts.dangerouslySkipPermissions) {
+    if (opts.allowDangerouslySkipPermissions) {
+      console.warn(
+        '[termhub:session] both dangerouslySkipPermissions and allowDangerouslySkipPermissions set' +
+          ' — dangerouslySkipPermissions takes precedence; ignoring allowDangerouslySkipPermissions',
+      )
+    }
+    flags.push('--dangerously-skip-permissions')
+  } else if (opts.allowDangerouslySkipPermissions) {
+    flags.push('--allow-dangerously-skip-permissions')
+  }
+
+  flags.push(`--permission-mode "${permissionMode}"`)
+  return flags
+}
+
 function buildClaudeCommand(opts: {
   sessionId: string
   agent?: string
   model?: string
   resume?: boolean
   dangerouslySkipPermissions?: boolean
+  allowDangerouslySkipPermissions?: boolean
   permissionMode?: string
 }): string {
-  const flags: string[] = [`--mcp-config "${mcpConfigPath}"`]
-  const permissionMode =
-    opts.permissionMode && opts.permissionMode.length > 0
-      ? opts.permissionMode
-      : DEFAULT_PERMISSION_MODE
-  if (opts.resume) {
-    flags.push(`--resume "${opts.sessionId}"`)
-    if (opts.model && opts.model.length > 0) {
-      flags.push(`--model "${opts.model}"`)
-    }
-    if (opts.dangerouslySkipPermissions) {
-      flags.push('--dangerously-skip-permissions')
-    }
-    flags.push(`--permission-mode "${permissionMode}"`)
-    return `claude ${flags.join(' ')}`
-  }
-  flags.push(`--session-id "${opts.sessionId}"`)
-  if (opts.agent && opts.agent.length > 0) {
-    flags.push(`--agent "${opts.agent}"`)
-  }
-  if (opts.model && opts.model.length > 0) {
-    flags.push(`--model "${opts.model}"`)
-  }
-  if (opts.dangerouslySkipPermissions) {
-    flags.push('--dangerously-skip-permissions')
-  }
-  flags.push(`--permission-mode "${permissionMode}"`)
+  const flags = buildClaudeArgs({ ...opts, mcpConfigPath })
   return `claude ${flags.join(' ')}`
 }
 
@@ -517,6 +548,7 @@ function createSessionInternal(opts: {
   agent?: string
   model?: string
   dangerouslySkipPermissions?: boolean
+  allowDangerouslySkipPermissions?: boolean
   permissionMode?: string
   name?: string
   source: 'ipc' | 'mcp' | 'startup' | 'resume'
@@ -576,6 +608,7 @@ function createSessionInternal(opts: {
     model: opts.model,
     permissionMode: opts.permissionMode,
     dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
+    allowDangerouslySkipPermissions: opts.allowDangerouslySkipPermissions,
     term,
     outputBuffer: '',
     status: 'idle',
@@ -645,6 +678,7 @@ function createSessionInternal(opts: {
         agent: opts.source !== 'resume' ? opts.agent : undefined,
         model: opts.model,
         dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
+        allowDangerouslySkipPermissions: opts.allowDangerouslySkipPermissions,
         permissionMode: opts.permissionMode,
         resume: opts.source === 'resume',
       })
@@ -763,6 +797,7 @@ function bootstrapSessions(config: Config) {
         model: s.model,
         permissionMode: s.permissionMode,
         dangerouslySkipPermissions: s.dangerouslySkipPermissions,
+        allowDangerouslySkipPermissions: s.allowDangerouslySkipPermissions,
         source: 'resume',
       })
       occupiedCwds.add(s.cwd)
@@ -784,6 +819,7 @@ function bootstrapSessions(config: Config) {
         agent: entry.agent,
         model: entry.model,
         dangerouslySkipPermissions: entry.dangerouslySkipPermissions,
+        allowDangerouslySkipPermissions: entry.allowDangerouslySkipPermissions,
         permissionMode: entry.permissionMode,
         name: entry.name,
         source: 'startup',
@@ -812,6 +848,7 @@ app.whenReady().then(async () => {
           agent,
           model,
           dangerouslySkipPermissions,
+          allowDangerouslySkipPermissions,
           permissionMode,
           name,
         }) =>
@@ -822,6 +859,7 @@ app.whenReady().then(async () => {
             agent,
             model,
             dangerouslySkipPermissions,
+            allowDangerouslySkipPermissions,
             permissionMode,
             name,
             source: 'mcp',

--- a/electron/mcp-bridge.ts
+++ b/electron/mcp-bridge.ts
@@ -29,7 +29,9 @@ async function main() {
       description:
         'Spawns a new terminal in termhub running `claude` (an interactive Claude Code session). ' +
         'Use this to delegate work to a sub-agent. Provide an absolute working directory and an ' +
-        'optional initial prompt that the new claude will receive as its first user message.',
+        'optional initial prompt that the new claude will receive as its first user message. ' +
+        'To start in plan mode but allow flipping to bypass later (without restarting), use ' +
+        'permissionMode: "plan" together with allowDangerouslySkipPermissions: true.',
       inputSchema: {
         cwd: z
           .string()
@@ -59,6 +61,17 @@ async function main() {
             'When true, passes --dangerously-skip-permissions to claude, bypassing all per-tool ' +
               'approval prompts. Use only for autonomous workers where you trust the prompt and ' +
               'agent definition; the worker can take any action without confirmation.',
+          ),
+        allowDangerouslySkipPermissions: z
+          .boolean()
+          .optional()
+          .describe(
+            'When true, passes --allow-dangerously-skip-permissions to claude. This adds ' +
+              'bypassPermissions to the shift+tab cycle without activating it immediately, so ' +
+              'the user or operator can flip into bypass mode mid-session without restarting. ' +
+              'Useful when starting in plan mode but wanting the option to escalate later. ' +
+              'Independent of dangerouslySkipPermissions; if both are true, ' +
+              'dangerouslySkipPermissions takes precedence.',
           ),
         permissionMode: z
           .enum([
@@ -95,6 +108,7 @@ async function main() {
             agent: args.agent,
             model: args.model,
             dangerouslySkipPermissions: args.dangerouslySkipPermissions,
+            allowDangerouslySkipPermissions: args.allowDangerouslySkipPermissions,
             permissionMode: args.permissionMode,
             name: args.name,
           }),

--- a/electron/mcp.ts
+++ b/electron/mcp.ts
@@ -14,6 +14,7 @@ export type McpHooks = {
     agent?: string
     model?: string
     dangerouslySkipPermissions?: boolean
+    allowDangerouslySkipPermissions?: boolean
     permissionMode?: string
     name?: string
   }) => OpenSessionResult
@@ -71,6 +72,7 @@ export async function startMcpServer(opts: {
         agent?: unknown
         model?: unknown
         dangerouslySkipPermissions?: unknown
+        allowDangerouslySkipPermissions?: unknown
         permissionMode?: unknown
         name?: unknown
       }
@@ -91,6 +93,10 @@ export async function startMcpServer(opts: {
         typeof parsed.dangerouslySkipPermissions === 'boolean'
           ? parsed.dangerouslySkipPermissions
           : undefined
+      const allowDangerouslySkipPermissions =
+        typeof parsed.allowDangerouslySkipPermissions === 'boolean'
+          ? parsed.allowDangerouslySkipPermissions
+          : undefined
       const permissionMode =
         typeof parsed.permissionMode === 'string' ? parsed.permissionMode : undefined
       const name = typeof parsed.name === 'string' ? parsed.name : undefined
@@ -101,6 +107,7 @@ export async function startMcpServer(opts: {
           agent,
           model,
           dangerouslySkipPermissions,
+          allowDangerouslySkipPermissions,
           permissionMode,
           name,
         })

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export type Config = {
     agent?: string
     model?: string
     dangerouslySkipPermissions?: boolean
+    allowDangerouslySkipPermissions?: boolean
     permissionMode?: string
     name?: string
   }>


### PR DESCRIPTION
## Summary

Adds `allowDangerouslySkipPermissions` to the `open_session` MCP tool. When set, termhub passes `--allow-dangerously-skip-permissions` to the spawned `claude` process, which adds `bypassPermissions` to the shift+tab cycle without activating it immediately. This lets you start a session in plan mode and flip to bypass mid-flight without restarting.

Previously there was no way to spawn a session in `plan` mode while still allowing the user or operator to escalate to bypass later in the same session.

## Changes

- `electron/mcp.ts` — added `allowDangerouslySkipPermissions?: boolean` to the `McpHooks.openClaudeSession` request type and HTTP handler
- `electron/mcp-bridge.ts` — added the field to the `open_session` zod input schema with a description; updated the tool description to explain the plan+allow pattern
- `electron/main.ts` — extracted a pure `buildClaudeArgs()` helper (exported for testing); appends `--allow-dangerously-skip-permissions` when the flag is set and `dangerouslySkipPermissions` is not; logs a warning when both are true and `dangerouslySkipPermissions` wins
- `src/types.ts` — added `allowDangerouslySkipPermissions?: boolean` to `Config.startupSessions`
- `electron/main.test.ts` — new Vitest tests covering all four flag combinations and key argv-construction invariants

## Test plan

- [ ] `npm test` — 9 tests pass covering: neither flag, only `dangerouslySkipPermissions`, only `allowDangerouslySkipPermissions`, both flags (warning logged + stronger flag wins), resume/non-resume session id flag, permission-mode default, mcp-config inclusion
- [ ] `npm run typecheck` — no errors