### PR TITLE
feat: track PRs for each session's branch and surface them in the right panel

### DIFF
--- a/electron/ipc-pr.ts
+++ b/electron/ipc-pr.ts
@@ -1,0 +1,177 @@
+// IPC handlers and poll loop for per-session PR tracking.
+// Fetches PR data via the `gh` CLI and emits 'session:pr' events to the
+// renderer whenever the PR state changes.
+
+import { ipcMain, BrowserWindow } from 'electron'
+import {
+  getSession,
+  getAllSessions,
+  onSessionCreatedHook,
+  onSessionClosedHook,
+} from './session-manager'
+import {
+  buildCacheKey,
+  fetchGhPrList,
+  getGitBranch,
+  runGhPrMerge,
+} from './pr-fetch'
+import type { SessionPr } from '../src/types'
+
+// In-memory PR cache keyed by `${cwd}::${branch}`.
+const prCache = new Map<string, SessionPr | null>()
+
+// Per-session poll timer handles. Keyed by session id.
+const pollTimers = new Map<string, ReturnType<typeof setInterval>>()
+
+let mainWindow: BrowserWindow | null = null
+
+export function setMainWindowForPr(window: BrowserWindow | null): void {
+  mainWindow = window
+}
+
+function emitPrChanged(sessionId: string, pr: SessionPr | null): void {
+  mainWindow?.webContents.send('session:pr', { id: sessionId, pr })
+}
+
+/**
+ * Fetch the PR for the active session, update the cache, and emit an event
+ * if the value changed.
+ */
+async function fetchAndCachePr(sessionId: string): Promise<void> {
+  const session = getSession(sessionId)
+  if (!session) return
+
+  let branch: string
+  try {
+    branch = await getGitBranch(session.cwd)
+  } catch (err) {
+    console.warn(`[termhub:pr] session ${sessionId.slice(0, 8)}: cannot determine branch:`, err instanceof Error ? err.message : String(err))
+    return
+  }
+
+  const cacheKey = buildCacheKey(session.cwd, branch)
+  console.info(`[termhub:pr] fetching PR for session ${sessionId.slice(0, 8)} (branch=${branch})`)
+
+  let prs: SessionPr[]
+  try {
+    prs = await fetchGhPrList(session.cwd, branch)
+  } catch (err) {
+    console.warn(`[termhub:pr] session ${sessionId.slice(0, 8)}: gh pr list failed:`, err instanceof Error ? err.message : String(err))
+    return
+  }
+
+  const pr = prs.length > 0 ? prs[0] : null
+  const previous = prCache.get(cacheKey)
+
+  // Only emit and log if the value changed (shallow compare by JSON).
+  const changed =
+    previous === undefined ||
+    JSON.stringify(previous) !== JSON.stringify(pr)
+
+  if (changed) {
+    prCache.set(cacheKey, pr)
+    console.info(
+      `[termhub:pr] session ${sessionId.slice(0, 8)}: PR state changed →`,
+      pr ? `#${pr.number} ${pr.state} ci=${pr.ciState}` : 'no PR',
+    )
+    emitPrChanged(sessionId, pr)
+  }
+}
+
+/** Start the 30-second poll loop for a session. Idempotent. */
+function startPollLoop(sessionId: string): void {
+  if (pollTimers.has(sessionId)) return
+  // Kick off an immediate fetch, then schedule a recurring poll.
+  void fetchAndCachePr(sessionId)
+  const timer = setInterval(() => {
+    const session = getSession(sessionId)
+    if (!session) {
+      stopPollLoop(sessionId)
+      return
+    }
+    void fetchAndCachePr(sessionId)
+  }, 30_000)
+  pollTimers.set(sessionId, timer)
+}
+
+/** Stop the poll loop for a session (called when session closes). */
+export function stopPollLoop(sessionId: string): void {
+  const timer = pollTimers.get(sessionId)
+  if (timer !== undefined) {
+    clearInterval(timer)
+    pollTimers.delete(sessionId)
+  }
+}
+
+export function registerPrHandlers(): void {
+  // Renderer requests the current PR for a session (on-demand refresh).
+  ipcMain.handle('session:pr:get', async (_event, payload: { id: string }) => {
+    const session = getSession(payload.id)
+    if (!session) return null
+
+    // Try to return from cache first; if not cached, fetch now.
+    let branch: string
+    try {
+      branch = await getGitBranch(session.cwd)
+    } catch {
+      return null
+    }
+
+    const cacheKey = buildCacheKey(session.cwd, branch)
+    if (prCache.has(cacheKey)) {
+      return prCache.get(cacheKey) ?? null
+    }
+
+    // Not in cache — fetch synchronously for this IPC call.
+    await fetchAndCachePr(payload.id)
+    return prCache.get(cacheKey) ?? null
+  })
+
+  // Renderer triggers a squash merge.
+  ipcMain.handle(
+    'session:pr:merge',
+    async (_event, payload: { id: string; prNumber: number }) => {
+      const session = getSession(payload.id)
+      if (!session) throw new Error(`Session not found: ${payload.id}`)
+
+      console.info(
+        `[termhub:pr] merge initiated — session ${payload.id.slice(0, 8)} PR #${payload.prNumber}`,
+      )
+      try {
+        await runGhPrMerge(session.cwd, payload.prNumber)
+        console.info(
+          `[termhub:pr] merge success — session ${payload.id.slice(0, 8)} PR #${payload.prNumber}`,
+        )
+      } catch (err) {
+        console.error(
+          `[termhub:pr] merge failed — session ${payload.id.slice(0, 8)} PR #${payload.prNumber}:`,
+          err,
+        )
+        throw err
+      }
+
+      // Refresh PR state after merge (it will now show as merged/closed).
+      await fetchAndCachePr(payload.id)
+    },
+  )
+
+  // Start poll loops for all sessions that are currently open when handlers
+  // are first registered (covers resumed sessions).
+  for (const session of getAllSessions()) {
+    startPollLoop(session.id)
+  }
+
+  // Wire into session lifecycle so poll loops start/stop automatically.
+  onSessionCreatedHook((sessionId) => {
+    startPollLoop(sessionId)
+  })
+
+  onSessionClosedHook((sessionId) => {
+    // Stop the poll timer; this is the primary goal. Cache entries for this
+    // session's branch are stale but small — they'll be overwritten on the
+    // next fetch if the cwd gets reused. We can't prune by cwd here because
+    // the session is already removed from the sessions map by the time this
+    // callback fires.
+    stopPollLoop(sessionId)
+  })
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -25,6 +25,10 @@ import {
   registerAppHandlers,
   setMainWindow as setAppHandlersMainWindow,
 } from './ipc-app'
+import {
+  registerPrHandlers,
+  setMainWindowForPr,
+} from './ipc-pr'
 
 // Isolate dev builds so their sessions, config, and MCP port don't bleed
 // into the production instance running alongside. Must run before the
@@ -104,11 +108,13 @@ function createWindow(): void {
     mainWindow = null
     setMainWindow(null)
     setAppHandlersMainWindow(null)
+    setMainWindowForPr(null)
   })
 
   // Wire the new BrowserWindow into modules that broadcast events to it.
   setMainWindow(mainWindow)
   setAppHandlersMainWindow(mainWindow)
