### PR TITLE
refactor: small cleanups (MCP routes, resize helper, createSession)

### DIFF
--- a/electron/main.test.ts
+++ b/electron/main.test.ts
@@ -37,7 +37,7 @@ vi.mock('electron', () => ({
 vi.mock('@lydell/node-pty', () => ({ spawn: () => ({}) }))
 vi.mock('node:child_process', () => ({ spawn: () => ({}) }))
 
-import { buildClaudeArgs } from './main'
+import { buildClaudeArgs, resizePty } from './main'
 
 const BASE = {
   sessionId: 'test-session-id',
@@ -105,5 +105,52 @@ describe('buildClaudeArgs', () => {
   it('includes --mcp-config with the provided path', () => {
     const flags = buildClaudeArgs({ ...BASE })
     expect(flags.some((f) => f.includes('--mcp-config') && f.includes('/path/to/mcp.json'))).toBe(true)
+  })
+})
+
+describe('resizePty', () => {
+  function makeTarget() {
+    const calls: Array<[number, number]> = []
+    return {
+      resize: (cols: number, rows: number) => { calls.push([cols, rows]) },
+      calls,
+    }
+  }
+
+  it('forwards cleanly-typed cols/rows untouched', () => {
+    const t = makeTarget()
+    resizePty(t, 80, 24)
+    expect(t.calls).toEqual([[80, 24]])
+  })
+
+  it('floors fractional values', () => {
+    const t = makeTarget()
+    resizePty(t, 80.7, 24.4)
+    expect(t.calls).toEqual([[80, 24]])
+  })
+
+  it('clamps zero/negative to 1', () => {
+    const t = makeTarget()
+    resizePty(t, 0, -5)
+    expect(t.calls).toEqual([[1, 1]])
+  })
+
+  it('drops NaN', () => {
+    const t = makeTarget()
+    resizePty(t, NaN, 24)
+    expect(t.calls).toEqual([])
+  })
+
+  it('drops Infinity', () => {
+    const t = makeTarget()
+    resizePty(t, 80, Infinity)
+    expect(t.calls).toEqual([])
+  })
+
+  it('swallows errors thrown by the target (PTY may have exited)', () => {
+    const t = {
+      resize: () => { throw new Error('pty exited') },
+    }
+    expect(() => resizePty(t, 80, 24)).not.toThrow()
   })
 })

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -50,6 +50,26 @@ type Session = {
 
 const MAX_OUTPUT_BUFFER_BYTES = 256 * 1024
 
+// Validate cols/rows from the renderer and forward to a PTY. Both the primary
+// (claude) and the secondary (shell) PTYs receive resize requests on every UI
+// resize / divider drag, so this gets called frequently. Non-finite values
+// from the renderer (NaN, Infinity) are silently dropped; resize errors from
+// an already-exited PTY are swallowed because they race against shutdown.
+//
+// Duck-typed on `resize` so unit tests can pass a plain object instead of a
+// real PTY. Exported only for tests.
+type PtyResizeTarget = { resize: (cols: number, rows: number) => void }
+export function resizePty(target: PtyResizeTarget, cols: number, rows: number): void {
+  if (!Number.isFinite(cols) || !Number.isFinite(rows)) return
+  const c = Math.max(1, Math.floor(cols))
+  const r = Math.max(1, Math.floor(rows))
+  try {
+    target.resize(c, r)
+  } catch {
+    // pty may have exited between resize requests
+  }
+}
+
 function appendToBuffer(buf: string, chunk: string): string {
   const combined = buf + chunk
   if (combined.length <= MAX_OUTPUT_BUFFER_BYTES) return combined
@@ -841,15 +861,13 @@ app.whenReady().then(async () => {
   // Bootstrap once the renderer is listening
   rendererReady.then(() => bootstrapSessions(config))
 
+  // Renderer-spawned sessions are plain shells rooted at the picked folder.
+  // Claude sessions are launched via startup config, restored on resume, or
+  // opened via the MCP `open_session` tool — never from the renderer.
   ipcMain.handle(
     'session:create',
-    (_event, opts: { cwd: string; command?: string; prompt?: string }) =>
-      createSessionInternal({
-        cwd: opts.cwd,
-        command: opts.command,
-        prompt: opts.prompt,
-        source: 'ipc',
-      }),
+    (_event, opts: { cwd: string }) =>
+      createSessionInternal({ cwd: opts.cwd, source: 'ipc' }),
   )
 
   ipcMain.on('session:input', (_event, payload: { id: string; data: string }) => {
@@ -861,14 +879,7 @@ app.whenReady().then(async () => {
     (_event, payload: { id: string; cols: number; rows: number }) => {
       const s = sessions.get(payload.id)
       if (!s) return
-      if (!Number.isFinite(payload.cols) || !Number.isFinite(payload.rows)) return
-      const cols = Math.max(1, Math.floor(payload.cols))
-      const rows = Math.max(1, Math.floor(payload.rows))
-      try {
-        s.term.resize(cols, rows)
-      } catch {
-        // pty may have exited between resize requests
-      }
+      resizePty(s.term, payload.cols, payload.rows)
     },
   )
 
@@ -905,14 +916,7 @@ app.whenReady().then(async () => {
     (_event, payload: { id: string; cols: number; rows: number }) => {
       const s = sessions.get(payload.id)
       if (!s) return
-      if (!Number.isFinite(payload.cols) || !Number.isFinite(payload.rows)) return
-      const cols = Math.max(1, Math.floor(payload.cols))
-      const rows = Math.max(1, Math.floor(payload.rows))
-      try {
-        s.shellTerm.resize(cols, rows)
-      } catch {
-        // pty may have exited between resize requests
-      }
+      resizePty(s.shellTerm, payload.cols, payload.rows)
     },
   )
 

--- a/electron/mcp-bridge.ts
+++ b/electron/mcp-bridge.ts
@@ -12,6 +12,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod'
+import { MCP_ROUTES } from './mcp-routes'
 
 const port = Number.parseInt(process.env.TERMHUB_PORT ?? '7787', 10)
 const baseUrl = `http://127.0.0.1:${port}`
@@ -99,7 +100,7 @@ async function main() {
     },
     async (args) => {
       try {
-        const response = await fetch(`${baseUrl}/internal/open_session`, {
+        const response = await fetch(`${baseUrl}${MCP_ROUTES.OPEN_SESSION}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -163,7 +164,7 @@ async function main() {
     },
     async (args) => {
       try {
-        const response = await fetch(`${baseUrl}/internal/send_input`, {
+        const response = await fetch(`${baseUrl}${MCP_ROUTES.SEND_INPUT}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ sessionId: args.sessionId, text: args.text }),
@@ -215,7 +216,7 @@ async function main() {
     },
     async (args) => {
       try {
-        const response = await fetch(`${baseUrl}/internal/read_output`, {
+        const response = await fetch(`${baseUrl}${MCP_ROUTES.READ_OUTPUT}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({

--- a/electron/mcp-routes.test.ts
+++ b/electron/mcp-routes.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { MCP_ROUTES } from './mcp-routes'
+
+// These constants are the wire contract between the stdio bridge and the
+// internal HTTP server. Pinning the values guards against accidental renames
+// that would silently break the bridge until the next end-to-end test.
+describe('MCP_ROUTES', () => {
+  it('uses the expected /internal/ paths', () => {
+    expect(MCP_ROUTES.OPEN_SESSION).toBe('/internal/open_session')
+    expect(MCP_ROUTES.SEND_INPUT).toBe('/internal/send_input')
+    expect(MCP_ROUTES.READ_OUTPUT).toBe('/internal/read_output')
+  })
+
+  it('routes are unique', () => {
+    const values = Object.values(MCP_ROUTES)
+    expect(new Set(values).size).toBe(values.length)
+  })
+})

--- a/electron/mcp-routes.ts
+++ b/electron/mcp-routes.ts
@@ -1,0 +1,12 @@
+// Route constants for the internal HTTP endpoint that bridges the stdio MCP
+// server (electron/mcp-bridge.ts) to the Electron main process (electron/mcp.ts).
+//
+// Both sides import from here so adding or renaming an endpoint is a single-file
+// change. The mcp.test.ts harness imports these too.
+export const MCP_ROUTES = {
+  OPEN_SESSION: '/internal/open_session',
+  SEND_INPUT: '/internal/send_input',
+  READ_OUTPUT: '/internal/read_output',
+} as const
+
+export type McpRoute = (typeof MCP_ROUTES)[keyof typeof MCP_ROUTES]

--- a/electron/mcp.test.ts
+++ b/electron/mcp.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { startMcpServer, type McpHooks } from './mcp'
+import { MCP_ROUTES } from './mcp-routes'
 
 const BASE_PORT = 19_876
 
@@ -51,7 +52,7 @@ describe('mcp HTTP server — error sanitization', () => {
     })
     close = handle.close
 
-    const { status, json } = await post(port, '/internal/open_session', { cwd: '/tmp' })
+    const { status, json } = await post(port, MCP_ROUTES.OPEN_SESSION, { cwd: '/tmp' })
 
     expect(status).toBe(500)
     const body = JSON.stringify(json)
@@ -69,7 +70,7 @@ describe('mcp HTTP server — error sanitization', () => {
     const handle = await startMcpServer({ port, hooks: makeHooks() })
     close = handle.close
 
-    const res = await fetch(`http://127.0.0.1:${port}/internal/open_session`, {
+    const res = await fetch(`http://127.0.0.1:${port}${MCP_ROUTES.OPEN_SESSION}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: '{ not valid json !!!',
@@ -89,7 +90,7 @@ describe('mcp HTTP server — error sanitization', () => {
     const handle = await startMcpServer({ port, hooks: makeHooks() })
     close = handle.close
 
-    const res = await fetch(`http://127.0.0.1:${port}/internal/send_input`, {
+    const res = await fetch(`http://127.0.0.1:${port}${MCP_ROUTES.SEND_INPUT}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: '<<bad>>',
@@ -109,7 +110,7 @@ describe('mcp HTTP server — error sanitization', () => {
     const handle = await startMcpServer({ port, hooks: makeHooks() })
     close = handle.close
 
-    const res = await fetch(`http://127.0.0.1:${port}/internal/read_output`, {
+    const res = await fetch(`http://127.0.0.1:${port}${MCP_ROUTES.READ_OUTPUT}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: 'not-json',
@@ -129,7 +130,7 @@ describe('mcp HTTP server — error sanitization', () => {
     const handle = await startMcpServer({ port, hooks: makeHooks() })
     close = handle.close
 
-    const { status, json } = await post(port, '/internal/open_session', { cwd: '/tmp' })
+    const { status, json } = await post(port, MCP_ROUTES.OPEN_SESSION, { cwd: '/tmp' })
     expect(status).toBe(200)
     expect((json as { id: string }).id).toBe('test-id')
   })

--- a/electron/mcp.ts
+++ b/electron/mcp.ts
@@ -4,6 +4,7 @@
 // MCP server, and it forwards tool calls here.
 
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import { MCP_ROUTES } from './mcp-routes'
 
 export type OpenSessionResult = { id: string; cwd: string }
 
@@ -61,10 +62,7 @@ export async function startMcpServer(opts: {
   const httpServer = createServer(async (req, res) => {
     console.log(`[termhub:mcp] ${req.method} ${req.url}`)
 
-    if (
-      req.url === '/internal/open_session' &&
-      req.method === 'POST'
-    ) {
+    if (req.url === MCP_ROUTES.OPEN_SESSION && req.method === 'POST') {
       const body = await readBody(req).catch(() => '')
       let parsed: {
         cwd?: unknown
@@ -120,7 +118,7 @@ export async function startMcpServer(opts: {
       return
     }
 
-    if (req.url === '/internal/send_input' && req.method === 'POST') {
+    if (req.url === MCP_ROUTES.SEND_INPUT && req.method === 'POST') {
       const body = await readBody(req).catch(() => '')
       let parsed: { sessionId?: unknown; text?: unknown }
       try {
@@ -142,7 +140,7 @@ export async function startMcpServer(opts: {
       return
     }
 
-    if (req.url === '/internal/read_output' && req.method === 'POST') {
+    if (req.url === MCP_ROUTES.READ_OUTPUT && req.method === 'POST') {
       const body = await readBody(req).catch(() => '')
       let parsed: { sessionId?: unknown; maxChars?: unknown; raw?: unknown }
       try {
@@ -176,7 +174,7 @@ export async function startMcpServer(opts: {
   })
 
   const url = `http://127.0.0.1:${opts.port}`
-  console.log(`[termhub:mcp] internal HTTP API listening on ${url}/internal/open_session`)
+  console.log(`[termhub:mcp] internal HTTP API listening on ${url}${MCP_ROUTES.OPEN_SESSION}`)
 
   return {
     port: opts.port,

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -20,12 +20,8 @@ type AddedPayload = {
 }
 
 const api = {
-  createSession: (
-    cwd: string,
-    command?: string,
-    prompt?: string,
-  ): Promise<{ id: string; cwd: string }> =>
-    ipcRenderer.invoke('session:create', { cwd, command, prompt }),
+  createSession: (cwd: string): Promise<{ id: string; cwd: string }> =>
+    ipcRenderer.invoke('session:create', { cwd }),
 
   sendInput: (id: string, data: string): void => {
     ipcRenderer.send('session:input', { id, data })

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,11 +44,7 @@ export type Config = {
 }
 
 export type TermhubApi = {
-  createSession: (
-    cwd: string,
-    command?: string,
-    prompt?: string,
-  ) => Promise<{ id: string; cwd: string }>
+  createSession: (cwd: string) => Promise<{ id: string; cwd: string }>
   sendInput: (id: string, data: string) => void
   resize: (id: string, cols: number, rows: number) => void
   close: (id: string) => void


### PR DESCRIPTION
## Summary
Three small refactor-backlog items bundled.

**#2 — MCP route constants.** The strings `/internal/open_session`, `/internal/send_input`, `/internal/read_output` were unindexed in three places (server, bridge, test harness). Moved to `electron/mcp-routes.ts`; adding or renaming an endpoint is now a one-file change.

**#3 — \`resizePty\` helper.** `session:resize` and `session:shell:resize` had identical 14-line cols/rows validation blocks. Extracted a duck-typed `resizePty(target, cols, rows)` helper and called it from both handlers.

**#5 — Honest \`createSession\` signature.** `TermhubApi.createSession` was typed `(cwd, command?, prompt?)` but the only caller (App.tsx) ever passed `cwd`. The two unused params were leftover contract from an earlier design — renderer-spawned sessions are always plain shells; claude sessions come from startup config / persistence / MCP. Dropped the unused params across types.ts, preload.ts, and the IPC handler payload.

**Deferred.** #4 (log-prefix sweep) — main.ts owns ~30 log sites that #7 (split main.ts) will move around. Sweeping prefixes before #7 is wasted churn; will roll into #7 or follow.

## Tests
- New `electron/mcp-routes.test.ts` pins the wire-contract values.
- New `resizePty` cases in `electron/main.test.ts`: clean values, fractional → floor, zero/negative → 1, NaN dropped, Infinity dropped, target-throws swallowed (6 cases).

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (52/52, +8 from main)
- [x] `npm run build`
- [ ] Manual smoke (caller): drag the divider repeatedly (exercises both resize paths), open a new session via the New button, confirm it lands as a plain shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)