### PR TITLE
feat: ctrl+click URLs in terminal output via @xterm/addon-web-links

### DIFF
--- a/electron/links.test.ts
+++ b/electron/links.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { isAllowedExternalUrl } from './links'
+
+describe('isAllowedExternalUrl', () => {
+  it('allows https URLs', () => {
+    expect(isAllowedExternalUrl('https://example.com')).toBe(true)
+  })
+
+  it('allows http URLs', () => {
+    expect(isAllowedExternalUrl('http://localhost:3000')).toBe(true)
+  })
+
+  it('rejects file: URLs', () => {
+    expect(isAllowedExternalUrl('file:///c:/windows/system32')).toBe(false)
+  })
+
+  it('rejects javascript: URLs', () => {
+    expect(isAllowedExternalUrl('javascript:alert(1)')).toBe(false)
+  })
+
+  it('rejects empty string', () => {
+    expect(isAllowedExternalUrl('')).toBe(false)
+  })
+
+  it('rejects ftp: URLs', () => {
+    expect(isAllowedExternalUrl('ftp://files.example.com')).toBe(false)
+  })
+})

--- a/electron/links.ts
+++ b/electron/links.ts
@@ -1,0 +1,11 @@
+// URL allowlist for openExternal — only http/https schemes are permitted.
+// file:, javascript:, and other schemes are rejected to prevent local-file
+// access or script execution via crafted terminal output.
+export function isAllowedExternalUrl(url: string): boolean {
+  try {
+    const { protocol } = new URL(url)
+    return protocol === 'http:' || protocol === 'https:'
+  } catch {
+    return false
+  }
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -6,6 +6,7 @@ import * as fs from 'node:fs'
 import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { startMcpServer, type McpHandle } from './mcp'
+import { isAllowedExternalUrl } from './links'
 
 // Advisory status derived from the session's output stream. Mirrors the
 // SessionStatus union exposed to the renderer in src/types.ts.
@@ -1016,6 +1017,18 @@ app.whenReady().then(async () => {
 
   ipcMain.on('clipboard:write', (_event, text: string) => {
     clipboard.writeText(text)
+  })
+
+  ipcMain.on('open-external', (_event, url: string) => {
+    if (isAllowedExternalUrl(url)) {
+      shell.openExternal(url)
+    } else {
+      try {
+        console.warn('[termhub:links] rejected openExternal with disallowed scheme:', new URL(url).protocol)
+      } catch {
+        console.warn('[termhub:links] rejected openExternal with malformed URL:', url)
+      }
+    }
   })
 
   // Window controls — invoked from the custom title bar.

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -156,6 +156,10 @@ const api = {
     ipcRenderer.on('window:maximizeChange', handler)
     return () => { ipcRenderer.off('window:maximizeChange', handler) }
   },
+
+  openExternal: (url: string): void => {
+    ipcRenderer.send('open-external', url)
+  },
 }
 
 contextBridge.exposeInMainWorld('termhub', api)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@lydell/node-pty": "1.1.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^5.5.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -2428,6 +2429,12 @@
       "peerDependencies": {
         "@xterm/xterm": "^5.0.0"
       }
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
+      "integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==",
+      "license": "MIT"
     },
     "node_modules/@xterm/xterm": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@lydell/node-pty": "1.1.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^5.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { Terminal } from '@xterm/xterm'
 import type { FitAddon } from '@xterm/addon-fit'
+import type { WebLinksAddon } from '@xterm/addon-web-links'
 import { TitleBar } from './TitleBar'
 import { Sidebar } from './Sidebar'
 import { TerminalView } from './TerminalView'
@@ -9,7 +10,7 @@ import { RightPanel } from './RightPanel'
 import { UsageModal } from './UsageModal'
 import type { Session, SessionStatus } from './types'
 
-export type TerminalEntry = { term: Terminal; fit: FitAddon }
+export type TerminalEntry = { term: Terminal; fit: FitAddon; linksAddon?: WebLinksAddon }
 
 export default function App() {
   const [sessions, setSessions] = useState<Session[]>([])

--- a/src/BottomTerminal.tsx
+++ b/src/BottomTerminal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, type MutableRefObject } from 'react'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
+import { WebLinksAddon } from '@xterm/addon-web-links'
 import type { Session } from './types'
 import type { TerminalEntry } from './App'
 
@@ -75,6 +76,11 @@ export function BottomTerminal({
       const fit = new FitAddon()
       term.loadAddon(fit)
 
+      const linksAddon = new WebLinksAddon((_event, uri) => {
+        window.termhub.openExternal(uri)
+      })
+      term.loadAddon(linksAddon)
+
       term.attachCustomKeyEventHandler((e) => {
         if (e.type !== 'keydown' || !e.ctrlKey) return true
         const isC = e.code === 'KeyC'
@@ -120,7 +126,7 @@ export function BottomTerminal({
 
       window.termhub.resizeShell(session.id, term.cols, term.rows)
 
-      termsRef.current.set(session.id, { term, fit })
+      termsRef.current.set(session.id, { term, fit, linksAddon })
 
       const queue = pendingDataRef.current.get(session.id)
       if (queue && queue.length > 0) {
@@ -139,6 +145,7 @@ export function BottomTerminal({
     return () => {
       const entry = termsRef.current.get(session.id)
       if (entry) {
+        entry.linksAddon?.dispose()
         entry.term.dispose()
         termsRef.current.delete(session.id)
       }

--- a/src/TerminalView.tsx
+++ b/src/TerminalView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, type MutableRefObject } from 'react'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
+import { WebLinksAddon } from '@xterm/addon-web-links'
 import type { Session } from './types'
 import type { TerminalEntry } from './App'
 type Props = {
@@ -74,6 +75,11 @@ export function TerminalView({ session, isActive, termsRef, pendingDataRef }: Pr
       const fit = new FitAddon()
       term.loadAddon(fit)
 
+      const linksAddon = new WebLinksAddon((_event, uri) => {
+        window.termhub.openExternal(uri)
+      })
+      term.loadAddon(linksAddon)
+
       // Single handler — xterm only keeps the last registered handler, so
       // all key interception must live in one call to attachCustomKeyEventHandler.
       term.attachCustomKeyEventHandler((e) => {
@@ -140,7 +146,7 @@ export function TerminalView({ session, isActive, termsRef, pendingDataRef }: Pr
       // an onResize (no-op when proposed dims match the constructor cols/rows).
       window.termhub.resize(session.id, term.cols, term.rows)
 
-      termsRef.current.set(session.id, { term, fit })
+      termsRef.current.set(session.id, { term, fit, linksAddon })
 
       const queue = pendingDataRef.current.get(session.id)
       if (queue && queue.length > 0) {
@@ -160,6 +166,7 @@ export function TerminalView({ session, isActive, termsRef, pendingDataRef }: Pr
     return () => {
       const entry = termsRef.current.get(session.id)
       if (entry) {
+        entry.linksAddon?.dispose()
         entry.term.dispose()
         termsRef.current.delete(session.id)
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,7 @@ export type TermhubApi = {
   closeWindow: () => void
   isMaximized: () => Promise<boolean>
   onMaximizeChange: (cb: (maximized: boolean) => void) => () => void
+  openExternal: (url: string) => void
 }
 
 declare global {


### PR DESCRIPTION
## Summary
Adds ctrl+click URL activation to both terminal views (primary Claude PTY and bottom shell) using the `@xterm/addon-web-links` addon. Clicking a URL while holding Ctrl opens it in the user's default browser via `shell.openExternal`. An allowlist in the IPC handler restricts launches to `http:` and `https:` only, rejecting `file:`, `javascript:`, and any other scheme.

## Changes
- Install `@xterm/addon-web-links` dependency
- Add `electron/links.ts` — exports `isAllowedExternalUrl` (pure, testable, no Electron dep)
- Add `openExternal` IPC: `ipcRenderer.send('open-external', url)` in preload, `ipcMain.on('open-external', ...)` handler in main with scheme allowlist
- Load `WebLinksAddon` in `TerminalView.tsx` and `BottomTerminal.tsx`; dispose it on unmount
- Extend `TerminalEntry` type in `App.tsx` with optional `linksAddon` field
- Add `openExternal(url: string): void` to the `TermhubApi` interface in `src/types.ts`
- Add `electron/links.test.ts` with 6 Vitest cases covering allowed and rejected schemes

## Test plan
- [ ] Run `npm test` — 6 tests pass
- [ ] Run `npm run typecheck` — no errors
- [ ] In the running app, ctrl+click a URL printed in a terminal session — browser opens
- [ ] Verify `file://` and `javascript:` URLs are not opened (warn logged to console)