### PR TITLE
refactor: extract useXterm hook to dedupe TerminalView/BottomTerminal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { Terminal } from '@xterm/xterm'
-import type { FitAddon } from '@xterm/addon-fit'
-import type { WebLinksAddon } from '@xterm/addon-web-links'
 import { TitleBar } from './TitleBar'
 import { Sidebar } from './Sidebar'
 import { TerminalView } from './TerminalView'
@@ -9,6 +6,7 @@ import { BottomTerminal } from './BottomTerminal'
 import { RightPanel } from './RightPanel'
 import { UsageModal } from './UsageModal'
 import type { Session, SessionStatus } from './types'
+import type { TerminalEntry } from './useXterm'
 import {
   clampHeight,
   readPersistedHeight,
@@ -17,8 +15,6 @@ import {
   BOTTOM_DEFAULT_HEIGHT,
   BOTTOM_HEIGHT_STORAGE_KEY,
 } from './layout'
-
-export type TerminalEntry = { term: Terminal; fit: FitAddon; linksAddon?: WebLinksAddon }
 
 export default function App() {
   const [sessions, setSessions] = useState<Session[]>([])

--- a/src/BottomTerminal.tsx
+++ b/src/BottomTerminal.tsx
@@ -1,9 +1,6 @@
-import { useEffect, useRef, type MutableRefObject } from 'react'
-import { Terminal } from '@xterm/xterm'
-import { FitAddon } from '@xterm/addon-fit'
-import { WebLinksAddon } from '@xterm/addon-web-links'
+import { useMemo, type MutableRefObject } from 'react'
 import type { Session } from './types'
-import type { TerminalEntry } from './App'
+import { useXterm, type TerminalEntry, type XtermBehavior } from './useXterm'
 
 type Props = {
   session: Session
@@ -12,194 +9,29 @@ type Props = {
   pendingDataRef: MutableRefObject<Map<string, string[]>>
 }
 
-// Docked shell terminal rendered under the primary TerminalView. Parallels
-// TerminalView almost line-for-line but wires input/resize to the shell PTY
-// channel (sendShellInput / resizeShell) instead of the primary one.
-export function BottomTerminal({
-  session,
-  isActive,
-  termsRef,
-  pendingDataRef,
-}: Props) {
-  const containerRef = useRef<HTMLDivElement>(null)
+// Docked shell terminal under the primary TerminalView. Wires xterm to the
+// shell IPC channel and preserves user scroll position across activations.
+// All lifecycle work lives in useXterm.
+export function BottomTerminal({ session, isActive, termsRef, pendingDataRef }: Props) {
+  const behavior = useMemo<XtermBehavior>(
+    () => ({
+      sendInput: (id, data) => window.termhub.sendShellInput(id, data),
+      resize: (id, cols, rows) => window.termhub.resizeShell(id, cols, rows),
+      minRows: 3,
+      interceptShiftEnter: false,
+      focusOnReactivate: false,
+      logTag: 'bottom-terminal',
+    }),
+    [],
+  )
 
-  useEffect(() => {
-    if (!isActive) return
-
-    const existing = termsRef.current.get(session.id)
-    if (existing) {
-      const raf = requestAnimationFrame(() => {
-        try {
-          existing.fit.fit()
-        } catch {
-          // ignore
-        }
-      })
-      return () => cancelAnimationFrame(raf)
-    }
-
-    const container = containerRef.current
-    if (!container) return
-
-    let cancelled = false
-    const raf = requestAnimationFrame(() => {
-      if (cancelled) return
-      if (termsRef.current.has(session.id)) return
-
-      const rect = container.getBoundingClientRect()
-      if (rect.width <= 0 || rect.height <= 0) {
-        console.warn(
-          `[termhub] bottom container has zero size for session ${session.id.slice(0, 8)}; skipping init`,
-        )
-        return
-      }
-
-      const cols = Math.max(20, Math.floor((rect.width - 12) / 8.5))
-      const rows = Math.max(3, Math.floor((rect.height - 12) / 17))
-
-      const term = new Terminal({
-        cols,
-        rows,
-        cursorBlink: true,
-        fontFamily:
-          '"Cascadia Mono", "JetBrains Mono", "Fira Code", Consolas, "Courier New", monospace',
-        fontSize: 13,
-        theme: {
-          background: '#161618',
-          foreground: '#e0dcf2',
-          cursor: '#c8c4e0',
-          selectionBackground: '#2d2550',
-        },
-        scrollback: 5000,
-        allowProposedApi: true,
-      })
-      const fit = new FitAddon()
-      term.loadAddon(fit)
-
-      const linksAddon = new WebLinksAddon((_event, uri) => {
-        window.termhub.openExternal(uri)
-      })
-      term.loadAddon(linksAddon)
-
-      term.attachCustomKeyEventHandler((e) => {
-        if (e.type !== 'keydown' || !e.ctrlKey) return true
-        const isC = e.code === 'KeyC'
-        const isV = e.code === 'KeyV'
-        if (!isC && !isV) return true
-
-        if (isC) {
-          const hasSelection = term.hasSelection()
-          if (e.shiftKey || hasSelection) {
-            const text = term.getSelection()
-            if (text) {
-              window.termhub.writeClipboard(text)
-              term.clearSelection()
-            }
-            return false
-          }
-          return true
-        }
-
-        // Ctrl+V: return false so xterm doesn't convert the keystroke into
-        // the SYN control char \x16 (and call preventDefault, which would
-        // suppress the textarea's native paste pipeline).  xterm's own
-        // built-in 'paste' listener on the textarea then handles writing
-        // the clipboard contents to the PTY with bracketed-paste-mode
-        // framing.  Calling readClipboard().then(term.paste()) here in
-        // addition produces a double paste.
-        return false
-      })
-
-      term.onData((data) => {
-        window.termhub.sendShellInput(session.id, data)
-      })
-      term.onResize(({ cols, rows }) => {
-        window.termhub.resizeShell(session.id, cols, rows)
-      })
-
-      // Snap-to-bottom fix: mirrors TerminalView — see the comment there.
-      let prevYdisp = 0
-      term.onScroll((newYdisp) => {
-        const ybase = term.buffer.active.baseY
-        if (newYdisp > prevYdisp && newYdisp >= ybase - 1 && newYdisp < ybase) {
-          term.scrollToBottom()
-        }
-        prevYdisp = newYdisp
-      })
-
-      term.open(container)
-      try {
-        fit.fit()
-      } catch (err) {
-        console.warn('[termhub] bottom fit.fit() failed:', err)
-      }
-
-      window.termhub.resizeShell(session.id, term.cols, term.rows)
-
-      termsRef.current.set(session.id, { term, fit, linksAddon })
-
-      const queue = pendingDataRef.current.get(session.id)
-      if (queue && queue.length > 0) {
-        for (const data of queue) term.write(data)
-        pendingDataRef.current.delete(session.id)
-      }
-    })
-
-    return () => {
-      cancelled = true
-      cancelAnimationFrame(raf)
-    }
-  }, [isActive, session.id, termsRef, pendingDataRef])
-
-  // ResizeObserver: re-fit when the container changes size due to layout
-  // changes (sidebar toggle, right panel show/hide, session switch, etc.).
-  // rAF throttling avoids per-pixel calls during animated resizes.
-  useEffect(() => {
-    const container = containerRef.current
-    if (!container) return
-
-    let rafId: number | null = null
-    const observer = new ResizeObserver(() => {
-      if (rafId !== null) return
-      rafId = requestAnimationFrame(() => {
-        rafId = null
-        const entry = termsRef.current.get(session.id)
-        if (!entry) return
-        const prevCols = entry.term.cols
-        const prevRows = entry.term.rows
-        try {
-          entry.fit.fit()
-        } catch {
-          // ignore — container may be zero-size during hide transition
-        }
-        const newCols = entry.term.cols
-        const newRows = entry.term.rows
-        if (newCols !== prevCols || newRows !== prevRows) {
-          console.info(
-            `[termhub:terminal] bottom session ${session.id.slice(0, 8)} resized ${prevCols}x${prevRows} -> ${newCols}x${newRows}`,
-          )
-        }
-      })
-    })
-
-    observer.observe(container)
-    return () => {
-      observer.disconnect()
-      if (rafId !== null) cancelAnimationFrame(rafId)
-    }
-  }, [session.id, termsRef])
-
-  useEffect(() => {
-    return () => {
-      const entry = termsRef.current.get(session.id)
-      if (entry) {
-        entry.linksAddon?.dispose()
-        entry.term.dispose()
-        termsRef.current.delete(session.id)
-      }
-      pendingDataRef.current.delete(session.id)
-    }
-  }, [session.id, termsRef, pendingDataRef])
+  const containerRef = useXterm({
+    session,
+    isActive,
+    termsRef,
+    pendingDataRef,
+    behavior,
+  })
 
   return (
     <div

--- a/src/TerminalView.tsx
+++ b/src/TerminalView.tsx
@@ -1,9 +1,7 @@
-import { useEffect, useRef, type MutableRefObject } from 'react'
-import { Terminal } from '@xterm/xterm'
-import { FitAddon } from '@xterm/addon-fit'
-import { WebLinksAddon } from '@xterm/addon-web-links'
+import { useMemo, type MutableRefObject } from 'react'
 import type { Session } from './types'
-import type { TerminalEntry } from './App'
+import { useXterm, type TerminalEntry, type XtermBehavior } from './useXterm'
+
 type Props = {
   session: Session
   isActive: boolean
@@ -11,230 +9,29 @@ type Props = {
   pendingDataRef: MutableRefObject<Map<string, string[]>>
 }
 
+// Primary terminal pane — hosts the claude (or other --command) PTY. Wires
+// xterm to the primary IPC channel, intercepts Shift+Enter, refocuses on
+// activation. All lifecycle work lives in useXterm.
 export function TerminalView({ session, isActive, termsRef, pendingDataRef }: Props) {
-  const containerRef = useRef<HTMLDivElement>(null)
+  const behavior = useMemo<XtermBehavior>(
+    () => ({
+      sendInput: (id, data) => window.termhub.sendInput(id, data),
+      resize: (id, cols, rows) => window.termhub.resize(id, cols, rows),
+      minRows: 5,
+      interceptShiftEnter: true,
+      focusOnReactivate: true,
+      logTag: 'terminal',
+    }),
+    [],
+  )
 
-  // Lazy-init: only create the xterm instance when the session first becomes
-  // visible. xterm's renderer needs a non-zero-size container at open() time
-  // and gets confused by StrictMode's double-invoke if init is synchronous —
-  // so we defer init to a rAF, which lets the first (cancelled) effect run
-  // bail out before doing any DOM work.
-  useEffect(() => {
-    if (!isActive) return
-
-    const existing = termsRef.current.get(session.id)
-    if (existing) {
-      const raf = requestAnimationFrame(() => {
-        try {
-          existing.fit.fit()
-          // Scroll to bottom after fit so the scrollbar extent is current before
-          // we jump — otherwise xterm may not be able to reach the last line.
-          existing.term.scrollToBottom()
-          existing.term.focus()
-        } catch {
-          // ignore
-        }
-      })
-      return () => cancelAnimationFrame(raf)
-    }
-
-    const container = containerRef.current
-    if (!container) return
-
-    let cancelled = false
-    const raf = requestAnimationFrame(() => {
-      if (cancelled) return
-      if (termsRef.current.has(session.id)) return
-
-      const rect = container.getBoundingClientRect()
-      if (rect.width <= 0 || rect.height <= 0) {
-        console.warn(
-          `[termhub] container has zero size for session ${session.id.slice(0, 8)}; skipping init`,
-        )
-        return
-      }
-
-      // Initial cols/rows estimated from container size so the renderer has
-      // sane dimensions before FitAddon refines them.
-      const cols = Math.max(20, Math.floor((rect.width - 12) / 8.5))
-      const rows = Math.max(5, Math.floor((rect.height - 12) / 17))
-
-      const term = new Terminal({
-        cols,
-        rows,
-        cursorBlink: true,
-        fontFamily:
-          '"Cascadia Mono", "JetBrains Mono", "Fira Code", Consolas, "Courier New", monospace',
-        fontSize: 13,
-        theme: {
-          background: '#161618',
-          foreground: '#e0dcf2',
-          cursor: '#c8c4e0',
-          selectionBackground: '#2d2550',
-        },
-        scrollback: 5000,
-        allowProposedApi: true,
-      })
-      const fit = new FitAddon()
-      term.loadAddon(fit)
-
-      const linksAddon = new WebLinksAddon((_event, uri) => {
-        window.termhub.openExternal(uri)
-      })
-      term.loadAddon(linksAddon)
-
-      // Single handler — xterm only keeps the last registered handler, so
-      // all key interception must live in one call to attachCustomKeyEventHandler.
-      term.attachCustomKeyEventHandler((e) => {
-        // Shift+Enter: send the kitty keyboard-protocol encoding (\x1b[13;2u).
-        // xterm.js is in normal terminal mode (Claude Code does not enable
-        // modifyOtherKeys or kitty protocol on this xterm instance), so without
-        // interception xterm emits bare CR (0d) which Claude Code treats as
-        // "submit".  The kitty form is what Claude Code maps to "insert newline"
-        // in Kitty / WezTerm.
-        if (e.type === 'keydown' && e.shiftKey && e.key === 'Enter') {
-          e.preventDefault()
-          window.termhub.sendInput(session.id, '\x1b[13;2u')
-          return false
-        }
-
-        if (e.type === 'keydown' && e.ctrlKey && e.code === 'KeyC') {
-          const hasSelection = term.hasSelection()
-          if (e.shiftKey || hasSelection) {
-            const text = term.getSelection()
-            if (text) {
-              window.termhub.writeClipboard(text)
-              term.clearSelection()
-            }
-            return false
-          }
-        }
-
-        // Ctrl+V: returning false stops xterm's _keyDown from converting
-        // the keystroke into the SYN control char \x16 and calling
-        // preventDefault on the keydown.  That preventDefault is what
-        // suppresses the browser's native textarea paste pipeline; with it
-        // gone, the textarea fires a real 'paste' ClipboardEvent and
-        // xterm's own paste listener handles it (calling term.paste() with
-        // bracketed-paste-mode framing).  No custom readClipboard call is
-        // needed — adding one produces a double paste because xterm's
-        // listener writes the same text again.
-        if (e.type === 'keydown' && e.ctrlKey && e.code === 'KeyV') {
-          return false
-        }
-
-        return true
-      })
-
-      // Wire data + resize handlers BEFORE fit() so the resize triggered
-      // by the initial fit reaches the pty. Otherwise the pty stays at its
-      // spawn-time 80x24 while xterm renders at the fitted size, causing
-      // cursor-positioning corruption (broken tab completion, TUIs that
-      // overwrite themselves instead of scrolling).
-      term.onData((data) => {
-        window.termhub.sendInput(session.id, data)
-      })
-      term.onResize(({ cols, rows }) => {
-        window.termhub.resize(session.id, cols, rows)
-      })
-
-      // Snap-to-bottom fix: xterm's internal pixel rounding can leave the
-      // scrollbar 1 line short of ybase when the user scrolls down after new
-      // output has arrived while they were scrolled up.  When the viewport
-      // moves downward and gets within 1 line of ybase, snap all the way to
-      // the bottom so the final line is always reachable.
-      // We only fire when scrolling downward (newYdisp > prevYdisp) to avoid
-      // fighting the user when they intentionally scroll up from the bottom.
-      let prevYdisp = 0
-      term.onScroll((newYdisp) => {
-        const ybase = term.buffer.active.baseY
-        if (newYdisp > prevYdisp && newYdisp >= ybase - 1 && newYdisp < ybase) {
-          term.scrollToBottom()
-        }
-        prevYdisp = newYdisp
-      })
-
-      term.open(container)
-      try {
-        fit.fit()
-      } catch (err) {
-        console.warn('[termhub] fit.fit() failed:', err)
-      }
-
-      // Explicitly push current dims to the pty in case fit() didn't trigger
-      // an onResize (no-op when proposed dims match the constructor cols/rows).
-      window.termhub.resize(session.id, term.cols, term.rows)
-
-      termsRef.current.set(session.id, { term, fit, linksAddon })
-
-      const queue = pendingDataRef.current.get(session.id)
-      if (queue && queue.length > 0) {
-        for (const data of queue) term.write(data)
-        pendingDataRef.current.delete(session.id)
-      }
-      // Land at the bottom of any buffered content on first mount so the user
-      // sees the latest output rather than the top of a filled scrollback.
-      term.scrollToBottom()
-    })
-
-    return () => {
-      cancelled = true
-      cancelAnimationFrame(raf)
-    }
-  }, [isActive, session.id, termsRef, pendingDataRef])
-
-  // ResizeObserver: re-fit when the container changes size due to layout
-  // changes (sidebar toggle, right panel show/hide, session switch, etc.).
-  // Without this, only window resize triggers FitAddon and the scrollbar
-  // falls out of sync with actual content.
-  // rAF throttling avoids per-pixel calls during animated resizes.
-  useEffect(() => {
-    const container = containerRef.current
-    if (!container) return
-
-    let rafId: number | null = null
-    const observer = new ResizeObserver(() => {
-      if (rafId !== null) return
-      rafId = requestAnimationFrame(() => {
-        rafId = null
-        const entry = termsRef.current.get(session.id)
-        if (!entry) return
-        const prevCols = entry.term.cols
-        const prevRows = entry.term.rows
-        try {
-          entry.fit.fit()
-        } catch {
-          // ignore — container may be zero-size during hide transition
-        }
-        const newCols = entry.term.cols
-        const newRows = entry.term.rows
-        if (newCols !== prevCols || newRows !== prevRows) {
-          console.info(
-            `[termhub:terminal] session ${session.id.slice(0, 8)} resized ${prevCols}x${prevRows} -> ${newCols}x${newRows}`,
-          )
-        }
-      })
-    })
-
-    observer.observe(container)
-    return () => {
-      observer.disconnect()
-      if (rafId !== null) cancelAnimationFrame(rafId)
-    }
-  }, [session.id, termsRef])
-
-  // Dispose only on unmount (not on every isActive flip).
-  useEffect(() => {
-    return () => {
-      const entry = termsRef.current.get(session.id)
-      if (entry) {
-        entry.linksAddon?.dispose()
-        entry.term.dispose()
-        termsRef.current.delete(session.id)
-      }
-      pendingDataRef.current.delete(session.id)
-    }
-  }, [session.id, termsRef, pendingDataRef])
+  const containerRef = useXterm({
+    session,
+    isActive,
+    termsRef,
+    pendingDataRef,
+    behavior,
+  })
 
   return (
     <div

--- a/src/useXterm.ts
+++ b/src/useXterm.ts
@@ -1,0 +1,294 @@
+import { useEffect, useRef, type MutableRefObject } from 'react'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import { WebLinksAddon } from '@xterm/addon-web-links'
+import type { Session } from './types'
+import { estimateInitialDims, shouldSnapToBottom } from './xterm-utils'
+
+// Stored in App.tsx's terms maps. The hook reads/writes these on the maps
+// passed in via props so the parent owns lifecycle across active-session
+// switches.
+export type TerminalEntry = {
+  term: Terminal
+  fit: FitAddon
+  linksAddon?: WebLinksAddon
+}
+
+// Per-variant wiring: which IPC methods to call, what minimum row count to
+// estimate at init, whether to intercept Shift+Enter for the kitty
+// keyboard-protocol newline, and whether to refocus + jump to bottom when
+// re-activating an existing entry.
+export type XtermBehavior = {
+  // Forwards keyboard input from xterm to the appropriate PTY.
+  sendInput: (id: string, data: string) => void
+  // Forwards xterm size changes (initial fit + ResizeObserver) to the PTY.
+  resize: (id: string, cols: number, rows: number) => void
+  // Lower bound for the rows estimate before FitAddon refines it. Primary
+  // pane uses 5; the docked shell uses 3 because it can be dragged smaller.
+  minRows: number
+  // Primary pane only: claude maps Shift+Enter (kitty form \x1b[13;2u) to
+  // "insert newline" while bare CR is "submit", so xterm's default CR
+  // emission has to be intercepted.
+  interceptShiftEnter: boolean
+  // Primary pane re-focuses + jumps to bottom on activation; the shell
+  // pane keeps the user's scroll position so they can read prior output
+  // without it scrolling away.
+  focusOnReactivate: boolean
+  // Suffix used in [termhub:terminal] log lines. 'terminal' for primary,
+  // 'bottom-terminal' for the docked shell.
+  logTag: string
+}
+
+const FONT_FAMILY =
+  '"Cascadia Mono", "JetBrains Mono", "Fira Code", Consolas, "Courier New", monospace'
+
+const TERMINAL_THEME = {
+  background: '#161618',
+  foreground: '#e0dcf2',
+  cursor: '#c8c4e0',
+  selectionBackground: '#2d2550',
+} as const
+
+type Props = {
+  session: Session
+  isActive: boolean
+  termsRef: MutableRefObject<Map<string, TerminalEntry>>
+  pendingDataRef: MutableRefObject<Map<string, string[]>>
+  behavior: XtermBehavior
+}
+
+// Returns a ref to attach to the container <div>. Owns the entire xterm
+// lifecycle for one (session, variant) pair: lazy init on first activation,
+// re-fit + (optionally) refocus on re-activation, ResizeObserver-driven
+// re-fit on container size changes, dispose on unmount.
+//
+// Replaces the duplicated init/dispose/resize bodies that previously lived
+// in TerminalView.tsx and BottomTerminal.tsx.
+export function useXterm({
+  session,
+  isActive,
+  termsRef,
+  pendingDataRef,
+  behavior,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Lazy-init: only create the xterm instance when the session first becomes
+  // visible. xterm's renderer needs a non-zero-size container at open() time
+  // and gets confused by StrictMode's double-invoke if init is synchronous —
+  // so we defer init to a rAF, which lets the first (cancelled) effect run
+  // bail out before doing any DOM work.
+  useEffect(() => {
+    if (!isActive) return
+
+    const existing = termsRef.current.get(session.id)
+    if (existing) {
+      const raf = requestAnimationFrame(() => {
+        try {
+          existing.fit.fit()
+          if (behavior.focusOnReactivate) {
+            // Scroll to bottom after fit so the scrollbar extent is current
+            // before we jump — otherwise xterm may not be able to reach the
+            // last line.
+            existing.term.scrollToBottom()
+            existing.term.focus()
+          }
+        } catch {
+          // ignore
+        }
+      })
+      return () => cancelAnimationFrame(raf)
+    }
+
+    const container = containerRef.current
+    if (!container) return
+
+    let cancelled = false
+    const raf = requestAnimationFrame(() => {
+      if (cancelled) return
+      if (termsRef.current.has(session.id)) return
+
+      const rect = container.getBoundingClientRect()
+      if (rect.width <= 0 || rect.height <= 0) {
+        console.warn(
+          `[termhub:${behavior.logTag}] container has zero size for session ${session.id.slice(0, 8)}; skipping init`,
+        )
+        return
+      }
+
+      const { cols, rows } = estimateInitialDims(rect, behavior.minRows)
+
+      const term = new Terminal({
+        cols,
+        rows,
+        cursorBlink: true,
+        fontFamily: FONT_FAMILY,
+        fontSize: 13,
+        theme: { ...TERMINAL_THEME },
+        scrollback: 5000,
+        allowProposedApi: true,
+      })
+      const fit = new FitAddon()
+      term.loadAddon(fit)
+
+      const linksAddon = new WebLinksAddon((_event, uri) => {
+        window.termhub.openExternal(uri)
+      })
+      term.loadAddon(linksAddon)
+
+      // Single handler — xterm only keeps the last registered handler, so
+      // all key interception must live in one call.
+      term.attachCustomKeyEventHandler((e) => {
+        // Shift+Enter (primary only): send the kitty keyboard-protocol
+        // encoding (\x1b[13;2u). xterm.js is in normal terminal mode (Claude
+        // Code does not enable modifyOtherKeys or kitty protocol on this
+        // xterm instance), so without interception xterm emits bare CR (0d)
+        // which Claude Code treats as "submit". The kitty form is what
+        // Claude Code maps to "insert newline" in Kitty / WezTerm.
+        if (
+          behavior.interceptShiftEnter &&
+          e.type === 'keydown' &&
+          e.shiftKey &&
+          e.key === 'Enter'
+        ) {
+          e.preventDefault()
+          behavior.sendInput(session.id, '\x1b[13;2u')
+          return false
+        }
+
+        if (e.type === 'keydown' && e.ctrlKey && e.code === 'KeyC') {
+          const hasSelection = term.hasSelection()
+          if (e.shiftKey || hasSelection) {
+            const text = term.getSelection()
+            if (text) {
+              window.termhub.writeClipboard(text)
+              term.clearSelection()
+            }
+            return false
+          }
+        }
+
+        // Ctrl+V: returning false stops xterm's _keyDown from converting
+        // the keystroke into the SYN control char \x16 and calling
+        // preventDefault on the keydown.  That preventDefault is what
+        // suppresses the browser's native textarea paste pipeline; with it
+        // gone, the textarea fires a real 'paste' ClipboardEvent and
+        // xterm's own paste listener handles it (calling term.paste() with
+        // bracketed-paste-mode framing).  No custom readClipboard call is
+        // needed — adding one produces a double paste because xterm's
+        // listener writes the same text again.
+        if (e.type === 'keydown' && e.ctrlKey && e.code === 'KeyV') {
+          return false
+        }
+
+        return true
+      })
+
+      // Wire data + resize handlers BEFORE fit() so the resize triggered
+      // by the initial fit reaches the pty. Otherwise the pty stays at its
+      // spawn-time 80x24 while xterm renders at the fitted size, causing
+      // cursor-positioning corruption (broken tab completion, TUIs that
+      // overwrite themselves instead of scrolling).
+      term.onData((data) => {
+        behavior.sendInput(session.id, data)
+      })
+      term.onResize(({ cols: c, rows: r }) => {
+        behavior.resize(session.id, c, r)
+      })
+
+      let prevYdisp = 0
+      term.onScroll((newYdisp) => {
+        const ybase = term.buffer.active.baseY
+        if (shouldSnapToBottom(prevYdisp, newYdisp, ybase)) {
+          term.scrollToBottom()
+        }
+        prevYdisp = newYdisp
+      })
+
+      term.open(container)
+      try {
+        fit.fit()
+      } catch (err) {
+        console.warn(`[termhub:${behavior.logTag}] fit.fit() failed:`, err)
+      }
+
+      // Explicitly push current dims to the pty in case fit() didn't trigger
+      // an onResize (no-op when proposed dims match the constructor cols/rows).
+      behavior.resize(session.id, term.cols, term.rows)
+
+      termsRef.current.set(session.id, { term, fit, linksAddon })
+
+      const queue = pendingDataRef.current.get(session.id)
+      if (queue && queue.length > 0) {
+        for (const data of queue) term.write(data)
+        pendingDataRef.current.delete(session.id)
+      }
+      if (behavior.focusOnReactivate) {
+        // Land at the bottom of any buffered content on first mount so the
+        // user sees the latest output rather than the top of a filled
+        // scrollback.
+        term.scrollToBottom()
+      }
+    })
+
+    return () => {
+      cancelled = true
+      cancelAnimationFrame(raf)
+    }
+  }, [isActive, session.id, termsRef, pendingDataRef, behavior])
+
+  // ResizeObserver: re-fit when the container changes size due to layout
+  // changes (sidebar toggle, right panel show/hide, session switch, divider
+  // drag). Without this, only window resize triggers FitAddon and the
+  // scrollbar falls out of sync with actual content.
+  // rAF throttling avoids per-pixel calls during animated resizes.
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    let rafId: number | null = null
+    const observer = new ResizeObserver(() => {
+      if (rafId !== null) return
+      rafId = requestAnimationFrame(() => {
+        rafId = null
+        const entry = termsRef.current.get(session.id)
+        if (!entry) return
+        const prevCols = entry.term.cols
+        const prevRows = entry.term.rows
+        try {
+          entry.fit.fit()
+        } catch {
+          // ignore — container may be zero-size during hide transition
+        }
+        const newCols = entry.term.cols
+        const newRows = entry.term.rows
+        if (newCols !== prevCols || newRows !== prevRows) {
+          console.info(
+            `[termhub:${behavior.logTag}] session ${session.id.slice(0, 8)} resized ${prevCols}x${prevRows} -> ${newCols}x${newRows}`,
+          )
+        }
+      })
+    })
+
+    observer.observe(container)
+    return () => {
+      observer.disconnect()
+      if (rafId !== null) cancelAnimationFrame(rafId)
+    }
+  }, [session.id, termsRef, behavior])
+
+  // Dispose only on unmount (not on every isActive flip).
+  useEffect(() => {
+    return () => {
+      const entry = termsRef.current.get(session.id)
+      if (entry) {
+        entry.linksAddon?.dispose()
+        entry.term.dispose()
+        termsRef.current.delete(session.id)
+      }
+      pendingDataRef.current.delete(session.id)
+    }
+  }, [session.id, termsRef, pendingDataRef])
+
+  return containerRef
+}

--- a/src/xterm-utils.test.ts
+++ b/src/xterm-utils.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { estimateInitialDims, shouldSnapToBottom } from './xterm-utils'
+
+describe('estimateInitialDims', () => {
+  it('subtracts container padding and divides by approximate cell size', () => {
+    // 800x400 container — (800-12)/8.5 = 92.7 → 92, (400-12)/17 = 22.8 → 22
+    expect(estimateInitialDims({ width: 800, height: 400 }, 5)).toEqual({
+      cols: 92,
+      rows: 22,
+    })
+  })
+
+  it('clamps cols to a minimum of 20', () => {
+    // Tiny container — would yield 1 col without the floor.
+    expect(estimateInitialDims({ width: 10, height: 200 }, 5).cols).toBe(20)
+  })
+
+  it('clamps rows to the provided minRows', () => {
+    expect(estimateInitialDims({ width: 800, height: 10 }, 5).rows).toBe(5)
+    expect(estimateInitialDims({ width: 800, height: 10 }, 3).rows).toBe(3)
+  })
+
+  it('floors fractional dimensions', () => {
+    // (200-12)/8.5 = 22.117 → 22, not 23.
+    expect(estimateInitialDims({ width: 200, height: 200 }, 5).cols).toBe(22)
+  })
+
+  it('honours minRows independently of width', () => {
+    // Wide but short — width yields a high cols, height clamps to minRows.
+    const { cols, rows } = estimateInitialDims({ width: 2000, height: 5 }, 7)
+    expect(cols).toBeGreaterThan(20)
+    expect(rows).toBe(7)
+  })
+})
+
+describe('shouldSnapToBottom', () => {
+  // Snap-to-bottom guards: only fire when scrolling DOWNWARD and we are
+  // within the last line of ybase but haven't reached it.
+  it('snaps when downward motion lands within 1 line of ybase', () => {
+    // ybase=100, prev=98, new=99 → newYdisp >= 99, < 100, downward → snap
+    expect(shouldSnapToBottom(98, 99, 100)).toBe(true)
+  })
+
+  it('does not snap when at ybase exactly (already at bottom)', () => {
+    // newYdisp === ybase — we're already at the bottom; no snap needed.
+    expect(shouldSnapToBottom(99, 100, 100)).toBe(false)
+  })
+
+  it('does not snap on upward motion', () => {
+    // User scrolling up (newYdisp < prevYdisp) — leave them alone.
+    expect(shouldSnapToBottom(99, 98, 100)).toBe(false)
+  })
+
+  it('does not snap if more than 1 line away from ybase', () => {
+    // newYdisp=50, ybase=100 — far from bottom; don't snap.
+    expect(shouldSnapToBottom(40, 50, 100)).toBe(false)
+  })
+
+  it('does not snap when stationary', () => {
+    expect(shouldSnapToBottom(99, 99, 100)).toBe(false)
+  })
+
+  it('snaps for ybase=0 corner case (no scrollback)', () => {
+    // ybase=0 means there's no scrollback yet. The guard newYdisp >= ybase-1
+    // becomes newYdisp >= -1, which is always true; downward motion + < 0 is
+    // impossible, so we never snap. Documenting the safe behavior.
+    expect(shouldSnapToBottom(0, 0, 0)).toBe(false)
+  })
+})

--- a/src/xterm-utils.ts
+++ b/src/xterm-utils.ts
@@ -1,0 +1,34 @@
+// Pure helpers for the xterm lifecycle that the useXterm hook drives. Kept
+// separate from useXterm.ts so they can be unit-tested without pulling
+// xterm.js (which references the browser `self` global at import time and
+// blows up under Vitest's default node environment).
+
+// Estimate cols/rows from a container's bounding rect so the xterm renderer
+// has sane initial dimensions before FitAddon refines them on first paint.
+// The 12px padding / 8.5px-per-col / 17px-per-row constants come from the
+// rendered font; they're approximations, not exact, and the immediate
+// FitAddon call corrects any drift.
+export function estimateInitialDims(
+  rect: { width: number; height: number },
+  minRows: number,
+): { cols: number; rows: number } {
+  return {
+    cols: Math.max(20, Math.floor((rect.width - 12) / 8.5)),
+    rows: Math.max(minRows, Math.floor((rect.height - 12) / 17)),
+  }
+}
+
+// xterm's pixel rounding can leave the scrollbar one line short of ybase
+// when the user scrolls down after new output arrived while they were
+// scrolled up. When the viewport advances downward to within 1 line of
+// ybase, snap all the way so the final line stays reachable.
+//
+// We only snap on downward motion (newYdisp > prevYdisp) so the user can
+// still scroll up from the bottom without being yanked back.
+export function shouldSnapToBottom(
+  prevYdisp: number,
+  newYdisp: number,
+  ybase: number,
+): boolean {
+  return newYdisp > prevYdisp && newYdisp >= ybase - 1 && newYdisp < ybase
+}


### PR DESCRIPTION
## Summary
\`TerminalView\` and \`BottomTerminal\` were ~95% line-for-line duplicates. Extract a single \`useXterm\` hook that owns the full lifecycle; variants pass an \`XtermBehavior\` record describing the differences.

**Variant deltas (now isolated to ~12 lines per component):**

| | TerminalView | BottomTerminal |
|---|---|---|
| IPC | \`sendInput\` / \`resize\` | \`sendShellInput\` / \`resizeShell\` |
| \`minRows\` | 5 | 3 |
| Shift+Enter intercept | yes (kitty form for newline) | no |
| Refocus + jump-to-bottom on activate | yes | no |
| \`logTag\` | \`terminal\` | \`bottom-terminal\` |

**Result:**
- \`TerminalView.tsx\`: 248 → 41 LOC
- \`BottomTerminal.tsx\`: 213 → 41 LOC
- New \`src/useXterm.ts\`: lifecycle owner (lazy-init, ResizeObserver, dispose)
- New \`src/xterm-utils.ts\`: pure helpers (\`estimateInitialDims\`, \`shouldSnapToBottom\`)
- \`TerminalEntry\` moved from \`App.tsx\` to \`useXterm.ts\` (consumers update one import)

The pure helpers live in their own module so Vitest can test them under the default node environment — \`@xterm/xterm\` and \`@xterm/addon-fit\` reference the browser \`self\` at import time, so any test importing from \`useXterm.ts\` directly would need \`jsdom\`/\`happy-dom\`.

## Tests
11 new cases in \`src/xterm-utils.test.ts\`:
- \`estimateInitialDims\`: typical (92×22 from 800×400), cols-clamp, rows-clamp, fractional flooring, minRows independent of width
- \`shouldSnapToBottom\`: downward-near-bottom snap, at-bottom no-snap, upward no-snap, far-from-bottom no-snap, stationary no-snap, ybase=0 corner case

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm test\` (63/63, +11 from main)
- [x] \`npm run build\` (renderer: 460.04 KB → 458.37 KB)
- [ ] Manual smoke (caller): primary terminal — Shift+Enter inserts newline; click switching sessions refocuses bottom-of-buffer; Ctrl+V doesn't double-paste. Bottom terminal — keeps scroll position across switches; same paste behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)