### PR TITLE
refactor: extract useSessions + useSplitLayout hooks from App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,240 +1,44 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { TitleBar } from './TitleBar'
 import { Sidebar } from './Sidebar'
 import { TerminalView } from './TerminalView'
 import { BottomTerminal } from './BottomTerminal'
 import { RightPanel } from './RightPanel'
 import { UsageModal } from './UsageModal'
-import type { Session, SessionStatus } from './types'
+import type { Session } from './types'
 import type { TerminalEntry } from './useXterm'
-import {
-  clampHeight,
-  readPersistedHeight,
-  BOTTOM_MIN_HEIGHT,
-  BOTTOM_MAX_FRACTION,
-  BOTTOM_DEFAULT_HEIGHT,
-  BOTTOM_HEIGHT_STORAGE_KEY,
-} from './layout'
+import { useSessions } from './useSessions'
+import { useSplitLayout } from './useSplitLayout'
 
 export default function App() {
-  const [sessions, setSessions] = useState<Session[]>([])
-  const [statuses, setStatuses] = useState<Record<string, SessionStatus>>({})
-  const [activeId, setActiveId] = useState<string | null>(null)
-  const [showUsage, setShowUsage] = useState(false)
-  // Primary (claude) PTY xterm instances, keyed by session id.
+  // Primary (claude) PTY xterm instances, keyed by session id. Owned here
+  // because both useSessions (for dispose-on-remove) and TerminalView /
+  // BottomTerminal (for lifecycle) need to share them.
   const termsRef = useRef(new Map<string, TerminalEntry>())
   const pendingDataRef = useRef(new Map<string, string[]>())
-  // Parallel state for the docked bottom shell terminals. Same map shape,
-  // keyed by the same session id, but wired to the shell PTY channel.
+  // Parallel state for the docked bottom shell terminals.
   const shellTermsRef = useRef(new Map<string, TerminalEntry>())
   const shellPendingDataRef = useRef(new Map<string, string[]>())
 
-  // Bottom terminal height — persisted across restarts via localStorage.
-  const [bottomHeight, setBottomHeight] = useState<number>(() =>
-    readPersistedHeight(BOTTOM_DEFAULT_HEIGHT),
-  )
-  // Ref so the mousemove handler always reads the latest height without needing
-  // to be re-registered on every height change.
-  const bottomHeightRef = useRef(bottomHeight)
-  // The container that holds .main-top + divider + .main-bottom. We need its
-  // bounding rect to compute the max allowed height during drag.
-  const mainContainerRef = useRef<HTMLElement>(null)
-  // isDragging is a ref (not state) to avoid re-renders during drag.
-  const isDraggingRef = useRef(false)
+  const {
+    sessions,
+    statuses,
+    activeId,
+    setActiveId,
+    closeSession,
+    renameSession,
+    newSession,
+  } = useSessions({
+    termsRef,
+    pendingDataRef,
+    shellTermsRef,
+    shellPendingDataRef,
+  })
 
-  useEffect(() => {
-    const offData = window.termhub.onData((id, data) => {
-      const entry = termsRef.current.get(id)
-      if (entry) {
-        entry.term.write(data)
-      } else {
-        const queue = pendingDataRef.current.get(id) ?? []
-        queue.push(data)
-        pendingDataRef.current.set(id, queue)
-      }
-    })
-    const offShellData = window.termhub.onShellData((id, data) => {
-      const entry = shellTermsRef.current.get(id)
-      if (entry) {
-        entry.term.write(data)
-      } else {
-        const queue = shellPendingDataRef.current.get(id) ?? []
-        queue.push(data)
-        shellPendingDataRef.current.set(id, queue)
-      }
-    })
-    const offExit = window.termhub.onExit((id, exitCode) => {
-      // Keep failed sessions visible so the red status dot is observable.
-      // They can still be dismissed via the × button. Clean exits remove
-      // the row immediately as before.
-      if (exitCode === 0) {
-        removeSession(id)
-      }
-    })
-    const offStatus = window.termhub.onStatusChanged((id, status) => {
-      setStatuses((prev) =>
-        prev[id] === status ? prev : { ...prev, [id]: status },
-      )
-    })
-    // Shell PTY exiting independently (user typed `exit`) doesn't tear the
-    // session down — only the primary exit does. We still drop the xterm
-    // instance so a future re-init could replace it, but v1 doesn't respawn.
-    const offShellExit = window.termhub.onShellExit((id) => {
-      const entry = shellTermsRef.current.get(id)
-      if (entry) {
-        entry.term.dispose()
-        shellTermsRef.current.delete(id)
-      }
-      shellPendingDataRef.current.delete(id)
-    })
-    const offAdded = window.termhub.onSessionAdded(
-      (id, cwd, autoActivate, command, name, repoRoot, repoLabel) => {
-        setSessions((prev) =>
-          prev.some((s) => s.id === id)
-            ? prev
-            : [...prev, { id, cwd, command, name, repoRoot, repoLabel }],
-        )
-        if (autoActivate) {
-          setActiveId((curr) => curr ?? id)
-        }
-      },
-    )
+  const { bottomHeight, mainContainerRef, handleDividerMouseDown } =
+    useSplitLayout()
 
-    // Catch up with any sessions main already created (resumed/startup) before
-    // our listeners were attached, then signal that we're ready so main can
-    // create the rest.
-    void window.termhub.listSessions().then((existing) => {
-      if (existing.length > 0) {
-        setSessions((prev) => {
-          const seen = new Set(prev.map((s) => s.id))
-          return [...prev, ...existing.filter((s) => !seen.has(s.id)).map((s) => ({
-            id: s.id,
-            cwd: s.cwd,
-            command: s.command,
-            name: s.name,
-            repoRoot: s.repoRoot,
-            repoLabel: s.repoLabel,
-          }))]
-        })
-        setActiveId((curr) => curr ?? existing[0].id)
-      }
-      window.termhub.appReady()
-    })
-
-    return () => {
-      offData()
-      offShellData()
-      offExit()
-      offStatus()
-      offShellExit()
-      offAdded()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  const removeSession = useCallback((id: string) => {
-    const entry = termsRef.current.get(id)
-    if (entry) {
-      entry.term.dispose()
-      termsRef.current.delete(id)
-    }
-    const shellEntry = shellTermsRef.current.get(id)
-    if (shellEntry) {
-      shellEntry.term.dispose()
-      shellTermsRef.current.delete(id)
-    }
-    shellPendingDataRef.current.delete(id)
-    setSessions((prev) => prev.filter((s) => s.id !== id))
-    setStatuses((prev) => {
-      if (!(id in prev)) return prev
-      const next = { ...prev }
-      delete next[id]
-      return next
-    })
-    setActiveId((curr) => {
-      if (curr !== id) return curr
-      // Pick the next remaining session, if any
-      const remaining = Array.from(termsRef.current.keys())
-      return remaining[0] ?? null
-    })
-  }, [])
-
-  const closeSession = useCallback(
-    (id: string) => {
-      window.termhub.close(id)
-      removeSession(id)
-    },
-    [removeSession],
-  )
-
-  const renameSession = useCallback(async (id: string, name: string) => {
-    try {
-      await window.termhub.renameSession(id, name)
-      setSessions((prev) =>
-        prev.map((s) => (s.id === id ? { ...s, name: name.trim() || undefined } : s)),
-      )
-    } catch (err) {
-      console.error('[termhub] renameSession failed:', err)
-    }
-  }, [])
-
-  const newSession = useCallback(async () => {
-    try {
-      const cwd = await window.termhub.pickFolder()
-      if (!cwd) return
-      const s = await window.termhub.createSession(cwd)
-      setSessions((prev) => [...prev, s])
-      setActiveId(s.id)
-    } catch (err) {
-      console.error('[termhub] newSession failed:', err)
-      alert(`Failed to create session:\n${err instanceof Error ? err.message : String(err)}`)
-    }
-  }, [])
-
-  // Keep ref in sync with state so the mousemove closure always sees the
-  // latest value without needing to be re-registered.
-  useEffect(() => {
-    bottomHeightRef.current = bottomHeight
-  }, [bottomHeight])
-
-  const handleDividerMouseDown = useCallback((e: React.MouseEvent) => {
-    e.preventDefault()
-    isDraggingRef.current = true
-    document.body.style.cursor = 'row-resize'
-    document.body.style.userSelect = 'none'
-    console.info('[termhub:layout] drag start, height before:', bottomHeightRef.current)
-
-    const onMouseMove = (ev: MouseEvent) => {
-      if (!isDraggingRef.current) return
-      const container = mainContainerRef.current
-      if (!container) return
-      const rect = container.getBoundingClientRect()
-      // Height = distance from mouse Y to the bottom of the container.
-      const raw = rect.bottom - ev.clientY
-      const clamped = clampHeight(raw, BOTTOM_MIN_HEIGHT, BOTTOM_MAX_FRACTION, rect.height)
-      setBottomHeight(clamped)
-      bottomHeightRef.current = clamped
-    }
-
-    const onMouseUp = () => {
-      isDraggingRef.current = false
-      document.body.style.cursor = ''
-      document.body.style.userSelect = ''
-      window.removeEventListener('mousemove', onMouseMove)
-      window.removeEventListener('mouseup', onMouseUp)
-      const finalHeight = bottomHeightRef.current
-      console.info('[termhub:layout] drag end, final height:', finalHeight)
-      // Persist the chosen height.
-      try {
-        localStorage.setItem(BOTTOM_HEIGHT_STORAGE_KEY, String(finalHeight))
-      } catch {
-        // localStorage may be unavailable in some environments
-      }
-    }
-
-    window.addEventListener('mousemove', onMouseMove)
-    window.addEventListener('mouseup', onMouseUp)
-  }, [])
+  const [showUsage, setShowUsage] = useState(false)
 
   // Refit both terminals for the active session when the window resizes.
   useEffect(() => {
@@ -261,7 +65,8 @@ export default function App() {
     return () => window.removeEventListener('resize', onResize)
   }, [activeId])
 
-  // Refit both when active session changes (their containers just became visible)
+  // Refit both when active session changes (their containers just became
+  // visible).
   useEffect(() => {
     if (!activeId) return
     const id = activeId
@@ -347,10 +152,10 @@ export default function App() {
   )
 }
 
-// Group sessions by repo root when available, falling back to cwd.
-// The map key is the group key (repoRoot or cwd); Sidebar reads the label
-// from the first session in the group via session.repoLabel or derives it
-// from the cwd.
+// Group sessions by repo root when available, falling back to cwd. The
+// map key is the group key (repoRoot or cwd); Sidebar reads the label
+// from the first session in the group via session.repoLabel or derives
+// it from the cwd.
 function groupSessions(sessions: Session[]): Map<string, Session[]> {
   const m = new Map<string, Session[]>()
   for (const s of sessions) {

--- a/src/useSessions.ts
+++ b/src/useSessions.ts
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useState, type MutableRefObject } from 'react'
+import type { Session, SessionStatus } from './types'
+import type { TerminalEntry } from './useXterm'
+
+type SessionRefs = {
+  termsRef: MutableRefObject<Map<string, TerminalEntry>>
+  pendingDataRef: MutableRefObject<Map<string, string[]>>
+  shellTermsRef: MutableRefObject<Map<string, TerminalEntry>>
+  shellPendingDataRef: MutableRefObject<Map<string, string[]>>
+}
+
+export type UseSessionsResult = {
+  sessions: Session[]
+  statuses: Record<string, SessionStatus>
+  activeId: string | null
+  setActiveId: (id: string | null | ((prev: string | null) => string | null)) => void
+  closeSession: (id: string) => void
+  renameSession: (id: string, name: string) => Promise<void>
+  newSession: () => Promise<void>
+}
+
+// Owns the renderer-side session state and the IPC subscription wiring
+// that keeps it in sync with main. Terminal refs are owned by the
+// caller (so TerminalView / BottomTerminal can also receive them) and
+// passed in here for the dispose-on-remove path.
+//
+// On mount: subscribes to onData / onShellData / onExit / onStatusChanged
+// / onShellExit / onSessionAdded, then catches up via listSessions and
+// signals appReady so main can begin creating bootstrap sessions.
+export function useSessions(refs: SessionRefs): UseSessionsResult {
+  const { termsRef, pendingDataRef, shellTermsRef, shellPendingDataRef } = refs
+
+  const [sessions, setSessions] = useState<Session[]>([])
+  const [statuses, setStatuses] = useState<Record<string, SessionStatus>>({})
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  const removeSession = useCallback(
+    (id: string) => {
+      const entry = termsRef.current.get(id)
+      if (entry) {
+        entry.term.dispose()
+        termsRef.current.delete(id)
+      }
+      const shellEntry = shellTermsRef.current.get(id)
+      if (shellEntry) {
+        shellEntry.term.dispose()
+        shellTermsRef.current.delete(id)
+      }
+      shellPendingDataRef.current.delete(id)
+      setSessions((prev) => prev.filter((s) => s.id !== id))
+      setStatuses((prev) => {
+        if (!(id in prev)) return prev
+        const next = { ...prev }
+        delete next[id]
+        return next
+      })
+      setActiveId((curr) => {
+        if (curr !== id) return curr
+        // Pick the next remaining session, if any
+        const remaining = Array.from(termsRef.current.keys())
+        return remaining[0] ?? null
+      })
+    },
+    [termsRef, shellTermsRef, shellPendingDataRef],
+  )
+
+  useEffect(() => {
+    const offData = window.termhub.onData((id, data) => {
+      const entry = termsRef.current.get(id)
+      if (entry) {
+        entry.term.write(data)
+      } else {
+        const queue = pendingDataRef.current.get(id) ?? []
+        queue.push(data)
+        pendingDataRef.current.set(id, queue)
+      }
+    })
+    const offShellData = window.termhub.onShellData((id, data) => {
+      const entry = shellTermsRef.current.get(id)
+      if (entry) {
+        entry.term.write(data)
+      } else {
+        const queue = shellPendingDataRef.current.get(id) ?? []
+        queue.push(data)
+        shellPendingDataRef.current.set(id, queue)
+      }
+    })
+    const offExit = window.termhub.onExit((id, exitCode) => {
+      // Keep failed sessions visible so the red status dot is observable.
+      // They can still be dismissed via the × button. Clean exits remove
+      // the row immediately as before.
+      if (exitCode === 0) {
+        removeSession(id)
+      }
+    })
+    const offStatus = window.termhub.onStatusChanged((id, status) => {
+      setStatuses((prev) =>
+        prev[id] === status ? prev : { ...prev, [id]: status },
+      )
+    })
+    // Shell PTY exiting independently (user typed `exit`) doesn't tear
+    // the session down — only the primary exit does. We still drop the
+    // xterm instance so a future re-init could replace it, but v1
+    // doesn't respawn.
+    const offShellExit = window.termhub.onShellExit((id) => {
+      const entry = shellTermsRef.current.get(id)
+      if (entry) {
+        entry.term.dispose()
+        shellTermsRef.current.delete(id)
+      }
+      shellPendingDataRef.current.delete(id)
+    })
+    const offAdded = window.termhub.onSessionAdded(
+      (id, cwd, autoActivate, command, name, repoRoot, repoLabel) => {
+        setSessions((prev) =>
+          prev.some((s) => s.id === id)
+            ? prev
+            : [...prev, { id, cwd, command, name, repoRoot, repoLabel }],
+        )
+        if (autoActivate) {
+          setActiveId((curr) => curr ?? id)
+        }
+      },
+    )
+
+    // Catch up with any sessions main already created (resumed/startup)
+    // before our listeners were attached, then signal that we're ready
+    // so main can create the rest.
+    void window.termhub.listSessions().then((existing) => {
+      if (existing.length > 0) {
+        setSessions((prev) => {
+          const seen = new Set(prev.map((s) => s.id))
+          return [
+            ...prev,
+            ...existing
+              .filter((s) => !seen.has(s.id))
+              .map((s) => ({
+                id: s.id,
+                cwd: s.cwd,
+                command: s.command,
+                name: s.name,
+                repoRoot: s.repoRoot,
+                repoLabel: s.repoLabel,
+              })),
+          ]
+        })
+        setActiveId((curr) => curr ?? existing[0].id)
+      }
+      window.termhub.appReady()
+    })
+
+    return () => {
+      offData()
+      offShellData()
+      offExit()
+      offStatus()
+      offShellExit()
+      offAdded()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const closeSession = useCallback(
+    (id: string) => {
+      window.termhub.close(id)
+      removeSession(id)
+    },
+    [removeSession],
+  )
+
+  const renameSession = useCallback(async (id: string, name: string) => {
+    try {
+      await window.termhub.renameSession(id, name)
+      setSessions((prev) =>
+        prev.map((s) =>
+          s.id === id ? { ...s, name: name.trim() || undefined } : s,
+        ),
+      )
+    } catch (err) {
+      console.error('[termhub] renameSession failed:', err)
+    }
+  }, [])
+
+  const newSession = useCallback(async () => {
+    try {
+      const cwd = await window.termhub.pickFolder()
+      if (!cwd) return
+      const s = await window.termhub.createSession(cwd)
+      setSessions((prev) => [...prev, s])
+      setActiveId(s.id)
+    } catch (err) {
+      console.error('[termhub] newSession failed:', err)
+      alert(
+        `Failed to create session:\n${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
+  }, [])
+
+  return {
+    sessions,
+    statuses,
+    activeId,
+    setActiveId,
+    closeSession,
+    renameSession,
+    newSession,
+  }
+}

--- a/src/useSplitLayout.ts
+++ b/src/useSplitLayout.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  clampHeight,
+  readPersistedHeight,
+  BOTTOM_MIN_HEIGHT,
+  BOTTOM_MAX_FRACTION,
+  BOTTOM_DEFAULT_HEIGHT,
+  BOTTOM_HEIGHT_STORAGE_KEY,
+} from './layout'
+
+export type UseSplitLayoutResult = {
+  // Current bottom-pane pixel height. Drives flexBasis on the .main-bottom div.
+  bottomHeight: number
+  // Ref to attach to the container element holding .main-top + divider +
+  // .main-bottom. We need its bounding rect during drag to compute the
+  // max allowed height and clamp.
+  mainContainerRef: React.MutableRefObject<HTMLElement | null>
+  // onMouseDown handler for the divider — installs window-level move/up
+  // listeners that drag the height and persist on release.
+  handleDividerMouseDown: (e: React.MouseEvent) => void
+}
+
+// Owns the resizable terminal split: persisted bottom-pane height,
+// the container ref, and the divider drag handlers. The drag is run
+// off-state via a ref so mousemove doesn't trigger re-renders; the
+// committed height is persisted to localStorage on mouseup.
+export function useSplitLayout(): UseSplitLayoutResult {
+  const [bottomHeight, setBottomHeight] = useState<number>(() =>
+    readPersistedHeight(BOTTOM_DEFAULT_HEIGHT),
+  )
+  // Ref so the mousemove handler always reads the latest height without
+  // needing to be re-registered on every height change.
+  const bottomHeightRef = useRef(bottomHeight)
+  // The container that holds .main-top + divider + .main-bottom.
+  const mainContainerRef = useRef<HTMLElement | null>(null)
+  // isDragging is a ref (not state) to avoid re-renders during drag.
+  const isDraggingRef = useRef(false)
+
+  // Keep ref in sync with state so the mousemove closure always sees the
+  // latest value without needing to be re-registered.
+  useEffect(() => {
+    bottomHeightRef.current = bottomHeight
+  }, [bottomHeight])
+
+  const handleDividerMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    isDraggingRef.current = true
+    document.body.style.cursor = 'row-resize'
+    document.body.style.userSelect = 'none'
+    console.info(
+      '[termhub:layout] drag start, height before:',
+      bottomHeightRef.current,
+    )
+
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!isDraggingRef.current) return
+      const container = mainContainerRef.current
+      if (!container) return
+      const rect = container.getBoundingClientRect()
+      // Height = distance from mouse Y to the bottom of the container.
+      const raw = rect.bottom - ev.clientY
+      const clamped = clampHeight(
+        raw,
+        BOTTOM_MIN_HEIGHT,
+        BOTTOM_MAX_FRACTION,
+        rect.height,
+      )
+      setBottomHeight(clamped)
+      bottomHeightRef.current = clamped
+    }
+
+    const onMouseUp = () => {
+      isDraggingRef.current = false
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+      window.removeEventListener('mousemove', onMouseMove)
+      window.removeEventListener('mouseup', onMouseUp)
+      const finalHeight = bottomHeightRef.current
+      console.info('[termhub:layout] drag end, final height:', finalHeight)
+      // Persist the chosen height.
+      try {
+        localStorage.setItem(BOTTOM_HEIGHT_STORAGE_KEY, String(finalHeight))
+      } catch {
+        // localStorage may be unavailable in some environments
+      }
+    }
+
+    window.addEventListener('mousemove', onMouseMove)
+    window.addEventListener('mouseup', onMouseUp)
+  }, [])
+
+  return { bottomHeight, mainContainerRef, handleDividerMouseDown }
+}


### PR DESCRIPTION
## Summary
App.tsx had grown to 363 LOC owning four loosely-related concerns: session state + IPC subscription wiring, terminal-instance refs, the resizable split divider drag, and the layout composition. The two non-presentational concerns are now their own hooks; App.tsx is back to composition + the refit-on-active-switch effects.

**App.tsx: 363 → 168 LOC (-54%).**

## New hooks

| File | LOC | Owns |
|---|---|---|
| \`src/useSessions.ts\` | 208 | sessions / statuses / activeId state, all the IPC subscription wiring (\`onData\` / \`onShellData\` / \`onExit\` / \`onStatusChanged\` / \`onShellExit\` / \`onSessionAdded\`), catch-up via \`listSessions\`, \`appReady\` signal, and the \`closeSession\` / \`renameSession\` / \`newSession\` callbacks. Terminal refs are passed in (the caller still owns them so \`TerminalView\` and \`BottomTerminal\` can receive them too) and used by the dispose-on-remove path. |
| \`src/useSplitLayout.ts\` | 93 | bottomHeight + localStorage persistence + divider drag handler. Returns \`mainContainerRef\` so App.tsx can attach it to the split container. |

## What stays in App.tsx
- Terminal-instance refs (passed to both useSessions and TerminalView/BottomTerminal — single source of truth for xterm lifecycle)
- \`showUsage\` modal state
- Refit-on-window-resize and refit-on-active-switch effects — they touch both the active id from useSessions and the terminal refs App.tsx owns, so co-locating them with composition keeps the dependency clear
- Composition + layout

## No new tests
This refactor is behaviorally identical — a mechanical move. The hooks are tightly coupled to browser globals (window event listeners, localStorage, document.body styles) that would require a jsdom test harness to exercise. Manual smoke covers the integration; unit tests for the pure helpers (\`clampHeight\`) already exist in \`src/layout.test.ts\`.

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm test\` (98/98, no count change)
- [x] \`npm run build\`
- [ ] Manual smoke (caller): all session lifecycle works (open from sidebar +, close via × button, rename via context menu, status dot updates), divider drag still resizes + persists across restart, MCP \`open_session\` still wires up the new session in the sidebar with status updates flowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)