### PR TITLE
feat: show confirm dialog before closing a live session

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,16 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { TitleBar } from './TitleBar'
 import { Sidebar } from './Sidebar'
 import { TerminalView } from './TerminalView'
 import { BottomTerminal } from './BottomTerminal'
 import { RightPanel } from './RightPanel'
 import { UsageModal } from './UsageModal'
+import { ConfirmCloseModal } from './ConfirmCloseModal'
 import type { Session } from './types'
 import type { TerminalEntry } from './useXterm'
 import { useSessions } from './useSessions'
 import { useSplitLayout } from './useSplitLayout'
+import { needsCloseConfirm } from './confirm-close'
 
 export default function App() {
   // Primary (claude) PTY xterm instances, keyed by session id. Owned here
@@ -39,6 +41,37 @@ export default function App() {
     useSplitLayout()
 
   const [showUsage, setShowUsage] = useState(false)
+  // Session id pending close confirmation, or null when no dialog is open.
+  const [pendingCloseId, setPendingCloseId] = useState<string | null>(null)
+
+  // Request to close a session. Shows confirm dialog for live sessions;
+  // closes immediately if the PTY has already exited (status 'failed').
+  const requestClose = useCallback(
+    (id: string) => {
+      if (needsCloseConfirm(statuses[id])) {
+        setPendingCloseId(id)
+      } else {
+        closeSession(id)
+      }
+    },
+    [statuses, closeSession],
+  )
+
+  const handleConfirmClose = useCallback(() => {
+    if (pendingCloseId !== null) {
+      closeSession(pendingCloseId)
+      setPendingCloseId(null)
+    }
+  }, [pendingCloseId, closeSession])
+
+  const handleCancelClose = useCallback(() => {
+    setPendingCloseId(null)
+  }, [])
+
+  const pendingCloseSession = useMemo(
+    () => (pendingCloseId !== null ? sessions.find((s) => s.id === pendingCloseId) ?? null : null),
+    [pendingCloseId, sessions],
+  )
 
   // Refit both terminals for the active session when the window resizes.
   useEffect(() => {
@@ -108,7 +141,7 @@ export default function App() {
           statuses={statuses}
           onNew={newSession}
           onSelect={setActiveId}
-          onClose={closeSession}
+          onClose={requestClose}
           onRename={renameSession}
         />
         <main className="main" ref={mainContainerRef}>
@@ -148,6 +181,13 @@ export default function App() {
         <RightPanel activeSession={activeSession} />
       </div>
       {showUsage && <UsageModal onClose={() => setShowUsage(false)} />}
+      {pendingCloseSession !== null && (
+        <ConfirmCloseModal
+          session={pendingCloseSession}
+          onConfirm={handleConfirmClose}
+          onCancel={handleCancelClose}
+        />
+      )}
     </div>
   )
 }

--- a/src/ConfirmCloseModal.tsx
+++ b/src/ConfirmCloseModal.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from 'react'
+import type { Session } from './types'
+
+type Props = {
+  session: Session
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmCloseModal({ session, onConfirm, onCancel }: Props) {
+  const cancelRef = useRef<HTMLButtonElement>(null)
+  const overlayRef = useRef<HTMLDivElement>(null)
+
+  // Default focus on Cancel so Enter doesn't accidentally close
+  useEffect(() => {
+    cancelRef.current?.focus()
+  }, [])
+
+  // Dismiss (cancel) on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [onCancel])
+
+  // Cancel when clicking the backdrop (not the dialog itself)
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === overlayRef.current) onCancel()
+  }
+
+  const label = session.name ?? session.cwd
+
+  return (
+    <div
+      ref={overlayRef}
+      onClick={handleOverlayClick}
+      className="confirm-close-overlay"
+    >
+      <div className="confirm-close-dialog" role="dialog" aria-modal="true" aria-labelledby="confirm-close-title">
+        <p id="confirm-close-title" className="confirm-close-msg">
+          Close session <strong>{label}</strong>?
+        </p>
+        <p className="confirm-close-sub">
+          Any unsaved work in the session will be lost.
+        </p>
+        <div className="confirm-close-actions">
+          <button
+            className="confirm-close-btn confirm-close-btn-destructive"
+            onClick={onConfirm}
+          >
+            Close
+          </button>
+          <button
+            ref={cancelRef}
+            className="confirm-close-btn"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/confirm-close.test.ts
+++ b/src/confirm-close.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { needsCloseConfirm } from './confirm-close'
+import type { SessionStatus } from './types'
+
+// ---------------------------------------------------------------------------
+// needsCloseConfirm — pure predicate
+// ---------------------------------------------------------------------------
+
+describe('needsCloseConfirm', () => {
+  it('returns true for a working session (live)', () => {
+    expect(needsCloseConfirm('working')).toBe(true)
+  })
+
+  it('returns true for an awaiting session (live)', () => {
+    expect(needsCloseConfirm('awaiting')).toBe(true)
+  })
+
+  it('returns true for an idle session (live)', () => {
+    expect(needsCloseConfirm('idle')).toBe(true)
+  })
+
+  it('returns false for a failed session (PTY dead)', () => {
+    expect(needsCloseConfirm('failed')).toBe(false)
+  })
+
+  it('returns true when status is undefined (unknown / not yet received)', () => {
+    expect(needsCloseConfirm(undefined)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Integration-style tests for the close guard logic, using stubs that
+// mirror what App.tsx does with needsCloseConfirm + closeSession.
+// ---------------------------------------------------------------------------
+
+describe('close guard behaviour', () => {
+  // Simulate the requestClose logic extracted from App.tsx
+  function makeRequestClose(
+    statuses: Record<string, SessionStatus>,
+    closeSession: (id: string) => void,
+    setPendingCloseId: (id: string) => void,
+  ) {
+    return (id: string) => {
+      if (needsCloseConfirm(statuses[id])) {
+        setPendingCloseId(id)
+      } else {
+        closeSession(id)
+      }
+    }
+  }
+
+  let closeSession: ReturnType<typeof vi.fn>
+  let setPendingCloseId: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    closeSession = vi.fn()
+    setPendingCloseId = vi.fn()
+  })
+
+  it('fires closeSession immediately for a dead (failed) session', () => {
+    const requestClose = makeRequestClose(
+      { 'sess-1': 'failed' },
+      closeSession,
+      setPendingCloseId,
+    )
+    requestClose('sess-1')
+    expect(closeSession).toHaveBeenCalledWith('sess-1')
+    expect(setPendingCloseId).not.toHaveBeenCalled()
+  })
+
+  it('opens the confirm dialog (does not close) for a live session', () => {
+    const requestClose = makeRequestClose(
+      { 'sess-2': 'working' },
+      closeSession,
+      setPendingCloseId,
+    )
+    requestClose('sess-2')
+    expect(setPendingCloseId).toHaveBeenCalledWith('sess-2')
+    expect(closeSession).not.toHaveBeenCalled()
+  })
+
+  it('opens the confirm dialog for an idle session', () => {
+    const requestClose = makeRequestClose(
+      { 'sess-3': 'idle' },
+      closeSession,
+      setPendingCloseId,
+    )
+    requestClose('sess-3')
+    expect(setPendingCloseId).toHaveBeenCalledWith('sess-3')
+    expect(closeSession).not.toHaveBeenCalled()
+  })
+
+  it('fires closeSession when user confirms the dialog', () => {
+    // Simulate confirm path: requestClose sets pendingCloseId, then user confirms
+    const requestClose = makeRequestClose(
+      { 'sess-4': 'idle' },
+      closeSession,
+      setPendingCloseId,
+    )
+    requestClose('sess-4')
+    expect(closeSession).not.toHaveBeenCalled()
+
+    // User clicks Confirm — App.tsx calls closeSession(pendingCloseId)
+    closeSession('sess-4')
+    expect(closeSession).toHaveBeenCalledWith('sess-4')
+  })
+
+  it('does not fire closeSession when user cancels the dialog', () => {
+    const requestClose = makeRequestClose(
+      { 'sess-5': 'awaiting' },
+      closeSession,
+      setPendingCloseId,
+    )
+    requestClose('sess-5')
+    // User clicks Cancel — pendingCloseId reset, closeSession never called
+    expect(closeSession).not.toHaveBeenCalled()
+  })
+})

--- a/src/confirm-close.ts
+++ b/src/confirm-close.ts
@@ -1,0 +1,8 @@
+import type { SessionStatus } from './types'
+
+// Returns true when the session requires a confirmation dialog before closing.
+// Dead sessions (PTY exited with non-zero code, status 'failed') can be
+// dismissed immediately — there is nothing left to lose.
+export function needsCloseConfirm(status: SessionStatus | undefined): boolean {
+  return status !== 'failed'
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -834,3 +834,76 @@ body,
 .empty button:hover {
   background: var(--accent-hover);
 }
+
+/* ---------- Confirm close session modal ---------- */
+
+.confirm-close-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.confirm-close-dialog {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 20px 24px;
+  max-width: 340px;
+  width: 100%;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.6);
+}
+
+.confirm-close-msg {
+  margin: 0 0 6px;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.confirm-close-sub {
+  margin: 0 0 16px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.confirm-close-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.confirm-close-btn {
+  background: var(--bg-elev);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.confirm-close-btn:hover {
+  background: var(--hover);
+  border-color: var(--accent);
+}
+
+.confirm-close-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.confirm-close-btn-destructive {
+  background: rgba(248, 81, 73, 0.15);
+  border-color: rgba(248, 81, 73, 0.4);
+  color: #f85149;
+}
+
+.confirm-close-btn-destructive:hover {
+  background: rgba(248, 81, 73, 0.28);
+  border-color: #f85149;
+}


### PR DESCRIPTION
## Summary

Adds a guard before any session-close so a misclick can't silently destroy a live PTY. Live sessions (working / awaiting / idle / unknown status) now show a small in-app modal — "Close session `<name>`? Any unsaved work in the session will be lost." — with **Cancel** focused by default. Dead sessions (status `failed`) are removed immediately with no dialog, because the PTY is already gone.

## Changes

- `src/confirm-close.ts` — pure `needsCloseConfirm(status)` predicate; returns `false` only for `'failed'`
- `src/ConfirmCloseModal.tsx` — in-app modal using the same overlay/dialog pattern as `UsageModal` and `SessionPrPanel`; Cancel gets autofocus, Esc dismisses, backdrop click cancels
- `src/App.tsx` — `requestClose` guard replaces direct `closeSession` on Sidebar's `onClose`; pending-close state drives the modal render
- `src/styles.css` — `.confirm-close-*` CSS matching existing dialog styles
- `src/confirm-close.test.ts` — 10 Vitest tests covering the predicate and the close-guard integration

## Test plan

- [ ] Open a session, click ×: modal appears with Cancel focused
- [ ] Press Enter (with Cancel focused): session preserved
- [ ] Press Esc: session preserved
- [ ] Click backdrop: session preserved
- [ ] Click Close button: session removed
- [ ] Close an already-dead session (status `failed`): removed immediately, no modal
- [ ] `npm test` — 134 tests pass
- [ ] `npm run typecheck` — clean