+  setMainWindowForPr(mainWindow)
 }
 
 // Renderer signals readiness via 'app:ready' once it has subscribed to
@@ -275,6 +281,7 @@ app.whenReady().then(async () => {
   registerSessionHandlers()
   registerDiscoveryHandlers()
   registerAppHandlers({ config })
+  registerPrHandlers()
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()

--- a/electron/pr-fetch.ts
+++ b/electron/pr-fetch.ts
@@ -1,0 +1,174 @@
+// Pure helpers for fetching and parsing GitHub PR data via the `gh` CLI.
+// No Electron or IPC dependencies — importable in tests without mocking.
+
+import { execFile } from 'node:child_process'
+import type { SessionPr } from '../src/types'
+
+// Raw shape returned by `gh pr list --json ...`
+type GhStatusCheckRollup = {
+  state: string  // e.g. 'SUCCESS', 'FAILURE', 'PENDING', 'ERROR'
+}
+
+type GhPrEntry = {
+  number: unknown
+  title: unknown
+  state: unknown
+  url: unknown
+  statusCheckRollup: unknown
+}
+
+/** Build the in-memory cache key for a given working directory + branch. */
+export function buildCacheKey(cwd: string, branch: string): string {
+  return `${cwd}::${branch}`
+}
+
+/**
+ * Map a GitHub PR state string (from `gh`) to our `SessionPr['state']`.
+ * gh returns 'OPEN', 'MERGED', 'CLOSED'.
+ */
+export function parseGhPrState(raw: string): SessionPr['state'] {
+  const upper = raw.toUpperCase()
+  if (upper === 'OPEN') return 'open'
+  if (upper === 'MERGED') return 'merged'
+  return 'closed'
+}
+
+/**
+ * Map the statusCheckRollup array (from `gh --json statusCheckRollup`) to
+ * our coarser `ciState`.
+ *
+ * gh's rollup entries each have a `state` property. We look at all entries:
+ *   - any 'FAILURE' or 'ERROR'      → 'failure'
+ *   - any 'PENDING' or 'IN_PROGRESS'→ 'pending'
+ *   - all 'SUCCESS'                 → 'success'
+ *   - empty array                   → null (no CI configured)
+ */
+export function parseGhCiState(
+  rollup: unknown,
+): SessionPr['ciState'] {
+  if (!Array.isArray(rollup) || rollup.length === 0) return null
+  let anyPending = false
+  for (const entry of rollup as GhStatusCheckRollup[]) {
+    if (typeof entry.state !== 'string') continue
+    const s = entry.state.toUpperCase()
+    if (s === 'FAILURE' || s === 'ERROR' || s === 'TIMED_OUT') return 'failure'
+    if (s === 'PENDING' || s === 'IN_PROGRESS' || s === 'QUEUED' || s === 'WAITING') {
+      anyPending = true
+    }
+  }
+  return anyPending ? 'pending' : 'success'
+}
+
+/**
+ * Parse the raw JSON array from `gh pr list --json number,title,state,url,statusCheckRollup`
+ * into `SessionPr[]`. Returns an empty array on any parse failure.
+ */
+export function parseGhPrListOutput(raw: string): SessionPr[] {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return []
+  }
+  if (!Array.isArray(parsed)) return []
+  const results: SessionPr[] = []
+  for (const entry of parsed as GhPrEntry[]) {
+    if (
+      typeof entry.number !== 'number' ||
+      typeof entry.title !== 'string' ||
+      typeof entry.state !== 'string' ||
+      typeof entry.url !== 'string'
+    ) {
+      continue
+    }
+    results.push({
+      number: entry.number,
+      title: entry.title,
+      state: parseGhPrState(entry.state),
+      url: entry.url,
+      ciState: parseGhCiState(entry.statusCheckRollup),
+    })
+  }
+  return results
+}
+
+/**
+ * Predicate: should the Merge button be enabled?
+ * Only allow merging when CI is confirmed green.
+ */
+export function isMergeEnabled(pr: SessionPr): boolean {
+  return pr.state === 'open' && pr.ciState === 'success'
+}
+
+/**
+ * Resolve the current git branch for the given working directory.
+ * Rejects if git is unavailable or cwd is not a git repo.
+ */
+export function getGitBranch(cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'git',
+      ['-C', cwd, 'rev-parse', '--abbrev-ref', 'HEAD'],
+      { shell: false },
+      (err, stdout, stderr) => {
+        if (err) {
+          reject(new Error(`git rev-parse failed: ${stderr.trim() || err.message}`))
+          return
+        }
+        const branch = stdout.trim()
+        if (!branch || branch === 'HEAD') {
+          reject(new Error(`detached HEAD or no branch in ${cwd}`))
+          return
+        }
+        resolve(branch)
+      },
+    )
+  })
+}
+
+/**
+ * Run `gh pr list` for the given branch from the given cwd.
+ * Rejects if gh is unavailable.
+ */
+export function fetchGhPrList(cwd: string, branch: string): Promise<SessionPr[]> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'gh',
+      [
+        'pr', 'list',
+        '--head', branch,
+        '--json', 'number,title,state,url,statusCheckRollup',
+        '--limit', '5',
+      ],
+      { cwd, shell: false },
+      (err, stdout, stderr) => {
+        if (err) {
+          reject(new Error(`gh pr list failed: ${stderr.trim() || err.message}`))
+          return
+        }
+        resolve(parseGhPrListOutput(stdout))
+      },
+    )
+  })
+}
+
+/**
+ * Spawn `gh pr merge <number> --squash --delete-branch` in the given cwd.
+ * Resolves on success, rejects on failure.
+ */
+export function runGhPrMerge(cwd: string, prNumber: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'gh',
+      ['pr', 'merge', String(prNumber), '--squash', '--delete-branch'],
+      { cwd, shell: false },
+      (err, _stdout, stderr) => {
+        if (err) {
+          reject(new Error(`gh pr merge failed: ${stderr.trim() || err.message}`))
+          return
+        }
+        resolve()
+      },
+    )
+  })
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron'
 import type {
   AgentDef,
   Config,
+  SessionPr,
   SessionStatus,
   SkillDef,
 } from '../src/types'
