### PR TITLE
refactor: dedupe cross-process types

### DIFF
--- a/electron/main.test.ts
+++ b/electron/main.test.ts
@@ -7,6 +7,8 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 vi.mock('electron', () => ({
   app: {
     getPath: () => '/tmp',
+    setPath: () => {},
+    isPackaged: true,
     // Return a promise that never resolves so the whenReady callbacks
     // never fire and we avoid unhandled errors from incomplete mocks.
     whenReady: () => new Promise(() => {}),

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -7,7 +7,13 @@ import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { startMcpServer, type McpHandle } from './mcp'
 import { isAllowedExternalUrl } from './links'
-import { watchSessionStatus, type WatcherHandle, type SessionStatus } from './status-watcher'
+import { watchSessionStatus, type WatcherHandle } from './status-watcher'
+import type {
+  AgentDef,
+  Config,
+  SessionStatus,
+  SkillDef,
+} from '../src/types'
 
 // Isolate dev builds so their sessions, config, and MCP port don't bleed into
 // the production instance running alongside. Must be called before the first
@@ -140,23 +146,6 @@ function findSessionByIdOrPrefix(idOrPrefix: string): FindSessionResult {
   }
 }
 
-type StartupSession = {
-  cwd: string
-  command?: string
-  prompt?: string
-  agent?: string
-  model?: string
-  dangerouslySkipPermissions?: boolean
-  allowDangerouslySkipPermissions?: boolean
-  permissionMode?: string
-  name?: string
-}
-
-type Config = {
-  mcpPort: number
-  startupSessions: StartupSession[]
-}
-
 type PersistedSession = {
   id: string
   cwd: string
@@ -240,8 +229,6 @@ function getSkillsDir(): string {
   return path.join(os.homedir(), '.claude', 'skills')
 }
 
-type AgentDef = { name: string; path: string; description?: string }
-
 function listAgents(): AgentDef[] {
   const dir = getAgentsDir()
   let entries: string[]
@@ -283,8 +270,6 @@ function parseAgentDescription(filePath: string): string | undefined {
     return undefined
   }
 }
-
-type SkillDef = { name: string; path: string; description?: string }
 
 function listSkills(): SkillDef[] {
   const dir = getSkillsDir()

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,8 +1,13 @@
 import { contextBridge, ipcRenderer } from 'electron'
+import type {
+  AgentDef,
+  Config,
+  SessionStatus,
+  SkillDef,
+} from '../src/types'
 
 type DataPayload = { id: string; data: string }
 type ExitPayload = { id: string; exitCode: number }
-type SessionStatus = 'working' | 'awaiting' | 'idle' | 'failed'
 type StatusPayload = { id: string; status: SessionStatus }
 type AddedPayload = {
   id: string
@@ -13,7 +18,6 @@ type AddedPayload = {
   repoRoot?: string
   repoLabel?: string
 }
-type AgentDef = { name: string; path: string; description?: string }
 
 const api = {
   createSession: (
@@ -47,8 +51,7 @@ const api = {
 
   home: (): Promise<string> => ipcRenderer.invoke('app:home'),
 
-  getConfig: (): Promise<{ startupSessions: Array<{ cwd: string }> }> =>
-    ipcRenderer.invoke('config:get'),
+  getConfig: (): Promise<Config> => ipcRenderer.invoke('config:get'),
 
   configPath: (): Promise<string> => ipcRenderer.invoke('config:path'),
 
@@ -136,7 +139,7 @@ const api = {
   openAgent: (path: string): Promise<void> =>
     ipcRenderer.invoke('agents:open', path),
 
-  listSkills: (): Promise<AgentDef[]> => ipcRenderer.invoke('skills:list'),
+  listSkills: (): Promise<SkillDef[]> => ipcRenderer.invoke('skills:list'),
 
   openSkill: (path: string): Promise<void> =>
     ipcRenderer.invoke('skills:open', path),

--- a/electron/status-watcher.ts
+++ b/electron/status-watcher.ts
@@ -1,9 +1,7 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as os from 'node:os'
-
-// Advisory status type mirroring src/types.ts SessionStatus.
-export type SessionStatus = 'working' | 'awaiting' | 'idle' | 'failed'
+import type { SessionStatus } from '../src/types'
 
 // Map Claude Code's session `status` field values to termhub's SessionStatus.
 // Values from Claude Code:

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,19 +26,21 @@ export type SkillDef = {
   description?: string
 }
 
+export type StartupSession = {
+  cwd: string
+  command?: string
+  prompt?: string
+  agent?: string
+  model?: string
+  dangerouslySkipPermissions?: boolean
+  allowDangerouslySkipPermissions?: boolean
+  permissionMode?: string
+  name?: string
+}
+
 export type Config = {
   mcpPort: number
-  startupSessions: Array<{
-    cwd: string
-    command?: string
-    prompt?: string
-    agent?: string
-    model?: string
-    dangerouslySkipPermissions?: boolean
-    allowDangerouslySkipPermissions?: boolean
-    permissionMode?: string
-    name?: string
-  }>
+  startupSessions: StartupSession[]
 }
 
 export type TermhubApi = {

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -12,5 +12,5 @@
     "resolveJsonModule": true,
     "types": ["node"]
   },
-  "include": ["electron"]
+  "include": ["electron", "src/types.ts"]
 }


### PR DESCRIPTION
## Summary
- Promote `src/types.ts` to the single source of truth for the cross-process contract. `SessionStatus`, `Config`, `AgentDef`, `SkillDef` were each redeclared in 2-3 places; main.ts also had its own inline `StartupSession`.
- Fix two contract drifts the dedupe surfaced: preload's `getConfig` was typed `Promise<{ startupSessions: Array<{ cwd: string }> }>` (now `Promise<Config>`), and `listSkills` returned `AgentDef[]` (now `SkillDef[]`).
- Repair `main.test.ts`: stub `app.setPath` / `app.isPackaged` so the dev-userData isolation block introduced in #35 doesn't blow up at module-import time. Brings the suite back to 44/44.
- Mechanism: `tsconfig.electron.json` now includes `src/types.ts` so electron-side files can `import type { ... } from '../src/types'`. esbuild already follows the import graph, so no bundler config change needed.

This is the first piece of the refactor backlog laid out after #35 merged. Subsequent PRs will build on it: small cleanups (MCP route constants, resize helper, log prefixes), then the `useXterm` hook, then carving up `electron/main.ts`.

## Test plan
- [x] `npm run typecheck` (both tsconfigs)
- [x] `npm test` (44/44, including the previously-broken `main.test.ts`)
- [x] `npm run build` (main, bridge, renderer all produced)
- [ ] Manual smoke (caller): launch dev build, open a session, send input, confirm status indicator + persistence still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)