### PR TITLE
fix: seed initial session status so sidebar dots reflect busy state

### DIFF
--- a/electron/main.test.ts
+++ b/electron/main.test.ts
@@ -37,7 +37,7 @@ vi.mock('electron', () => ({
 vi.mock('@lydell/node-pty', () => ({ spawn: () => ({}) }))
 vi.mock('node:child_process', () => ({ spawn: () => ({}) }))
 
-import { buildClaudeArgs, resizePty } from './main'
+import { buildClaudeArgs, resizePty, shouldEmitStatus } from './main'
 
 const BASE = {
   sessionId: 'test-session-id',
@@ -152,5 +152,35 @@ describe('resizePty', () => {
       resize: () => { throw new Error('pty exited') },
     }
     expect(() => resizePty(t, 80, 24)).not.toThrow()
+  })
+})
+
+// Regression: pre-fix, sessions starting at 'working' that first reported
+// 'busy' (which maps to 'working') would never emit a 'session:status'
+// event, leaving the sidebar dot stuck at the renderer's 'idle' default.
+// shouldEmitStatus forces the first emission so the renderer is seeded.
+describe('shouldEmitStatus', () => {
+  it('emits the very first call regardless of equality', () => {
+    const emitted = new Set<string>()
+    expect(shouldEmitStatus(emitted, 'a', 'working', 'working')).toBe(true)
+  })
+
+  it('suppresses repeated equal calls after the first', () => {
+    const emitted = new Set<string>(['a'])
+    expect(shouldEmitStatus(emitted, 'a', 'working', 'working')).toBe(false)
+  })
+
+  it('emits when the status changes after a previous emission', () => {
+    const emitted = new Set<string>(['a'])
+    expect(shouldEmitStatus(emitted, 'a', 'working', 'idle')).toBe(true)
+    expect(shouldEmitStatus(emitted, 'a', 'idle', 'awaiting')).toBe(true)
+    expect(shouldEmitStatus(emitted, 'a', 'awaiting', 'failed')).toBe(true)
+  })
+
+  it('treats each session id independently', () => {
+    // Session "a" already seeded; session "b" hasn't been emitted yet.
+    const emitted = new Set<string>(['a'])
+    expect(shouldEmitStatus(emitted, 'a', 'working', 'working')).toBe(false)
+    expect(shouldEmitStatus(emitted, 'b', 'working', 'working')).toBe(true)
   })
 })

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -93,9 +93,32 @@ function stripAnsi(s: string): string {
 // Status management
 // ---------------------------------------------------------------------------
 
+// Tracks which session ids have had at least one 'session:status' event sent
+// to the renderer. Without this, sessions whose first observed status equals
+// the initial 'working' default would never emit (the equality check below
+// would suppress a no-op transition), and the renderer would default the
+// dot to 'idle' (green) for active sessions stuck busy. Cleared in
+// killAllSessions and on session removal.
+const statusEmitted = new Set<string>()
+
+// Pure decision: should this transition produce a 'session:status' IPC
+// emission? Forces the very first emission per session id so the renderer
+// has a seeded value, then suppresses no-op (equal) transitions.
+//
+// Exported only for tests.
+export function shouldEmitStatus(
+  emitted: ReadonlySet<string>,
+  sessionId: string,
+  current: SessionStatus,
+  next: SessionStatus,
+): boolean {
+  return !emitted.has(sessionId) || current !== next
+}
+
 function setStatus(session: Session, next: SessionStatus) {
-  if (session.status === next) return
+  if (!shouldEmitStatus(statusEmitted, session.id, session.status, next)) return
   session.status = next
+  statusEmitted.add(session.id)
   mainWindow?.webContents.send('session:status', { id: session.id, status: next })
 }
 
@@ -570,6 +593,12 @@ function createSessionInternal(opts: {
   sessions.set(id, session)
   persistSessions()
 
+  // Seed the renderer with the initial status so the sidebar dot doesn't
+  // default to 'idle' (green) while the session is actually working. The
+  // first-emit force in setStatus handles cases where the first JSONL
+  // reading happens to equal the initial 'working' default.
+  setStatus(session, session.status)
+
   // Watch the Claude Code JSONL file for ground-truth status updates. The
   // file is created by Claude Code shortly after startup; the watcher polls
   // and will begin emitting once the file appears.
@@ -611,6 +640,7 @@ function createSessionInternal(opts: {
       // already dead
     }
     sessions.delete(id)
+    statusEmitted.delete(id)
     persistSessions()
   })
 
@@ -731,6 +761,7 @@ function killAllSessions() {
     }
   }
   sessions.clear()
+  statusEmitted.clear()
 }
 
 // Renderer signals readiness via 'app:ready' once it has subscribed to
@@ -901,6 +932,7 @@ app.whenReady().then(async () => {
       // already dead
     }
     sessions.delete(payload.id)
+    statusEmitted.delete(payload.id)
     persistSessions()
   })
 


### PR DESCRIPTION
## Summary
The activity dot in the sidebar gets stuck on green/idle for any session that starts busy and stays busy. Confirmed against \`~/.claude/sessions/\` — claude is writing the JSONL files correctly with \`status:"busy"\`, but the renderer never sees them.

**Root cause** (regression from #35):
1. \`createSessionInternal\` initializes \`session.status = 'working'\`.
2. JSONL watcher polls, reads \`status:"busy"\` → maps to \`'working'\`.
3. \`setStatus\` is called with current \`'working'\` and next \`'working'\` → \`if (session.status === next) return\` bails out.
4. Renderer never receives a \`'session:status'\` event for that session id.
5. \`Sidebar.tsx\`: \`statuses[s.id] ?? 'idle'\` renders the green idle dot.
6. Status only updates when claude transitions OUT of busy (e.g. → idle). Long-running busy sessions never refresh.

The pre-#35 regex heuristics emitted aggressively and accidentally seeded the renderer; the change-only emit policy added in #35 didn't.

## Fix
- Track per-session whether \`session:status\` has been emitted yet (\`statusEmitted: Set<string>\`).
- \`setStatus\` forces the first emission per session id regardless of equality, then suppresses no-op transitions afterwards.
- Call \`setStatus(session, session.status)\` right after \`sessions.set(id, session)\` so the renderer is seeded immediately (not just when the JSONL watcher first runs).
- Clear \`statusEmitted\` entries on session delete (close, exit, \`killAllSessions\`) so id reuse can't carry stale state.

## Tests
4 new cases in \`electron/main.test.ts\` against a \`shouldEmitStatus\` pure helper:
- First emission forced regardless of equality
- Repeated equal calls suppressed after seeding
- Real transitions emit (working → idle, idle → awaiting, awaiting → failed)
- Session ids are independent

\`shouldEmitStatus\` is exported only for tests.

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm test\` (56/56, +4)
- [x] \`npm run build\`
- [ ] Manual smoke (caller): start the app with the orchestrator session config, watch claude actually do something, confirm the sidebar dot turns blue (working) and goes green (idle) when it finishes. Repeat with a session that's been running busy across an app restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)