@@ -9,6 +10,7 @@ import type {
 type DataPayload = { id: string; data: string }
 type ExitPayload = { id: string; exitCode: number }
 type StatusPayload = { id: string; status: SessionStatus }
+type PrPayload = { id: string; pr: SessionPr | null }
 type AddedPayload = {
   id: string
   cwd: string
@@ -158,6 +160,23 @@ const api = {
 
   openExternal: (url: string): void => {
     ipcRenderer.send('open-external', url)
+  },
+
+  getSessionPr: (sessionId: string): Promise<SessionPr | null> =>
+    ipcRenderer.invoke('session:pr:get', { id: sessionId }),
+
+  mergeSessionPr: (sessionId: string, prNumber: number): Promise<void> =>
+    ipcRenderer.invoke('session:pr:merge', { id: sessionId, prNumber }),
+
+  onSessionPrChanged: (
+    cb: (sessionId: string, pr: SessionPr | null) => void,
+  ): (() => void) => {
+    const handler = (_e: Electron.IpcRendererEvent, p: PrPayload) =>
+      cb(p.id, p.pr)
+    ipcRenderer.on('session:pr', handler)
+    return () => {
+      ipcRenderer.off('session:pr', handler)
+    }
   },
 }
 

--- a/electron/session-manager.ts
+++ b/electron/session-manager.ts
@@ -67,6 +67,19 @@ export function setMainWindow(window: BrowserWindow | null): void {
   mainWindow = window
 }
 
+// Lifecycle callbacks registered by other modules (e.g. ipc-pr) to react
+// to session creation and closure without creating circular imports.
+const sessionCreatedCallbacks: Array<(id: string) => void> = []
+const sessionClosedCallbacks: Array<(id: string) => void> = []
+
+export function onSessionCreatedHook(cb: (id: string) => void): void {
+  sessionCreatedCallbacks.push(cb)
+}
+
+export function onSessionClosedHook(cb: (id: string) => void): void {
+  sessionClosedCallbacks.push(cb)
+}
+
 // Pure decision: should this transition produce a 'session:status' IPC
 // emission? Forces the very first emission per session id so the
 // renderer has a seeded value, then suppresses no-op (equal) transitions.
@@ -137,6 +150,7 @@ export function persistSessions(): void {
 export function deleteSession(id: string): void {
   sessions.delete(id)
   statusEmitted.delete(id)
+  for (const cb of sessionClosedCallbacks) cb(id)
 }
 
 export function createSessionInternal(opts: {
@@ -218,6 +232,9 @@ export function createSessionInternal(opts: {
   }
   sessions.set(id, session)
   persistSessions()
+
+  // Notify lifecycle listeners (e.g. ipc-pr poll loop) that a session was created.
+  for (const cb of sessionCreatedCallbacks) cb(id)
 
   // Seed the renderer with the initial status so the sidebar dot doesn't
   // default to 'idle' (green) while the session is actually working. The
@@ -328,6 +345,7 @@ export function createSessionInternal(opts: {
     }
     sessions.delete(id)
     statusEmitted.delete(id)
+    for (const cb of sessionClosedCallbacks) cb(id)
     persistSessions()
   })
 

--- a/src/RightPanel.tsx
+++ b/src/RightPanel.tsx
@@ -13,9 +13,6 @@ export function RightPanel({ activeSession }: Props) {
   return (
     <aside className="right-panel">
       <div className="right-panel-body">
-        <CollapsibleSection title="Pull Request">
-          <SessionPrPanel session={activeSession} />
-        </CollapsibleSection>
         <CollapsibleSection title="Agents">
           <AgentList />
         </CollapsibleSection>
@@ -24,6 +21,9 @@ export function RightPanel({ activeSession }: Props) {
         </CollapsibleSection>
         <CollapsibleSection title="MCP">
           <McpList session={activeSession} />
+        </CollapsibleSection>
+        <CollapsibleSection title="Pull Request">
+          <SessionPrPanel session={activeSession} />
         </CollapsibleSection>
       </div>
     </aside>

--- a/src/RightPanel.tsx
+++ b/src/RightPanel.tsx
@@ -2,6 +2,7 @@ import { CollapsibleSection } from './CollapsibleSection'
 import { AgentList } from './AgentList'
 import { SkillList } from './SkillList'
 import { McpList } from './McpList'
+import { SessionPrPanel } from './SessionPrPanel'
 import type { Session } from './types'
 
 type Props = {
@@ -12,6 +13,9 @@ export function RightPanel({ activeSession }: Props) {
   return (
     <aside className="right-panel">
       <div className="right-panel-body">
+        <CollapsibleSection title="Pull Request">
+          <SessionPrPanel session={activeSession} />
+        </CollapsibleSection>
         <CollapsibleSection title="Agents">
           <AgentList />
         </CollapsibleSection>

--- a/src/SessionPrPanel.tsx
+++ b/src/SessionPrPanel.tsx
@@ -1,0 +1,222 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { Session, SessionPr } from './types'
+import { isMergeEnabled } from './pr-utils'
+
+type Props = {
+  session: Session | null
+}
+
+type MergeDialogState = {
+  open: boolean
+  pr: SessionPr | null
+}
+
+function CiDot({ ciState }: { ciState: SessionPr['ciState'] }) {
+  if (ciState === null) return null
+  const label =
+    ciState === 'success' ? 'CI passing' :
+    ciState === 'failure' ? 'CI failing' :
+    'CI pending'
+  const cls =
+    ciState === 'success' ? 'pr-ci-dot pr-ci-success' :
+    ciState === 'failure' ? 'pr-ci-dot pr-ci-failure' :
+    'pr-ci-dot pr-ci-pending'
+  return <span className={cls} title={label} aria-label={label} />
+}
+
+function PrStateBadge({ state }: { state: SessionPr['state'] }) {
+  const cls =
+    state === 'open' ? 'pr-badge pr-badge-open' :
+    state === 'merged' ? 'pr-badge pr-badge-merged' :
+    'pr-badge pr-badge-closed'
+  return <span className={cls}>{state}</span>
+}
+
+export function SessionPrPanel({ session }: Props) {
+  const [pr, setPr] = useState<SessionPr | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [mergeDialog, setMergeDialog] = useState<MergeDialogState>({
+    open: false,
+    pr: null,
+  })
+  const [merging, setMerging] = useState(false)
+  const sessionIdRef = useRef<string | null>(null)
+
+  const fetchPr = useCallback(
+    async (id: string) => {
+      setLoading(true)
+      setError(null)
+      try {
+        const result = await window.termhub.getSessionPr(id)
+        // Guard stale responses if session changed while request was in flight.
+        if (sessionIdRef.current === id) {
+          setPr(result)
+        }
+      } catch (err) {
+        if (sessionIdRef.current === id) {
+          setError(err instanceof Error ? err.message : String(err))
+        }
+      } finally {
+        if (sessionIdRef.current === id) {
+          setLoading(false)
+        }
+      }
+    },
+    [],
+  )
+
+  // Reset and fetch when the active session changes.
+  useEffect(() => {
+    if (!session) {
+      sessionIdRef.current = null
+      setPr(null)
+      setError(null)
+      setLoading(false)
+      return
+    }
+    sessionIdRef.current = session.id
+    setPr(null)
+    setError(null)
+    void fetchPr(session.id)
+  }, [session, fetchPr])
+
+  // Subscribe to push events from the poll loop.
+  useEffect(() => {
+    const unsub = window.termhub.onSessionPrChanged((sessionId, updatedPr) => {
+      if (sessionIdRef.current === sessionId) {
+        setPr(updatedPr)
+      }
+    })
+    return unsub
+  }, [])
+
+  const handleOpenGitHub = () => {
+    if (pr?.url) window.termhub.openExternal(pr.url)
+  }
+
+  const handleMergeClick = () => {
+    if (!pr) return
+    setMergeDialog({ open: true, pr })
+  }
+
+  const handleMergeConfirm = async () => {
+    if (!session || !mergeDialog.pr) return
+    setMergeDialog((d) => ({ ...d, open: false }))
+    setMerging(true)
+    try {
+      await window.termhub.mergeSessionPr(session.id, mergeDialog.pr.number)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setMerging(false)
+    }
+  }
+
+  const handleMergeCancel = () => {
+    setMergeDialog({ open: false, pr: null })
+  }
+
+  if (!session) {
+    return <p className="hint">No active session.</p>
+  }
+
+  if (loading && pr === null) {
+    return <p className="hint">Loading…</p>
+  }
+
+  if (error) {
+    return (
+      <div>
+        <p className="hint error">{error}</p>
+        <button
+          className="pr-action-btn"
+          onClick={() => { void fetchPr(session.id) }}
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  if (pr === null) {
+    return (
+      <div>
+        <p className="hint">No PR yet for this branch.</p>
+        <button
+          className="pr-action-btn"
+          onClick={() => { void fetchPr(session.id) }}
+        >
+          Refresh
+        </button>
+      </div>
+    )
+  }
+
+  const mergeAllowed = isMergeEnabled(pr)
+  const mergeTitle = !mergeAllowed
+    ? pr.state !== 'open'
+      ? 'PR is not open'
+      : 'CI must pass before merging'
+    : undefined
+
+  return (
+    <div className="pr-panel">
+      <div className="pr-header">
+        <CiDot ciState={pr.ciState} />
+        <PrStateBadge state={pr.state} />
+        <span className="pr-number">#{pr.number}</span>
+      </div>
+      <div className="pr-title" title={pr.title}>{pr.title}</div>
+      <div className="pr-actions">
+        <button
+          className="pr-action-btn"
+          onClick={handleOpenGitHub}
+        >
+          Open in GitHub
+        </button>
+        <button
+          className="pr-action-btn pr-merge-btn"
+          onClick={handleMergeClick}
+          disabled={!mergeAllowed || merging}
+          title={mergeTitle}
+        >
+          {merging ? 'Merging…' : 'Merge'}
+        </button>
+        <button
+          className="pr-action-btn pr-refresh-btn"
+          onClick={() => { void fetchPr(session.id) }}
+          title="Refresh PR status"
+          disabled={loading}
+        >
+          {loading ? '…' : 'Refresh'}
+        </button>
+      </div>
+
+      {mergeDialog.open && mergeDialog.pr ? (
+        <div className="pr-confirm-overlay">
+          <div className="pr-confirm-dialog">
+            <p className="pr-confirm-msg">
+              Squash-merge PR #{mergeDialog.pr.number} and delete branch?
+            </p>
+            <p className="pr-confirm-title">{mergeDialog.pr.title}</p>
+            <div className="pr-confirm-actions">
+              <button
+                className="pr-action-btn pr-merge-btn"
+                onClick={() => { void handleMergeConfirm() }}
+              >
+                Confirm Merge
+              </button>
+              <button
+                className="pr-action-btn"
+                onClick={handleMergeCancel}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/pr-utils.test.ts
+++ b/src/pr-utils.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest'
+import { isMergeEnabled } from './pr-utils'
+import type { SessionPr } from './types'
+
+// The JSON parsing and cache-key helpers live in electron/pr-fetch.ts which
+// can be imported directly because it has no Electron dependencies.
+import {
+  buildCacheKey,
+  parseGhPrListOutput,
+  parseGhPrState,
+  parseGhCiState,
+} from '../electron/pr-fetch'
+
+// ---------------------------------------------------------------------------
+// buildCacheKey
+// ---------------------------------------------------------------------------
+
+describe('buildCacheKey', () => {
+  it('combines cwd and branch with :: separator', () => {
+    expect(buildCacheKey('/home/user/repo', 'feat/foo')).toBe(
+      '/home/user/repo::feat/foo',
+    )
+  })
+
+  it('is distinct for different cwds with same branch', () => {
+    const a = buildCacheKey('/repo-a', 'main')
+    const b = buildCacheKey('/repo-b', 'main')
+    expect(a).not.toBe(b)
+  })
+
+  it('is distinct for same cwd with different branches', () => {
+    const a = buildCacheKey('/repo', 'main')
+    const b = buildCacheKey('/repo', 'feat/foo')
+    expect(a).not.toBe(b)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseGhPrState
+// ---------------------------------------------------------------------------
+
+describe('parseGhPrState', () => {
+  it('maps OPEN → open', () => {
+    expect(parseGhPrState('OPEN')).toBe('open')
+  })
+
+  it('maps MERGED → merged', () => {
+    expect(parseGhPrState('MERGED')).toBe('merged')
+  })
+
+  it('maps CLOSED → closed', () => {
+    expect(parseGhPrState('CLOSED')).toBe('closed')
+  })
+
+  it('is case-insensitive', () => {
+    expect(parseGhPrState('open')).toBe('open')
+    expect(parseGhPrState('Merged')).toBe('merged')
+  })
+
+  it('falls back to closed for unknown values', () => {
+    expect(parseGhPrState('UNKNOWN')).toBe('closed')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseGhCiState
+// ---------------------------------------------------------------------------
+
+describe('parseGhCiState', () => {
+  it('returns null for empty array', () => {
+    expect(parseGhCiState([])).toBe(null)
+  })
+
+  it('returns null for non-array', () => {
+    expect(parseGhCiState(null)).toBe(null)
+    expect(parseGhCiState(undefined)).toBe(null)
+    expect(parseGhCiState('SUCCESS')).toBe(null)
+  })
+
+  it('returns success when all checks pass', () => {
+    expect(parseGhCiState([{ state: 'SUCCESS' }, { state: 'SUCCESS' }])).toBe('success')
+  })
+
+  it('returns failure when any check fails', () => {
+    expect(parseGhCiState([{ state: 'SUCCESS' }, { state: 'FAILURE' }])).toBe('failure')
+    expect(parseGhCiState([{ state: 'ERROR' }])).toBe('failure')
+    expect(parseGhCiState([{ state: 'TIMED_OUT' }])).toBe('failure')
+  })
+
+  it('failure takes precedence over pending', () => {
+    expect(parseGhCiState([{ state: 'PENDING' }, { state: 'FAILURE' }])).toBe('failure')
+  })
+
+  it('returns pending when some checks are pending and none failed', () => {
+    expect(parseGhCiState([{ state: 'SUCCESS' }, { state: 'PENDING' }])).toBe('pending')
+    expect(parseGhCiState([{ state: 'IN_PROGRESS' }])).toBe('pending')
+    expect(parseGhCiState([{ state: 'QUEUED' }])).toBe('pending')
+    expect(parseGhCiState([{ state: 'WAITING' }])).toBe('pending')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseGhPrListOutput
+// ---------------------------------------------------------------------------
+
+describe('parseGhPrListOutput', () => {
+  it('parses a well-formed gh response', () => {
+    const raw = JSON.stringify([
+      {
+        number: 42,
+        title: 'feat: add something cool',
+        state: 'OPEN',
+        url: 'https://github.com/owner/repo/pull/42',
+        statusCheckRollup: [{ state: 'SUCCESS' }],
+      },
+    ])
+    const result = parseGhPrListOutput(raw)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual<SessionPr>({
+      number: 42,
+      title: 'feat: add something cool',
+      state: 'open',
+      url: 'https://github.com/owner/repo/pull/42',
+      ciState: 'success',
+    })
+  })
+
+  it('returns empty array for invalid JSON', () => {
+    expect(parseGhPrListOutput('not json')).toEqual([])
+    expect(parseGhPrListOutput('')).toEqual([])
+  })
+
+  it('returns empty array when top-level is not an array', () => {
+    expect(parseGhPrListOutput('null')).toEqual([])
+    expect(parseGhPrListOutput('{}')).toEqual([])
+  })
+
+  it('skips entries missing required fields', () => {
+    const raw = JSON.stringify([
+      { number: 'not-a-number', title: 'x', state: 'OPEN', url: 'u' },
+      { number: 1, title: 42, state: 'OPEN', url: 'u' },
+      { number: 2, title: 'ok', state: 'OPEN', url: 'https://github.com/x/y/pull/2', statusCheckRollup: [] },
+    ])
+    const result = parseGhPrListOutput(raw)
+    expect(result).toHaveLength(1)
+    expect(result[0].number).toBe(2)
+  })
+
+  it('handles absent statusCheckRollup (returns ciState null)', () => {
+    const raw = JSON.stringify([
+      {
+        number: 7,
+        title: 'chore: stuff',
+        state: 'MERGED',
+        url: 'https://github.com/x/y/pull/7',
+      },
+    ])
+    const result = parseGhPrListOutput(raw)
+    expect(result[0].ciState).toBe(null)
+  })
+
+  it('handles multiple PRs and returns all valid ones', () => {
+    const raw = JSON.stringify([
+      {
+        number: 1,
+        title: 'first',
+        state: 'OPEN',
+        url: 'https://github.com/x/y/pull/1',
+        statusCheckRollup: [{ state: 'PENDING' }],
+      },
+      {
+        number: 2,
+        title: 'second',
+        state: 'CLOSED',
+        url: 'https://github.com/x/y/pull/2',
+        statusCheckRollup: [],
+      },
+    ])
+    const result = parseGhPrListOutput(raw)
+    expect(result).toHaveLength(2)
+    expect(result[0].ciState).toBe('pending')
+    expect(result[1].ciState).toBe(null)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isMergeEnabled
+// ---------------------------------------------------------------------------
+
+describe('isMergeEnabled', () => {
+  const base: SessionPr = {
+    number: 1,
+    title: 'test',
+    state: 'open',
+    url: 'https://github.com/x/y/pull/1',
+    ciState: 'success',
+  }
+
+  it('returns true when state=open and ciState=success', () => {
+    expect(isMergeEnabled(base)).toBe(true)
+  })
+
+  it('returns false when CI is pending', () => {
+    expect(isMergeEnabled({ ...base, ciState: 'pending' })).toBe(false)
+  })
+
+  it('returns false when CI is failing', () => {
+    expect(isMergeEnabled({ ...base, ciState: 'failure' })).toBe(false)
+  })
+
+  it('returns false when CI is null (no CI configured)', () => {
+    expect(isMergeEnabled({ ...base, ciState: null })).toBe(false)
+  })
+
+  it('returns false when PR is merged', () => {
+    expect(isMergeEnabled({ ...base, state: 'merged', ciState: 'success' })).toBe(false)
+  })
+
+  it('returns false when PR is closed', () => {
+    expect(isMergeEnabled({ ...base, state: 'closed', ciState: 'success' })).toBe(false)
+  })
+})

--- a/src/pr-utils.ts
+++ b/src/pr-utils.ts
@@ -1,0 +1,12 @@
+// Pure utility functions for PR data, usable in both renderer and tests.
+// No Electron or IPC dependencies.
+
+import type { SessionPr } from './types'
+
+/**
+ * Predicate: should the Merge button be enabled for this PR?
+ * Squash-merge only; CI must be green and PR must be open.
+ */
+export function isMergeEnabled(pr: SessionPr): boolean {
+  return pr.state === 'open' && pr.ciState === 'success'
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -571,6 +571,163 @@ body,
   color: #7ee787;
 }
 
+/* ---------- PR panel ---------- */
+
+.pr-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.pr-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.pr-ci-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.pr-ci-success {
+  background: #3fb950;
+  box-shadow: 0 0 4px rgba(63, 185, 80, 0.6);
+}
+
+.pr-ci-failure {
+  background: #f85149;
+  box-shadow: 0 0 4px rgba(248, 81, 73, 0.5);
+}
+
+.pr-ci-pending {
+  background: #e3b341;
+  box-shadow: 0 0 4px rgba(227, 179, 65, 0.5);
+}
+
+.pr-badge {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+.pr-badge-open {
+  background: rgba(35, 134, 54, 0.25);
+  color: #7ee787;
+}
+
+.pr-badge-merged {
+  background: rgba(163, 113, 247, 0.25);
+  color: #c9b1ff;
+}
+
+.pr-badge-closed {
+  background: rgba(248, 81, 73, 0.2);
+  color: #f48771;
+}
+
+.pr-number {
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.pr-title {
+  font-size: 12px;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pr-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.pr-action-btn {
+  background: var(--bg-elev);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 3px 8px;
+  font-size: 11px;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.pr-action-btn:hover:not(:disabled) {
+  background: var(--hover);
+  border-color: var(--accent);
+}
+
+.pr-action-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.pr-merge-btn {
+  background: rgba(35, 134, 54, 0.2);
+  border-color: rgba(63, 185, 80, 0.4);
+  color: #7ee787;
+}
+
+.pr-merge-btn:hover:not(:disabled) {
+  background: rgba(35, 134, 54, 0.35);
+  border-color: #3fb950;
+}
+
+.pr-refresh-btn {
+  margin-left: auto;
+}
+
+/* Confirm merge dialog — floats over the section body */
+.pr-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.pr-confirm-dialog {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 20px 24px;
+  max-width: 340px;
+  width: 100%;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.6);
+}
+
+.pr-confirm-msg {
+  margin: 0 0 6px;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.pr-confirm-title {
+  margin: 0 0 16px;
+  font-size: 12px;
+  color: var(--text-dim);
+  word-break: break-word;
+}
+
+.pr-confirm-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
 /* ---------- Main pane ---------- */
 
 .main {

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,14 @@ export type Config = {
   startupSessions: StartupSession[]
 }
 
+export type SessionPr = {
+  number: number
+  title: string
+  state: 'open' | 'merged' | 'closed'
+  url: string
+  ciState: 'pending' | 'success' | 'failure' | null
+}
+
 export type TermhubApi = {
   createSession: (cwd: string) => Promise<{ id: string; cwd: string }>
   sendInput: (id: string, data: string) => void
@@ -93,6 +101,11 @@ export type TermhubApi = {
   isMaximized: () => Promise<boolean>
   onMaximizeChange: (cb: (maximized: boolean) => void) => () => void
   openExternal: (url: string) => void
+  getSessionPr: (sessionId: string) => Promise<SessionPr | null>
+  mergeSessionPr: (sessionId: string, prNumber: number) => Promise<void>
+  onSessionPrChanged: (
+    cb: (sessionId: string, pr: SessionPr | null) => void,
+  ) => () => void
 }
 
 declare global {


### PR DESCRIPTION
## Summary

Adds a **Pull Request** section to the right-hand inspector panel that shows the PR tied to the currently active session's git branch. The panel displays the PR number, title, state (open/merged/closed), and CI rollup (green/red/yellow dot). Two action buttons let you open the PR in your browser or squash-merge it directly from termhub — with a confirmation dialog before merging and the merge button disabled until CI is green.

## Changes

- **`electron/pr-fetch.ts`** — pure helpers: `getGitBranch`, `fetchGhPrList`, `runGhPrMerge`, and parsers (`parseGhPrListOutput`, `parseGhCiState`, `parseGhPrState`, `buildCacheKey`). No Electron deps, so they are directly testable.
- **`electron/ipc-pr.ts`** — IPC handlers (`session:pr:get`, `session:pr:merge`) and a 30-second poll loop per session. Emits `session:pr` push events only when PR state changes. Poll stops automatically when a session closes via lifecycle hooks in `session-manager.ts`.
- **`electron/session-manager.ts`** — adds `onSessionCreatedHook`/`onSessionClosedHook` callback arrays to expose lifecycle events without circular imports.
- **`electron/preload.ts`** — exposes `getSessionPr`, `mergeSessionPr`, `onSessionPrChanged`.
- **`src/types.ts`** — adds `SessionPr` type and three new `TermhubApi` methods.
- **`src/SessionPrPanel.tsx`** — React component: CI dot, state badge, Open in GitHub, Merge (with confirm overlay), Refresh. Stale-response guard via `sessionIdRef`.
- **`src/RightPanel.tsx`** — adds Pull Request collapsible section at the top.
- **`src/pr-utils.ts`** — renderer-side `isMergeEnabled` predicate.
- **`src/pr-utils.test.ts`** — 27 Vitest tests covering parsers, cache key, and merge predicate.
- **`src/styles.css`** — PR panel styles (CI dot, state badge, action buttons, confirm overlay).

## Test plan

- [ ] `npm test` → 124 tests pass
- [ ] `npm run typecheck` → same pre-existing errors as main (no regressions introduced)
- [ ] `npm run dev` → open a session whose branch has a PR; Pull Request section appears in the right panel with state + CI dot
- [ ] Click **Open in GitHub** → browser opens the PR URL
- [ ] While CI is red/pending: Merge button is disabled with tooltip "CI must pass before merging"
- [ ] Once CI is green: Merge button enables; click → confirm dialog → cancel → no merge
- [ ] Accept confirm → PR squash-merges and panel updates to show merged state
- [ ] Session with no PR → "No PR yet for this branch." empty state
- [ ] Session without `gh` on PATH → graceful error with Retry button