### PR TITLE
feat: make terminal split divider draggable with persistence

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,14 @@ import { BottomTerminal } from './BottomTerminal'
 import { RightPanel } from './RightPanel'
 import { UsageModal } from './UsageModal'
 import type { Session, SessionStatus } from './types'
+import {
+  clampHeight,
+  readPersistedHeight,
+  BOTTOM_MIN_HEIGHT,
+  BOTTOM_MAX_FRACTION,
+  BOTTOM_DEFAULT_HEIGHT,
+  BOTTOM_HEIGHT_STORAGE_KEY,
+} from './layout'
 
 export type TerminalEntry = { term: Terminal; fit: FitAddon; linksAddon?: WebLinksAddon }
 
@@ -24,6 +32,19 @@ export default function App() {
   // keyed by the same session id, but wired to the shell PTY channel.
   const shellTermsRef = useRef(new Map<string, TerminalEntry>())
   const shellPendingDataRef = useRef(new Map<string, string[]>())
+
+  // Bottom terminal height — persisted across restarts via localStorage.
+  const [bottomHeight, setBottomHeight] = useState<number>(() =>
+    readPersistedHeight(BOTTOM_DEFAULT_HEIGHT),
+  )
+  // Ref so the mousemove handler always reads the latest height without needing
+  // to be re-registered on every height change.
+  const bottomHeightRef = useRef(bottomHeight)
+  // The container that holds .main-top + divider + .main-bottom. We need its
+  // bounding rect to compute the max allowed height during drag.
+  const mainContainerRef = useRef<HTMLElement>(null)
+  // isDragging is a ref (not state) to avoid re-renders during drag.
+  const isDraggingRef = useRef(false)
 
   useEffect(() => {
     const offData = window.termhub.onData((id, data) => {
@@ -174,6 +195,51 @@ export default function App() {
     }
   }, [])
 
+  // Keep ref in sync with state so the mousemove closure always sees the
+  // latest value without needing to be re-registered.
+  useEffect(() => {
+    bottomHeightRef.current = bottomHeight
+  }, [bottomHeight])
+
+  const handleDividerMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    isDraggingRef.current = true
+    document.body.style.cursor = 'row-resize'
+    document.body.style.userSelect = 'none'
+    console.info('[termhub:layout] drag start, height before:', bottomHeightRef.current)
+
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!isDraggingRef.current) return
+      const container = mainContainerRef.current
+      if (!container) return
+      const rect = container.getBoundingClientRect()
+      // Height = distance from mouse Y to the bottom of the container.
+      const raw = rect.bottom - ev.clientY
+      const clamped = clampHeight(raw, BOTTOM_MIN_HEIGHT, BOTTOM_MAX_FRACTION, rect.height)
+      setBottomHeight(clamped)
+      bottomHeightRef.current = clamped
+    }
+
+    const onMouseUp = () => {
+      isDraggingRef.current = false
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+      window.removeEventListener('mousemove', onMouseMove)
+      window.removeEventListener('mouseup', onMouseUp)
+      const finalHeight = bottomHeightRef.current
+      console.info('[termhub:layout] drag end, final height:', finalHeight)
+      // Persist the chosen height.
+      try {
+        localStorage.setItem(BOTTOM_HEIGHT_STORAGE_KEY, String(finalHeight))
+      } catch {
+        // localStorage may be unavailable in some environments
+      }
+    }
+
+    window.addEventListener('mousemove', onMouseMove)
+    window.addEventListener('mouseup', onMouseUp)
+  }, [])
+
   // Refit both terminals for the active session when the window resizes.
   useEffect(() => {
     const onResize = () => {
@@ -244,7 +310,7 @@ export default function App() {
           onClose={closeSession}
           onRename={renameSession}
         />
-        <main className="main">
+        <main className="main" ref={mainContainerRef}>
           {sessions.length === 0 ? (
             <div className="empty">
               <p>No sessions yet.</p>
@@ -263,8 +329,8 @@ export default function App() {
                   />
                 ))}
               </div>
-              <div className="main-divider" />
-              <div className="main-bottom">
+              <div className="main-divider" onMouseDown={handleDividerMouseDown} />
+              <div className="main-bottom" style={{ flexBasis: bottomHeight }}>
                 {sessions.map((s) => (
                   <BottomTerminal
                     key={s.id}

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import {
+  clampHeight,
+  readPersistedHeight,
+  BOTTOM_MIN_HEIGHT,
+  BOTTOM_MAX_FRACTION,
+  BOTTOM_DEFAULT_HEIGHT,
+  BOTTOM_HEIGHT_STORAGE_KEY,
+} from './layout'
+
+describe('clampHeight', () => {
+  const available = 800
+
+  it('returns the raw value when within bounds', () => {
+    expect(clampHeight(300, BOTTOM_MIN_HEIGHT, BOTTOM_MAX_FRACTION, available)).toBe(300)
+  })
+
+  it('clamps to minimum when raw is too small', () => {
+    expect(clampHeight(10, BOTTOM_MIN_HEIGHT, BOTTOM_MAX_FRACTION, available)).toBe(BOTTOM_MIN_HEIGHT)
+  })
+
+  it('clamps to maximum fraction when raw exceeds it', () => {
+    // 70% of 800 = 560
+    expect(clampHeight(700, BOTTOM_MIN_HEIGHT, BOTTOM_MAX_FRACTION, available)).toBe(560)
+  })
+
+  it('allows exactly the minimum', () => {
+    expect(clampHeight(BOTTOM_MIN_HEIGHT, BOTTOM_MIN_HEIGHT, BOTTOM_MAX_FRACTION, available)).toBe(
+      BOTTOM_MIN_HEIGHT,
+    )
+  })
+
+  it('allows exactly the maximum', () => {
+    const max = Math.floor(available * BOTTOM_MAX_FRACTION)
+    expect(clampHeight(max, BOTTOM_MIN_HEIGHT, BOTTOM_MAX_FRACTION, available)).toBe(max)
+  })
+
+  it('rounds fractional pixel values', () => {
+    expect(clampHeight(300.7, BOTTOM_MIN_HEIGHT, BOTTOM_MAX_FRACTION, available)).toBe(301)
+  })
+
+  it('handles zero available height gracefully (max becomes 0 → clamped to min)', () => {
+    // When available is 0 the max is also 0 which is less than min,
+    // so the result should equal the minimum (Math.max wins).
+    expect(clampHeight(100, BOTTOM_MIN_HEIGHT, BOTTOM_MAX_FRACTION, 0)).toBe(BOTTOM_MIN_HEIGHT)
+  })
+})
+
+describe('readPersistedHeight', () => {
+  // Simulate localStorage using a plain object since jsdom may or may not be
+  // available in vitest's default node environment.  We patch globalThis.localStorage.
+  const makeFakeStorage = (initial: Record<string, string> = {}) => {
+    const store = { ...initial }
+    return {
+      getItem: (key: string) => store[key] ?? null,
+      setItem: (key: string, value: string) => { store[key] = value },
+      removeItem: (key: string) => { delete store[key] },
+    } as Storage
+  }
+
+  it('returns defaultHeight when nothing is stored', () => {
+    const orig = globalThis.localStorage
+    Object.defineProperty(globalThis, 'localStorage', { value: makeFakeStorage(), configurable: true })
+    expect(readPersistedHeight(BOTTOM_DEFAULT_HEIGHT)).toBe(BOTTOM_DEFAULT_HEIGHT)
+    Object.defineProperty(globalThis, 'localStorage', { value: orig, configurable: true })
+  })
+
+  it('returns the stored numeric value', () => {
+    const orig = globalThis.localStorage
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: makeFakeStorage({ [BOTTOM_HEIGHT_STORAGE_KEY]: '350' }),
+      configurable: true,
+    })
+    expect(readPersistedHeight(BOTTOM_DEFAULT_HEIGHT)).toBe(350)
+    Object.defineProperty(globalThis, 'localStorage', { value: orig, configurable: true })
+  })
+
+  it('falls back to default when the stored value is NaN', () => {
+    const orig = globalThis.localStorage
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: makeFakeStorage({ [BOTTOM_HEIGHT_STORAGE_KEY]: 'banana' }),
+      configurable: true,
+    })
+    expect(readPersistedHeight(BOTTOM_DEFAULT_HEIGHT)).toBe(BOTTOM_DEFAULT_HEIGHT)
+    Object.defineProperty(globalThis, 'localStorage', { value: orig, configurable: true })
+  })
+
+  it('falls back to default when the stored value is zero', () => {
+    const orig = globalThis.localStorage
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: makeFakeStorage({ [BOTTOM_HEIGHT_STORAGE_KEY]: '0' }),
+      configurable: true,
+    })
+    expect(readPersistedHeight(BOTTOM_DEFAULT_HEIGHT)).toBe(BOTTOM_DEFAULT_HEIGHT)
+    Object.defineProperty(globalThis, 'localStorage', { value: orig, configurable: true })
+  })
+
+  it('falls back to default when localStorage throws', () => {
+    const orig = globalThis.localStorage
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: { getItem: () => { throw new Error('quota') } } as unknown as Storage,
+      configurable: true,
+    })
+    expect(readPersistedHeight(BOTTOM_DEFAULT_HEIGHT)).toBe(BOTTOM_DEFAULT_HEIGHT)
+    Object.defineProperty(globalThis, 'localStorage', { value: orig, configurable: true })
+  })
+})

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -1,0 +1,43 @@
+// Pure helpers for the resizable terminal split layout.
+
+export const BOTTOM_MIN_HEIGHT = 60
+export const BOTTOM_MAX_FRACTION = 0.7
+export const BOTTOM_DEFAULT_HEIGHT = 220
+export const BOTTOM_HEIGHT_STORAGE_KEY = 'termhub:bottomTerminalHeight'
+
+/**
+ * Clamp a raw bottom-terminal height to valid bounds.
+ *
+ * @param raw           Unclamped height in pixels (e.g. from a drag computation).
+ * @param min           Minimum allowed height in pixels.
+ * @param maxFraction   Maximum fraction of the available container height.
+ * @param available     Total available content-area height in pixels.
+ * @returns             Clamped height in pixels.
+ */
+export function clampHeight(
+  raw: number,
+  min: number,
+  maxFraction: number,
+  available: number,
+): number {
+  // Ensure max is never less than min so the minimum always wins in
+  // degenerate situations (e.g. a zero-height container).
+  const max = Math.max(min, Math.floor(available * maxFraction))
+  return Math.min(Math.max(Math.round(raw), min), max)
+}
+
+/**
+ * Read the persisted bottom-terminal height from localStorage.
+ * Falls back to `defaultHeight` when the stored value is absent or
+ * not a finite positive number.
+ */
+export function readPersistedHeight(defaultHeight: number): number {
+  try {
+    const raw = localStorage.getItem(BOTTOM_HEIGHT_STORAGE_KEY)
+    if (raw === null) return defaultHeight
+    const parsed = Number(raw)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultHeight
+  } catch {
+    return defaultHeight
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -590,18 +590,23 @@ body,
   min-height: 0;
 }
 
-/* Horizontal rule between the two stacked terminals. Fixed height; a
-   draggable resizer is future work. */
+/* Horizontal rule between the two stacked terminals. Draggable to resize. */
 .main-divider {
   flex: 0 0 auto;
   height: 4px;
   background: var(--border);
   cursor: row-resize;
+  transition: background 0.15s;
 }
 
-/* Bottom shell pane — fixed v1 height. */
+.main-divider:hover,
+.main-divider:active {
+  background: var(--accent);
+}
+
+/* Bottom shell pane — height is controlled dynamically via inline style (flex-basis). */
 .main-bottom {
-  flex: 0 0 220px;
+  flex: 0 0 auto;
   position: relative;
   overflow: hidden;
   min-height: 0;


### PR DESCRIPTION
## Summary

The divider between the main Claude terminal and the bottom shell terminal is now draggable. Mousedown on the divider tracks the mouse globally and adjusts the bottom terminal's height in real time. The chosen height is clamped (min 60 px, max 70 % of the content area) and persisted to `localStorage` so it survives restarts. The existing `ResizeObserver` wiring in `BottomTerminal` picks up the flex-basis change automatically, so both xterm instances refit without any extra plumbing.

## Changes

- `src/layout.ts` — pure helpers: `clampHeight`, `readPersistedHeight`, and the related constants
- `src/App.tsx` — `bottomHeight` state initialised from localStorage; `handleDividerMouseDown` wires global mousemove/mouseup listeners; `mainContainerRef` anchors the bounding-rect for max-height computation; inline `flexBasis` on `.main-bottom`; info-level log on drag start/end
- `src/styles.css` — remove hard-coded `flex: 0 0 220px` from `.main-bottom`; accent-colour hover/active state on `.main-divider`

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm test` — 12 new tests in `src/layout.test.ts` (32 total, all green)
- [ ] Manual: drag the divider up and down; bottom terminal refits in real time
- [ ] Manual: resize below min (60 px) and above 70 % — both hard stops hold
- [ ] Manual: close and reopen the app — persisted height is restored