### PR TITLE
refactor: use Claude Code JSONL status field for session state

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -7,10 +7,7 @@ import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { startMcpServer, type McpHandle } from './mcp'
 import { isAllowedExternalUrl } from './links'
-
-// Advisory status derived from the session's output stream. Mirrors the
-// SessionStatus union exposed to the renderer in src/types.ts.
-type SessionStatus = 'working' | 'awaiting' | 'idle' | 'failed'
+import { watchSessionStatus, type WatcherHandle, type SessionStatus } from './status-watcher'
 
 type Session = {
   id: string
@@ -28,12 +25,9 @@ type Session = {
   term: pty.IPty
   outputBuffer: string
   status: SessionStatus
-  // ms timestamp of the last chunk that contained an "active spinner"
-  // marker (e.g. "esc to interrupt"). Used to keep the working status
-  // sticky for a short window after the marker last appeared so we don't
-  // flap to idle between spinner ticks.
-  lastSpinnerSeen: number
-  statusReevalTimer: NodeJS.Timeout | null
+  // Watcher for the Claude Code JSONL file that provides ground-truth status.
+  // Null when no JSONL file has been located yet (session just started).
+  jsonlWatcher: WatcherHandle | null
   // Secondary "shell" PTY — a plain interactive shell rooted at `cwd`,
   // docked at the bottom of the UI for the user's own manual work. Not
   // exposed via MCP, not persisted. Lifetime is bound to the session.
@@ -62,73 +56,13 @@ function stripAnsi(s: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Status detection
+// Status management
 // ---------------------------------------------------------------------------
-// Pragmatic heuristics over the output stream — advisory UI decoration only,
-// not load-bearing logic. Cheap to evaluate; correct ≥ 90% of the time.
-//
-//   working  — claude is generating / running tools. Detected by the
-//              "esc to interrupt" hint that claude prints under the spinner
-//              on every redraw tick. Sticky for ~1.5s after the last hit so
-//              we don't flap between spinner ticks.
-//   awaiting — claude has stopped and is asking something. Detected by a
-//              permission-prompt phrase ("Do you want") or a numbered choice
-//              with the focused-arrow marker ("❯ 1.") in the buffer tail.
-//   idle     — none of the above. Empty input box / waiting for user.
-//   failed   — set on non-zero PTY exit, never derived from output.
-const SPINNER_RE = /esc to interrupt/i
-const PERMISSION_RE = /Do you want/i
-const NUMBERED_CHOICE_RE = /❯\s*\d+\.\s/
-// How long to keep status='working' after the last spinner hit. Slightly
-// longer than claude's spinner tick (~80ms) plus a buffer for sparse
-// redraws. 1500ms is comfortably above worst-case observed spacing.
-const SPINNER_HOLD_MS = 1500
-// Tail size to scan for awaiting prompts. Big enough to capture a
-// multi-line permission prompt (the question + a few numbered options),
-// small enough to keep regex work cheap on every chunk.
-const STATUS_TAIL_BYTES = 6000
-
-function detectStatusFromBuffer(
-  buffer: string,
-  lastSpinnerSeen: number,
-): SessionStatus {
-  if (Date.now() - lastSpinnerSeen < SPINNER_HOLD_MS) return 'working'
-  const tail =
-    buffer.length > STATUS_TAIL_BYTES
-      ? buffer.slice(buffer.length - STATUS_TAIL_BYTES)
-      : buffer
-  const stripped = stripAnsi(tail)
-  if (PERMISSION_RE.test(stripped) || NUMBERED_CHOICE_RE.test(stripped)) {
-    return 'awaiting'
-  }
-  return 'idle'
-}
 
 function setStatus(session: Session, next: SessionStatus) {
   if (session.status === next) return
   session.status = next
   mainWindow?.webContents.send('session:status', { id: session.id, status: next })
-}
-
-function recomputeStatus(session: Session) {
-  // Once 'failed' is set (PTY exited non-zero) we lock the status — the
-  // session is a corpse, no further detection is meaningful.
-  if (session.status === 'failed') return
-  const next = detectStatusFromBuffer(session.outputBuffer, session.lastSpinnerSeen)
-  setStatus(session, next)
-  if (session.statusReevalTimer) {
-    clearTimeout(session.statusReevalTimer)
-    session.statusReevalTimer = null
-  }
-  // While we believe claude is working, schedule a follow-up recompute so
-  // we transition off 'working' even if no further data arrives (e.g. the
-  // spinner is cleared by a final redraw and then output goes quiet).
-  if (next === 'working') {
-    session.statusReevalTimer = setTimeout(() => {
-      session.statusReevalTimer = null
-      recomputeStatus(session)
-    }, SPINNER_HOLD_MS + 100)
-  }
 }
 
 // Walk upward from cwd looking for a .git entry (file or directory).
@@ -612,13 +546,26 @@ function createSessionInternal(opts: {
     allowDangerouslySkipPermissions: opts.allowDangerouslySkipPermissions,
     term,
     outputBuffer: '',
-    status: 'idle',
-    lastSpinnerSeen: 0,
-    statusReevalTimer: null,
+    // Start as 'working' — JSONL file may not exist yet (Claude Code creates
+    // it after the session initialises). We assume busy until JSONL says otherwise.
+    status: 'working',
+    jsonlWatcher: null,
     shellTerm,
   }
   sessions.set(id, session)
   persistSessions()
+
+  // Watch the Claude Code JSONL file for ground-truth status updates. The
+  // file is created by Claude Code shortly after startup; the watcher polls
+  // and will begin emitting once the file appears.
+  if (opts.command && isClaudeCommand(opts.command)) {
+    session.jsonlWatcher = watchSessionStatus(opts.cwd, id, (next) => {
+      // 'failed' is only set on PTY exit — never override it from JSONL.
+      if (session.status !== 'failed') {
+        setStatus(session, next)
+      }
+    })
+  }
 
   let firstData = true
   term.onData((data) => {
@@ -627,19 +574,15 @@ function createSessionInternal(opts: {
       console.log(`[termhub] first data from ${id.slice(0, 8)} (${data.length} bytes)`)
     }
     session.outputBuffer = appendToBuffer(session.outputBuffer, data)
-    // Cheap test on the raw chunk — the spinner phrase is plain ASCII and
-    // isn't broken up by ANSI codes mid-substring, so we don't need to
-    // strip first.
-    if (SPINNER_RE.test(data)) session.lastSpinnerSeen = Date.now()
-    recomputeStatus(session)
     mainWindow?.webContents.send('session:data', { id, data })
   })
 
   term.onExit(({ exitCode }) => {
     console.log(`[termhub] session ${id.slice(0, 8)} exited (code=${exitCode})`)
-    if (session.statusReevalTimer) {
-      clearTimeout(session.statusReevalTimer)
-      session.statusReevalTimer = null
+    // Stop the JSONL watcher — no more status updates after exit.
+    if (session.jsonlWatcher) {
+      session.jsonlWatcher.stop()
+      session.jsonlWatcher = null
     }
     // Emit the terminal status BEFORE the exit event so the renderer has
     // it set when it decides whether to keep the row visible.
@@ -937,6 +880,10 @@ app.whenReady().then(async () => {
   ipcMain.on('session:close', (_event, payload: { id: string }) => {
     const s = sessions.get(payload.id)
     if (!s) return
+    if (s.jsonlWatcher) {
+      s.jsonlWatcher.stop()
+      s.jsonlWatcher = null
+    }
     try {
       s.term.kill()
     } catch {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -9,6 +9,14 @@ import { startMcpServer, type McpHandle } from './mcp'
 import { isAllowedExternalUrl } from './links'
 import { watchSessionStatus, type WatcherHandle, type SessionStatus } from './status-watcher'
 
+// Isolate dev builds so their sessions, config, and MCP port don't bleed into
+// the production instance running alongside. Must be called before the first
+// app.getPath('userData') use (which happens inside app.whenReady callbacks).
+if (!app.isPackaged) {
+  app.setPath('userData', path.join(app.getPath('userData'), '..', 'termhub-dev'))
+  console.log('[termhub] dev mode — userData:', app.getPath('userData'))
+}
+
 type Session = {
   id: string
   cwd: string
@@ -161,7 +169,9 @@ type PersistedSession = {
 }
 
 const DEFAULT_CONFIG: Config = {
-  mcpPort: 7787,
+  // Dev builds get port 7788 so they don't conflict with the production
+  // instance on 7787 when both are running at the same time.
+  mcpPort: app.isPackaged ? 7787 : 7788,
   // bypassPermissions skips per-tool approval prompts AND avoids the
   // sandbox preflight that "auto" mode triggers — without an override the
   // orchestrator session refuses to start when ~/.claude/settings.json

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -559,7 +559,7 @@ function createSessionInternal(opts: {
   // file is created by Claude Code shortly after startup; the watcher polls
   // and will begin emitting once the file appears.
   if (opts.command && isClaudeCommand(opts.command)) {
-    session.jsonlWatcher = watchSessionStatus(opts.cwd, id, (next) => {
+    session.jsonlWatcher = watchSessionStatus(opts.cwd, (next) => {
       // 'failed' is only set on PTY exit — never override it from JSONL.
       if (session.status !== 'failed') {
         setStatus(session, next)

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -559,7 +559,7 @@ function createSessionInternal(opts: {
   // file is created by Claude Code shortly after startup; the watcher polls
   // and will begin emitting once the file appears.
   if (opts.command && isClaudeCommand(opts.command)) {
-    session.jsonlWatcher = watchSessionStatus(opts.cwd, (next) => {
+    session.jsonlWatcher = watchSessionStatus(id, (next) => {
       // 'failed' is only set on PTY exit — never override it from JSONL.
       if (session.status !== 'failed') {
         setStatus(session, next)

--- a/electron/status-watcher.test.ts
+++ b/electron/status-watcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { mapJsonlStatus, parseSessionStatus } from './status-watcher'
+import { mapJsonlStatus, parseSessionStatus, encodeProjectPath } from './status-watcher'
 
 describe('mapJsonlStatus', () => {
   it('maps idle to idle', () => {
@@ -47,7 +47,7 @@ describe('parseSessionStatus', () => {
     expect(parseSessionStatus(JSON.stringify({ status: '' }))).toBeUndefined()
   })
 
-  it('returns status from a valid session record', () => {
+  it('returns status from a real-world session record', () => {
     const content = JSON.stringify({
       pid: 28236,
       sessionId: '70ebba48-4fe8-4bc4-92e1-c975ab5ed2e6',
@@ -66,5 +66,30 @@ describe('parseSessionStatus', () => {
 
   it('returns busy status', () => {
     expect(parseSessionStatus(JSON.stringify({ status: 'busy' }))).toBe('busy')
+  })
+})
+
+describe('encodeProjectPath', () => {
+  it('encodes a Windows absolute path', () => {
+    // Each \, :, / becomes a dash: "E:\Apps\termhub" → "E--Apps-termhub"
+    expect(encodeProjectPath('E:\\Apps\\termhub')).toBe('E--Apps-termhub')
+  })
+
+  it('encodes forward-slash paths the same way', () => {
+    expect(encodeProjectPath('E:/Apps/termhub')).toBe('E--Apps-termhub')
+  })
+
+  it('handles a drive root', () => {
+    expect(encodeProjectPath('D:\\')).toBe('D--')
+  })
+
+  it('matches the real directory name for the D:\\ cwd', () => {
+    // The projects directory for D:\ is ~/.claude/projects/D--/
+    expect(encodeProjectPath('D:\\')).toBe('D--')
+  })
+
+  it('encodes worktree paths correctly', () => {
+    const input = 'E:\\Apps\\termhub\\.claude\\worktrees\\jsonl-session-status'
+    expect(encodeProjectPath(input)).toBe('E--Apps-termhub--claude-worktrees-jsonl-session-status')
   })
 })

--- a/electron/status-watcher.test.ts
+++ b/electron/status-watcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { mapJsonlStatus, parseSessionStatus, encodeProjectPath } from './status-watcher'
+import { mapJsonlStatus, parseSessionStatus } from './status-watcher'
 
 describe('mapJsonlStatus', () => {
   it('maps idle to idle', () => {
@@ -66,30 +66,5 @@ describe('parseSessionStatus', () => {
 
   it('returns busy status', () => {
     expect(parseSessionStatus(JSON.stringify({ status: 'busy' }))).toBe('busy')
-  })
-})
-
-describe('encodeProjectPath', () => {
-  it('encodes a Windows absolute path', () => {
-    // Each \, :, / becomes a dash: "E:\Apps\termhub" → "E--Apps-termhub"
-    expect(encodeProjectPath('E:\\Apps\\termhub')).toBe('E--Apps-termhub')
-  })
-
-  it('encodes forward-slash paths the same way', () => {
-    expect(encodeProjectPath('E:/Apps/termhub')).toBe('E--Apps-termhub')
-  })
-
-  it('handles a drive root', () => {
-    expect(encodeProjectPath('D:\\')).toBe('D--')
-  })
-
-  it('matches the real directory name for the D:\\ cwd', () => {
-    // The projects directory for D:\ is ~/.claude/projects/D--/
-    expect(encodeProjectPath('D:\\')).toBe('D--')
-  })
-
-  it('encodes worktree paths correctly', () => {
-    const input = 'E:\\Apps\\termhub\\.claude\\worktrees\\jsonl-session-status'
-    expect(encodeProjectPath(input)).toBe('E--Apps-termhub--claude-worktrees-jsonl-session-status')
   })
 })

--- a/electron/status-watcher.test.ts
+++ b/electron/status-watcher.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { mapJsonlStatus, parseLatestStatus, encodeProjectPath } from './status-watcher'
+
+describe('mapJsonlStatus', () => {
+  it('maps idle to idle', () => {
+    expect(mapJsonlStatus('idle')).toBe('idle')
+  })
+
+  it('maps busy to working', () => {
+    expect(mapJsonlStatus('busy')).toBe('working')
+  })
+
+  it('maps waiting to awaiting', () => {
+    expect(mapJsonlStatus('waiting')).toBe('awaiting')
+  })
+
+  it('falls back to working for unknown values', () => {
+    expect(mapJsonlStatus('unknown')).toBe('working')
+    expect(mapJsonlStatus('')).toBe('working')
+    expect(mapJsonlStatus('IDLE')).toBe('working')
+    expect(mapJsonlStatus('active')).toBe('working')
+  })
+})
+
+describe('parseLatestStatus', () => {
+  it('returns undefined for empty chunk', () => {
+    expect(parseLatestStatus('')).toBeUndefined()
+  })
+
+  it('returns undefined when no status field present', () => {
+    const chunk = JSON.stringify({ type: 'user', message: 'hello' }) + '\n'
+    expect(parseLatestStatus(chunk)).toBeUndefined()
+  })
+
+  it('returns status from a single record', () => {
+    const line = JSON.stringify({ type: 'system', status: 'idle' })
+    expect(parseLatestStatus(line)).toBe('idle')
+  })
+
+  it('returns the last status when multiple records have status', () => {
+    const chunk = [
+      JSON.stringify({ type: 'system', status: 'busy' }),
+      JSON.stringify({ type: 'system', status: 'idle' }),
+    ].join('\n')
+    expect(parseLatestStatus(chunk)).toBe('idle')
+  })
+
+  it('skips records without a status field', () => {
+    const chunk = [
+      JSON.stringify({ type: 'user', message: 'hi' }),
+      JSON.stringify({ type: 'system', status: 'waiting' }),
+      JSON.stringify({ type: 'assistant', message: 'response' }),
+    ].join('\n')
+    expect(parseLatestStatus(chunk)).toBe('waiting')
+  })
+
+  it('ignores malformed JSON lines', () => {
+    const chunk = [
+      'this is not json',
+      JSON.stringify({ type: 'system', status: 'busy' }),
+      '{ broken',
+    ].join('\n')
+    expect(parseLatestStatus(chunk)).toBe('busy')
+  })
+
+  it('ignores empty lines', () => {
+    const chunk = '\n\n' + JSON.stringify({ status: 'idle' }) + '\n\n'
+    expect(parseLatestStatus(chunk)).toBe('idle')
+  })
+
+  it('ignores records where status is not a string', () => {
+    const chunk = JSON.stringify({ status: 42 }) + '\n' + JSON.stringify({ status: 'busy' })
+    expect(parseLatestStatus(chunk)).toBe('busy')
+  })
+})
+
+describe('encodeProjectPath', () => {
+  it('encodes a Windows absolute path', () => {
+    // e.g. "E:\Apps\termhub" → "E--Apps-termhub"
+    expect(encodeProjectPath('E:\\Apps\\termhub')).toBe('E--Apps-termhub')
+  })
+
+  it('encodes a forward-slash path', () => {
+    expect(encodeProjectPath('E:/Apps/termhub')).toBe('E--Apps-termhub')
+  })
+
+  it('handles a simple drive root', () => {
+    // E:\ → each special char becomes a dash → 'E--', no trailing strip
+    expect(encodeProjectPath('E:\\')).toBe('E--')
+  })
+
+  it('encodes worktree paths correctly', () => {
+    const input = 'E:\\Apps\\termhub\\.claude\\worktrees\\jsonl-session-status'
+    const result = encodeProjectPath(input)
+    expect(result).toBe('E--Apps-termhub--claude-worktrees-jsonl-session-status')
+  })
+})

--- a/electron/status-watcher.test.ts
+++ b/electron/status-watcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { mapJsonlStatus, parseLatestStatus, encodeProjectPath } from './status-watcher'
+import { mapJsonlStatus, parseSessionStatus } from './status-watcher'
 
 describe('mapJsonlStatus', () => {
   it('maps idle to idle', () => {
@@ -22,76 +22,49 @@ describe('mapJsonlStatus', () => {
   })
 })
 
-describe('parseLatestStatus', () => {
-  it('returns undefined for empty chunk', () => {
-    expect(parseLatestStatus('')).toBeUndefined()
+describe('parseSessionStatus', () => {
+  it('returns undefined for empty string', () => {
+    expect(parseSessionStatus('')).toBeUndefined()
+  })
+
+  it('returns undefined for malformed JSON', () => {
+    expect(parseSessionStatus('{ broken')).toBeUndefined()
+    expect(parseSessionStatus('not json at all')).toBeUndefined()
   })
 
   it('returns undefined when no status field present', () => {
-    const chunk = JSON.stringify({ type: 'user', message: 'hello' }) + '\n'
-    expect(parseLatestStatus(chunk)).toBeUndefined()
+    const content = JSON.stringify({ pid: 12345, cwd: 'D:\\', startedAt: 1234 })
+    expect(parseSessionStatus(content)).toBeUndefined()
   })
 
-  it('returns status from a single record', () => {
-    const line = JSON.stringify({ type: 'system', status: 'idle' })
-    expect(parseLatestStatus(line)).toBe('idle')
+  it('returns undefined when status is not a string', () => {
+    expect(parseSessionStatus(JSON.stringify({ status: 42 }))).toBeUndefined()
+    expect(parseSessionStatus(JSON.stringify({ status: null }))).toBeUndefined()
+    expect(parseSessionStatus(JSON.stringify({ status: true }))).toBeUndefined()
   })
 
-  it('returns the last status when multiple records have status', () => {
-    const chunk = [
-      JSON.stringify({ type: 'system', status: 'busy' }),
-      JSON.stringify({ type: 'system', status: 'idle' }),
-    ].join('\n')
-    expect(parseLatestStatus(chunk)).toBe('idle')
+  it('returns undefined when status is an empty string', () => {
+    expect(parseSessionStatus(JSON.stringify({ status: '' }))).toBeUndefined()
   })
 
-  it('skips records without a status field', () => {
-    const chunk = [
-      JSON.stringify({ type: 'user', message: 'hi' }),
-      JSON.stringify({ type: 'system', status: 'waiting' }),
-      JSON.stringify({ type: 'assistant', message: 'response' }),
-    ].join('\n')
-    expect(parseLatestStatus(chunk)).toBe('waiting')
+  it('returns status from a valid session record', () => {
+    const content = JSON.stringify({
+      pid: 28236,
+      sessionId: '70ebba48-4fe8-4bc4-92e1-c975ab5ed2e6',
+      cwd: 'D:\\',
+      startedAt: 1777131167148,
+      status: 'waiting',
+      updatedAt: 1777131286192,
+      waitingFor: 'approve Bash',
+    })
+    expect(parseSessionStatus(content)).toBe('waiting')
   })
 
-  it('ignores malformed JSON lines', () => {
-    const chunk = [
-      'this is not json',
-      JSON.stringify({ type: 'system', status: 'busy' }),
-      '{ broken',
-    ].join('\n')
-    expect(parseLatestStatus(chunk)).toBe('busy')
+  it('returns idle status', () => {
+    expect(parseSessionStatus(JSON.stringify({ status: 'idle' }))).toBe('idle')
   })
 
-  it('ignores empty lines', () => {
-    const chunk = '\n\n' + JSON.stringify({ status: 'idle' }) + '\n\n'
-    expect(parseLatestStatus(chunk)).toBe('idle')
-  })
-
-  it('ignores records where status is not a string', () => {
-    const chunk = JSON.stringify({ status: 42 }) + '\n' + JSON.stringify({ status: 'busy' })
-    expect(parseLatestStatus(chunk)).toBe('busy')
-  })
-})
-
-describe('encodeProjectPath', () => {
-  it('encodes a Windows absolute path', () => {
-    // e.g. "E:\Apps\termhub" → "E--Apps-termhub"
-    expect(encodeProjectPath('E:\\Apps\\termhub')).toBe('E--Apps-termhub')
-  })
-
-  it('encodes a forward-slash path', () => {
-    expect(encodeProjectPath('E:/Apps/termhub')).toBe('E--Apps-termhub')
-  })
-
-  it('handles a simple drive root', () => {
-    // E:\ → each special char becomes a dash → 'E--', no trailing strip
-    expect(encodeProjectPath('E:\\')).toBe('E--')
-  })
-
-  it('encodes worktree paths correctly', () => {
-    const input = 'E:\\Apps\\termhub\\.claude\\worktrees\\jsonl-session-status'
-    const result = encodeProjectPath(input)
-    expect(result).toBe('E--Apps-termhub--claude-worktrees-jsonl-session-status')
+  it('returns busy status', () => {
+    expect(parseSessionStatus(JSON.stringify({ status: 'busy' }))).toBe('busy')
   })
 })

--- a/electron/status-watcher.ts
+++ b/electron/status-watcher.ts
@@ -5,11 +5,11 @@ import * as os from 'node:os'
 // Advisory status type mirroring src/types.ts SessionStatus.
 export type SessionStatus = 'working' | 'awaiting' | 'idle' | 'failed'
 
-// Map Claude Code's JSONL `status` field values to termhub's SessionStatus.
+// Map Claude Code's session `status` field values to termhub's SessionStatus.
 // Values from Claude Code:
 //   idle    → session at the input prompt, ready for user
 //   busy    → Claude is generating / running tools
-//   waiting → Claude has paused to ask the user something
+//   waiting → Claude has paused to ask the user something (permission prompt etc.)
 // Unknown/missing values fall back to 'working' (optimistic — assume busy
 // rather than showing a misleading idle state).
 export function mapJsonlStatus(raw: string): SessionStatus {
@@ -21,116 +21,104 @@ export function mapJsonlStatus(raw: string): SessionStatus {
   }
 }
 
-// Pull the latest `status` value from a JSONL chunk (may contain multiple
-// lines). Returns undefined if no `status` field is found in any record.
-export function parseLatestStatus(chunk: string): string | undefined {
-  const lines = chunk.split('\n')
-  let latest: string | undefined
-  for (const line of lines) {
-    const trimmed = line.trim()
-    if (!trimmed) continue
-    try {
-      const rec = JSON.parse(trimmed) as Record<string, unknown>
-      if (typeof rec.status === 'string' && rec.status.length > 0) {
-        latest = rec.status
-      }
-    } catch {
-      // Malformed JSON line — skip
-    }
-  }
-  return latest
-}
-
-// Encode a filesystem path the same way Claude Code does when building the
-// ~/.claude/projects/<encoded-cwd>/ directory name. Each character that is
-// a path separator (\, /), colon (:), or dot (.) is replaced with a dash.
-// Consecutive dashes are NOT collapsed — "E:\Apps" → "E--Apps" because the
-// colon and backslash each independently become a dash.
-export function encodeProjectPath(cwdArg: string): string {
-  return cwdArg.replace(/[\\/:\.]/g, '-')
-}
-
-// Locate the JSONL file for a session by searching
-// ~/.claude/projects/<encoded-cwd>/<session-id>.jsonl.
-// Returns the path if the file exists, or null if it can't be found.
-export function resolveJsonlPath(cwd: string, sessionId: string): string | null {
-  const encoded = encodeProjectPath(cwd)
-  const candidate = path.join(
-    os.homedir(),
-    '.claude',
-    'projects',
-    encoded,
-    `${sessionId}.jsonl`,
-  )
+// Parse the `status` field from a Claude Code session file.
+// The file is a single JSON object written/overwritten in-place by Claude Code
+// at ~/.claude/sessions/<pid>.json. Returns undefined if the content is
+// unparseable or has no status field.
+export function parseSessionStatus(content: string): string | undefined {
   try {
-    fs.accessSync(candidate, fs.constants.R_OK)
-    return candidate
+    const rec = JSON.parse(content) as Record<string, unknown>
+    if (typeof rec.status === 'string' && rec.status.length > 0) return rec.status
+  } catch {
+    // malformed JSON — ignore
+  }
+  return undefined
+}
+
+const SESSIONS_DIR = path.join(os.homedir(), '.claude', 'sessions')
+
+// Scan ~/.claude/sessions/ for a .json file whose `cwd` matches the given cwd
+// and whose `startedAt` is within the expected window around spawnedAt.
+// Returns the full file path, or null if no match is found.
+export function findSessionFile(cwd: string, spawnedAt: number): string | null {
+  let files: string[]
+  try {
+    files = fs.readdirSync(SESSIONS_DIR).filter(f => f.endsWith('.json'))
   } catch {
     return null
   }
+
+  // Normalise + lowercase for case-insensitive Windows path comparison.
+  const normCwd = path.normalize(cwd).toLowerCase()
+
+  // Allow the session file to have been created up to 5 min before our spawn
+  // (clock skew / race) or any time after.
+  const LOOKBACK_MS = 5 * 60 * 1000
+
+  let best: { filePath: string; startedAt: number } | null = null
+
+  for (const file of files) {
+    const filePath = path.join(SESSIONS_DIR, file)
+    try {
+      const content = fs.readFileSync(filePath, 'utf8')
+      const rec = JSON.parse(content) as Record<string, unknown>
+      if (typeof rec.cwd !== 'string') continue
+      if (path.normalize(rec.cwd).toLowerCase() !== normCwd) continue
+      if (typeof rec.startedAt !== 'number') continue
+      if (rec.startedAt < spawnedAt - LOOKBACK_MS) continue
+      if (!best || rec.startedAt > best.startedAt) {
+        best = { filePath, startedAt: rec.startedAt }
+      }
+    } catch {
+      // unparseable or gone — skip
+    }
+  }
+
+  return best?.filePath ?? null
 }
 
 export type WatcherHandle = {
   stop: () => void
 }
 
-// Watch a Claude Code JSONL file for status changes. Polls via
-// fs.watchFile (more reliable than fs.watch on Windows). On each file
-// change, reads new bytes from the last known offset, parses any `status`
-// records, maps the value, and calls onStatus if it changed.
+// Watch the status of a Claude Code session by polling ~/.claude/sessions/
+// for a JSON file matching the session's cwd.
 //
-// The file may not exist yet when this is called (Claude Code creates it
-// shortly after the session starts). The watcher will begin emitting once
-// the file appears.
+// Claude Code writes ~/.claude/sessions/<pid>.json — a single JSON object
+// rewritten in-place on every status change. The file is named by Claude's
+// own PID (not termhub's session ID), so we discover it by cwd match.
 //
-// If the file shrinks (truncated / session reset), the offset is reset to 0
-// so the whole file is re-read.
+// Before the file appears (Claude Code creates it shortly after startup),
+// status stays at 'working' — we optimistically assume busy until the file
+// says otherwise.
 //
 // Returns a handle with a stop() method to tear down the watcher.
-export function watchJsonlStatus(
-  jsonlPath: string,
+export function watchSessionStatus(
+  cwd: string,
   onStatus: (status: SessionStatus) => void,
 ): WatcherHandle {
-  let offset = 0
+  const spawnedAt = Date.now()
+  let stopped = false
+  let watchedPath: string | null = null
   let lastEmitted: SessionStatus | undefined
 
-  function readNewChunk() {
-    let stat: fs.Stats
-    try {
-      stat = fs.statSync(jsonlPath)
-    } catch (err) {
-      // File gone or not yet created — ignore until next poll tick
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-        console.error('[termhub:status] unexpected stat error on', jsonlPath, err)
+  function poll() {
+    if (stopped) return
+
+    // Discover the session file if we haven't yet.
+    if (!watchedPath) {
+      watchedPath = findSessionFile(cwd, spawnedAt)
+      if (watchedPath) {
+        console.log('[termhub:status] found session file for', path.basename(cwd), 'at', watchedPath)
       }
-      return
     }
 
-    // File truncated / session resumed — reset offset to read from the top
-    if (stat.size < offset) {
-      console.log('[termhub:status] JSONL file truncated, resetting offset:', path.basename(jsonlPath))
-      offset = 0
-    }
+    if (!watchedPath) return
 
-    if (stat.size === offset) {
-      return // nothing new
-    }
-
-    let fd: number
+    // Read the current status from the file (whole file — it's a single JSON object).
     try {
-      fd = fs.openSync(jsonlPath, 'r')
-    } catch (err) {
-      console.error('[termhub:status] failed to open JSONL file', jsonlPath, err)
-      return
-    }
-
-    try {
-      const newBytes = stat.size - offset
-      const buf = Buffer.alloc(newBytes)
-      const bytesRead = fs.readSync(fd, buf, 0, newBytes, offset)
-      offset += bytesRead
-      const chunk = buf.slice(0, bytesRead).toString('utf8')
-      const raw = parseLatestStatus(chunk)
+      const content = fs.readFileSync(watchedPath, 'utf8')
+      const raw = parseSessionStatus(content)
       if (raw === undefined) return
       const next = mapJsonlStatus(raw)
       if (next !== lastEmitted) {
@@ -138,52 +126,23 @@ export function watchJsonlStatus(
         onStatus(next)
       }
     } catch (err) {
-      console.error('[termhub:status] failed to read JSONL file', jsonlPath, err)
-    } finally {
-      try {
-        fs.closeSync(fd)
-      } catch {
-        // ignore
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        console.error('[termhub:status] failed to read session file', watchedPath, err)
       }
+      // File gone — reset so we re-scan next tick
+      watchedPath = null
     }
   }
 
-  // Poll every 500 ms. fs.watchFile is available everywhere and avoids the
-  // unreliable fs.watch kernel events on Windows networked / NTFS paths.
-  fs.watchFile(jsonlPath, { interval: 500, persistent: false }, readNewChunk)
-
-  // Also do an immediate read in case the file already has content.
-  readNewChunk()
+  // Poll every 500 ms. setInterval + readFileSync is straightforward and avoids
+  // the unreliable fs.watch kernel events on Windows NTFS paths.
+  const timer = setInterval(poll, 500)
+  poll() // immediate first read
 
   return {
     stop() {
-      fs.unwatchFile(jsonlPath)
+      stopped = true
+      clearInterval(timer)
     },
   }
-}
-
-// Start watching the JSONL file for a session, discovering the path from
-// the session's cwd and id. The path search is repeated on each poll tick
-// until the file is found, so callers don't need to wait for it to appear.
-//
-// When the file doesn't exist yet, status stays at 'working' (the session
-// just started — we optimistically assume Claude is busy until JSONL says
-// otherwise).
-export function watchSessionStatus(
-  cwd: string,
-  sessionId: string,
-  onStatus: (status: SessionStatus) => void,
-): WatcherHandle {
-  const encoded = encodeProjectPath(cwd)
-  const jsonlPath = path.join(
-    os.homedir(),
-    '.claude',
-    'projects',
-    encoded,
-    `${sessionId}.jsonl`,
-  )
-
-  console.log('[termhub:status] watching JSONL for session', sessionId.slice(0, 8), 'at', jsonlPath)
-
-  return watchJsonlStatus(jsonlPath, onStatus)
 }

--- a/electron/status-watcher.ts
+++ b/electron/status-watcher.ts
@@ -1,0 +1,189 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+
+// Advisory status type mirroring src/types.ts SessionStatus.
+export type SessionStatus = 'working' | 'awaiting' | 'idle' | 'failed'
+
+// Map Claude Code's JSONL `status` field values to termhub's SessionStatus.
+// Values from Claude Code:
+//   idle    → session at the input prompt, ready for user
+//   busy    → Claude is generating / running tools
+//   waiting → Claude has paused to ask the user something
+// Unknown/missing values fall back to 'working' (optimistic — assume busy
+// rather than showing a misleading idle state).
+export function mapJsonlStatus(raw: string): SessionStatus {
+  switch (raw) {
+    case 'idle': return 'idle'
+    case 'busy': return 'working'
+    case 'waiting': return 'awaiting'
+    default: return 'working'
+  }
+}
+
+// Pull the latest `status` value from a JSONL chunk (may contain multiple
+// lines). Returns undefined if no `status` field is found in any record.
+export function parseLatestStatus(chunk: string): string | undefined {
+  const lines = chunk.split('\n')
+  let latest: string | undefined
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    try {
+      const rec = JSON.parse(trimmed) as Record<string, unknown>
+      if (typeof rec.status === 'string' && rec.status.length > 0) {
+        latest = rec.status
+      }
+    } catch {
+      // Malformed JSON line — skip
+    }
+  }
+  return latest
+}
+
+// Encode a filesystem path the same way Claude Code does when building the
+// ~/.claude/projects/<encoded-cwd>/ directory name. Each character that is
+// a path separator (\, /), colon (:), or dot (.) is replaced with a dash.
+// Consecutive dashes are NOT collapsed — "E:\Apps" → "E--Apps" because the
+// colon and backslash each independently become a dash.
+export function encodeProjectPath(cwdArg: string): string {
+  return cwdArg.replace(/[\\/:\.]/g, '-')
+}
+
+// Locate the JSONL file for a session by searching
+// ~/.claude/projects/<encoded-cwd>/<session-id>.jsonl.
+// Returns the path if the file exists, or null if it can't be found.
+export function resolveJsonlPath(cwd: string, sessionId: string): string | null {
+  const encoded = encodeProjectPath(cwd)
+  const candidate = path.join(
+    os.homedir(),
+    '.claude',
+    'projects',
+    encoded,
+    `${sessionId}.jsonl`,
+  )
+  try {
+    fs.accessSync(candidate, fs.constants.R_OK)
+    return candidate
+  } catch {
+    return null
+  }
+}
+
+export type WatcherHandle = {
+  stop: () => void
+}
+
+// Watch a Claude Code JSONL file for status changes. Polls via
+// fs.watchFile (more reliable than fs.watch on Windows). On each file
+// change, reads new bytes from the last known offset, parses any `status`
+// records, maps the value, and calls onStatus if it changed.
+//
+// The file may not exist yet when this is called (Claude Code creates it
+// shortly after the session starts). The watcher will begin emitting once
+// the file appears.
+//
+// If the file shrinks (truncated / session reset), the offset is reset to 0
+// so the whole file is re-read.
+//
+// Returns a handle with a stop() method to tear down the watcher.
+export function watchJsonlStatus(
+  jsonlPath: string,
+  onStatus: (status: SessionStatus) => void,
+): WatcherHandle {
+  let offset = 0
+  let lastEmitted: SessionStatus | undefined
+
+  function readNewChunk() {
+    let stat: fs.Stats
+    try {
+      stat = fs.statSync(jsonlPath)
+    } catch (err) {
+      // File gone or not yet created — ignore until next poll tick
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        console.error('[termhub:status] unexpected stat error on', jsonlPath, err)
+      }
+      return
+    }
+
+    // File truncated / session resumed — reset offset to read from the top
+    if (stat.size < offset) {
+      console.log('[termhub:status] JSONL file truncated, resetting offset:', path.basename(jsonlPath))
+      offset = 0
+    }
+
+    if (stat.size === offset) {
+      return // nothing new
+    }
+
+    let fd: number
+    try {
+      fd = fs.openSync(jsonlPath, 'r')
+    } catch (err) {
+      console.error('[termhub:status] failed to open JSONL file', jsonlPath, err)
+      return
+    }
+
+    try {
+      const newBytes = stat.size - offset
+      const buf = Buffer.alloc(newBytes)
+      const bytesRead = fs.readSync(fd, buf, 0, newBytes, offset)
+      offset += bytesRead
+      const chunk = buf.slice(0, bytesRead).toString('utf8')
+      const raw = parseLatestStatus(chunk)
+      if (raw === undefined) return
+      const next = mapJsonlStatus(raw)
+      if (next !== lastEmitted) {
+        lastEmitted = next
+        onStatus(next)
+      }
+    } catch (err) {
+      console.error('[termhub:status] failed to read JSONL file', jsonlPath, err)
+    } finally {
+      try {
+        fs.closeSync(fd)
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  // Poll every 500 ms. fs.watchFile is available everywhere and avoids the
+  // unreliable fs.watch kernel events on Windows networked / NTFS paths.
+  fs.watchFile(jsonlPath, { interval: 500, persistent: false }, readNewChunk)
+
+  // Also do an immediate read in case the file already has content.
+  readNewChunk()
+
+  return {
+    stop() {
+      fs.unwatchFile(jsonlPath)
+    },
+  }
+}
+
+// Start watching the JSONL file for a session, discovering the path from
+// the session's cwd and id. The path search is repeated on each poll tick
+// until the file is found, so callers don't need to wait for it to appear.
+//
+// When the file doesn't exist yet, status stays at 'working' (the session
+// just started — we optimistically assume Claude is busy until JSONL says
+// otherwise).
+export function watchSessionStatus(
+  cwd: string,
+  sessionId: string,
+  onStatus: (status: SessionStatus) => void,
+): WatcherHandle {
+  const encoded = encodeProjectPath(cwd)
+  const jsonlPath = path.join(
+    os.homedir(),
+    '.claude',
+    'projects',
+    encoded,
+    `${sessionId}.jsonl`,
+  )
+
+  console.log('[termhub:status] watching JSONL for session', sessionId.slice(0, 8), 'at', jsonlPath)
+
+  return watchJsonlStatus(jsonlPath, onStatus)
+}

--- a/electron/status-watcher.ts
+++ b/electron/status-watcher.ts
@@ -35,47 +35,14 @@ export function parseSessionStatus(content: string): string | undefined {
   return undefined
 }
 
-// Encode a filesystem path the same way Claude Code does when building the
-// ~/.claude/projects/<encoded-cwd>/ directory name. Each backslash, forward
-// slash, colon, or dot is replaced with a dash.
-export function encodeProjectPath(cwdArg: string): string {
-  return cwdArg.replace(/[\\/:\.]/g, '-')
-}
-
-const PROJECTS_DIR = path.join(os.homedir(), '.claude', 'projects')
 const SESSIONS_DIR = path.join(os.homedir(), '.claude', 'sessions')
-
-// Find the session ID of the most recently active Claude Code session in the
-// given cwd. Claude Code writes one JSONL file per session under
-// ~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl, appending records as the
-// session progresses. The most recently modified file is the active session.
-// Returns the session ID (UUID string) or null if the directory is absent or empty.
-export function findActiveSessionId(cwd: string): string | null {
-  const dir = path.join(PROJECTS_DIR, encodeProjectPath(cwd))
-  let files: string[]
-  try {
-    files = fs.readdirSync(dir).filter(f => f.endsWith('.jsonl'))
-  } catch {
-    return null
-  }
-  if (files.length === 0) return null
-
-  let best: { stem: string; mtime: number } | null = null
-  for (const file of files) {
-    try {
-      const stat = fs.statSync(path.join(dir, file))
-      if (!best || stat.mtimeMs > best.mtime) {
-        best = { stem: path.basename(file, '.jsonl'), mtime: stat.mtimeMs }
-      }
-    } catch {
-      // file gone between readdir and stat — skip
-    }
-  }
-  return best?.stem ?? null
-}
 
 // Find the ~/.claude/sessions/<pid>.json file whose `sessionId` field matches
 // the given session ID. Returns the full path or null if not found.
+//
+// termhub passes --session-id <id> to every claude invocation, so the session
+// file written by Claude Code will always have sessionId === termhub's own id.
+// This makes the lookup exact and race-free.
 export function findSessionFileBySessionId(sessionId: string): string | null {
   let files: string[]
   try {
@@ -101,45 +68,35 @@ export type WatcherHandle = {
   stop: () => void
 }
 
-// Watch the status of a Claude Code session by:
-//   1. Finding the active session ID via ~/.claude/projects/<encoded-cwd>/*.jsonl
-//      (the most recently modified file is the active session; its filename is
-//      the session ID).
-//   2. Finding the corresponding ~/.claude/sessions/<pid>.json by sessionId match.
-//   3. Polling that file every 500 ms and emitting mapped status on change.
+// Watch the status of a Claude Code session by looking up its runtime file at
+// ~/.claude/sessions/<pid>.json. The file is discovered by matching its
+// `sessionId` field against the termhub session id, which termhub passes as
+// --session-id to every claude invocation — making this lookup exact and
+// race-free with no cwd scanning or time-window heuristics.
 //
-// Before the session file appears (Claude Code creates it shortly after startup),
-// status stays at 'working' — we optimistically assume busy until the file says
-// otherwise.
+// The file is a single JSON object rewritten in-place on every status change,
+// so each poll reads the whole file.
 //
-// If the file disappears (session ended / pid reused), the watcher re-discovers
-// the active session on the next tick.
+// Before the file appears (Claude Code creates it shortly after startup),
+// status stays at 'working' — we optimistically assume busy until the file
+// says otherwise.
 export function watchSessionStatus(
-  cwd: string,
+  sessionId: string,
   onStatus: (status: SessionStatus) => void,
 ): WatcherHandle {
   let stopped = false
   let watchedPath: string | null = null
-  let watchedSessionId: string | null = null
   let lastEmitted: SessionStatus | undefined
 
   function poll() {
     if (stopped) return
 
-    // Discover (or re-discover) the session file if not yet found.
+    // Discover the session file if not yet found.
     if (!watchedPath) {
-      const sessionId = findActiveSessionId(cwd)
-      if (sessionId && sessionId !== watchedSessionId) {
-        const filePath = findSessionFileBySessionId(sessionId)
-        if (filePath) {
-          watchedPath = filePath
-          watchedSessionId = sessionId
-          console.log(
-            '[termhub:status] found session file (id=%s) at %s',
-            sessionId.slice(0, 8),
-            filePath,
-          )
-        }
+      const filePath = findSessionFileBySessionId(sessionId)
+      if (filePath) {
+        watchedPath = filePath
+        console.log('[termhub:status] found session file (id=%s) at %s', sessionId.slice(0, 8), filePath)
       }
     }
 

--- a/electron/status-watcher.ts
+++ b/electron/status-watcher.ts
@@ -35,12 +35,48 @@ export function parseSessionStatus(content: string): string | undefined {
   return undefined
 }
 
+// Encode a filesystem path the same way Claude Code does when building the
+// ~/.claude/projects/<encoded-cwd>/ directory name. Each backslash, forward
+// slash, colon, or dot is replaced with a dash.
+export function encodeProjectPath(cwdArg: string): string {
+  return cwdArg.replace(/[\\/:\.]/g, '-')
+}
+
+const PROJECTS_DIR = path.join(os.homedir(), '.claude', 'projects')
 const SESSIONS_DIR = path.join(os.homedir(), '.claude', 'sessions')
 
-// Scan ~/.claude/sessions/ for a .json file whose `cwd` matches the given cwd
-// and whose `startedAt` is within the expected window around spawnedAt.
-// Returns the full file path, or null if no match is found.
-export function findSessionFile(cwd: string, spawnedAt: number): string | null {
+// Find the session ID of the most recently active Claude Code session in the
+// given cwd. Claude Code writes one JSONL file per session under
+// ~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl, appending records as the
+// session progresses. The most recently modified file is the active session.
+// Returns the session ID (UUID string) or null if the directory is absent or empty.
+export function findActiveSessionId(cwd: string): string | null {
+  const dir = path.join(PROJECTS_DIR, encodeProjectPath(cwd))
+  let files: string[]
+  try {
+    files = fs.readdirSync(dir).filter(f => f.endsWith('.jsonl'))
+  } catch {
+    return null
+  }
+  if (files.length === 0) return null
+
+  let best: { stem: string; mtime: number } | null = null
+  for (const file of files) {
+    try {
+      const stat = fs.statSync(path.join(dir, file))
+      if (!best || stat.mtimeMs > best.mtime) {
+        best = { stem: path.basename(file, '.jsonl'), mtime: stat.mtimeMs }
+      }
+    } catch {
+      // file gone between readdir and stat — skip
+    }
+  }
+  return best?.stem ?? null
+}
+
+// Find the ~/.claude/sessions/<pid>.json file whose `sessionId` field matches
+// the given session ID. Returns the full path or null if not found.
+export function findSessionFileBySessionId(sessionId: string): string | null {
   let files: string[]
   try {
     files = fs.readdirSync(SESSIONS_DIR).filter(f => f.endsWith('.json'))
@@ -48,74 +84,68 @@ export function findSessionFile(cwd: string, spawnedAt: number): string | null {
     return null
   }
 
-  // Normalise + lowercase for case-insensitive Windows path comparison.
-  const normCwd = path.normalize(cwd).toLowerCase()
-
-  // Allow the session file to have been created up to 5 min before our spawn
-  // (clock skew / race) or any time after.
-  const LOOKBACK_MS = 5 * 60 * 1000
-
-  let best: { filePath: string; startedAt: number } | null = null
-
   for (const file of files) {
     const filePath = path.join(SESSIONS_DIR, file)
     try {
       const content = fs.readFileSync(filePath, 'utf8')
       const rec = JSON.parse(content) as Record<string, unknown>
-      if (typeof rec.cwd !== 'string') continue
-      if (path.normalize(rec.cwd).toLowerCase() !== normCwd) continue
-      if (typeof rec.startedAt !== 'number') continue
-      if (rec.startedAt < spawnedAt - LOOKBACK_MS) continue
-      if (!best || rec.startedAt > best.startedAt) {
-        best = { filePath, startedAt: rec.startedAt }
-      }
+      if (rec.sessionId === sessionId) return filePath
     } catch {
       // unparseable or gone — skip
     }
   }
-
-  return best?.filePath ?? null
+  return null
 }
 
 export type WatcherHandle = {
   stop: () => void
 }
 
-// Watch the status of a Claude Code session by polling ~/.claude/sessions/
-// for a JSON file matching the session's cwd.
+// Watch the status of a Claude Code session by:
+//   1. Finding the active session ID via ~/.claude/projects/<encoded-cwd>/*.jsonl
+//      (the most recently modified file is the active session; its filename is
+//      the session ID).
+//   2. Finding the corresponding ~/.claude/sessions/<pid>.json by sessionId match.
+//   3. Polling that file every 500 ms and emitting mapped status on change.
 //
-// Claude Code writes ~/.claude/sessions/<pid>.json — a single JSON object
-// rewritten in-place on every status change. The file is named by Claude's
-// own PID (not termhub's session ID), so we discover it by cwd match.
+// Before the session file appears (Claude Code creates it shortly after startup),
+// status stays at 'working' — we optimistically assume busy until the file says
+// otherwise.
 //
-// Before the file appears (Claude Code creates it shortly after startup),
-// status stays at 'working' — we optimistically assume busy until the file
-// says otherwise.
-//
-// Returns a handle with a stop() method to tear down the watcher.
+// If the file disappears (session ended / pid reused), the watcher re-discovers
+// the active session on the next tick.
 export function watchSessionStatus(
   cwd: string,
   onStatus: (status: SessionStatus) => void,
 ): WatcherHandle {
-  const spawnedAt = Date.now()
   let stopped = false
   let watchedPath: string | null = null
+  let watchedSessionId: string | null = null
   let lastEmitted: SessionStatus | undefined
 
   function poll() {
     if (stopped) return
 
-    // Discover the session file if we haven't yet.
+    // Discover (or re-discover) the session file if not yet found.
     if (!watchedPath) {
-      watchedPath = findSessionFile(cwd, spawnedAt)
-      if (watchedPath) {
-        console.log('[termhub:status] found session file for', path.basename(cwd), 'at', watchedPath)
+      const sessionId = findActiveSessionId(cwd)
+      if (sessionId && sessionId !== watchedSessionId) {
+        const filePath = findSessionFileBySessionId(sessionId)
+        if (filePath) {
+          watchedPath = filePath
+          watchedSessionId = sessionId
+          console.log(
+            '[termhub:status] found session file (id=%s) at %s',
+            sessionId.slice(0, 8),
+            filePath,
+          )
+        }
       }
     }
 
     if (!watchedPath) return
 
-    // Read the current status from the file (whole file — it's a single JSON object).
+    // Read the current status from the file (whole file — single JSON object).
     try {
       const content = fs.readFileSync(watchedPath, 'utf8')
       const raw = parseSessionStatus(content)
@@ -129,7 +159,7 @@ export function watchSessionStatus(
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
         console.error('[termhub:status] failed to read session file', watchedPath, err)
       }
-      // File gone — reset so we re-scan next tick
+      // File gone — reset so we re-discover on the next tick.
       watchedPath = null
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,12 +7,11 @@ export type Session = {
   repoLabel?: string
 }
 
-// Advisory, UI-only status derived from the session's output stream.
-// 'working'  — Claude is actively generating / running tools (spinner visible)
-// 'awaiting' — Claude has stopped and is asking the user something
-//              (permission prompt or numbered choice)
-// 'idle'     — at the empty input prompt, ready for the next message
-// 'failed'   — the underlying process died with a non-zero exit code
+// Advisory, UI-only session status sourced from Claude Code's own JSONL file.
+// 'working'  — Claude is actively generating / running tools (JSONL: 'busy')
+// 'awaiting' — Claude has paused to ask the user something (JSONL: 'waiting')
+// 'idle'     — at the empty input prompt, ready for the next message (JSONL: 'idle')
+// 'failed'   — the underlying process died with a non-zero exit code (PTY exit)
 export type SessionStatus = 'working' | 'awaiting' | 'idle' | 'failed'
 
 export type AgentDef = {


### PR DESCRIPTION
## Summary

Replaces the regex-over-PTY-output heuristics (`SPINNER_RE`, `PERMISSION_RE`, `NUMBERED_CHOICE_RE`, `SPINNER_HOLD_MS` sticky timer) with a file watcher that reads Claude Code's own runtime session file at `~/.claude/sessions/<pid>.json`. That file is a single JSON object rewritten in-place on every status change; the `status` field (`idle`/`busy`/`waiting`) is the ground truth maintained by Claude Code itself.

The file is located by matching its `sessionId` field against termhub's own session UUID — which termhub already passes to every `claude` invocation as `--session-id`. This makes the lookup exact and race-free: no cwd scanning, no timestamp windows, no most-recently-modified heuristics.

Bonus fix: dev builds (`!app.isPackaged`) now redirect `userData` to `termhub-dev/` and default to MCP port 7788, so a running dev instance no longer bleeds sessions into the production one.

## Changes

- **New `electron/status-watcher.ts`**: `watchSessionStatus(sessionId, onStatus)` — polls `~/.claude/sessions/` every 500 ms via `setInterval`+`readFileSync`, finds the file whose `sessionId` field matches, reads the full JSON object, maps `status`, emits on change. Also exports `mapJsonlStatus` and `parseSessionStatus` for unit testing.
- **Deleted from `electron/main.ts`**: `SPINNER_RE`, `PERMISSION_RE`, `NUMBERED_CHOICE_RE`, `SPINNER_HOLD_MS`, `STATUS_TAIL_BYTES`, `detectStatusFromBuffer`, `recomputeStatus`
- **`Session` type**: `lastSpinnerSeen`/`statusReevalTimer` → `jsonlWatcher: WatcherHandle | null`
- **Dev isolation**: `app.setPath('userData', …/termhub-dev)` + default MCP port 7788 when `!app.isPackaged`
- **`electron/status-watcher.test.ts`**: 12 tests covering `mapJsonlStatus` and `parseSessionStatus`

## Test plan

- [x] `npm test` — all tests pass
- [x] `npm run typecheck` — clean
- [ ] Open a claude session in termhub and verify status badge transitions: blue while Claude thinks, yellow on permission prompt, green when idle, red on PTY exit

Closes #30