### PR TITLE
feat(mcp): add Codex and Gemini CLI runtimes to open_session

### DIFF
--- a/electron/codex-command.test.ts
+++ b/electron/codex-command.test.ts
@@ -3,6 +3,7 @@ import {
   isClaudeModelName,
   buildCodexArgs,
   buildCodexCommand,
+  DEFAULT_CODEX_BYPASS_APPROVALS,
 } from './codex-command'
 
 describe('isClaudeModelName', () => {
@@ -36,8 +37,25 @@ describe('isClaudeModelName', () => {
 })
 
 describe('buildCodexArgs', () => {
-  it('returns empty array when no opts provided', () => {
-    expect(buildCodexArgs({})).toEqual([])
+  it('DEFAULT_CODEX_BYPASS_APPROVALS is true', () => {
+    expect(DEFAULT_CODEX_BYPASS_APPROVALS).toBe(true)
+  })
+
+  it('includes --dangerously-bypass-approvals-and-sandbox by default (no opts)', () => {
+    // Default prevents directory-trust and command-approval prompts from blocking
+    // MCP-spawned autonomous sessions.
+    const flags = buildCodexArgs({})
+    expect(flags).toContain('--dangerously-bypass-approvals-and-sandbox')
+  })
+
+  it('includes --dangerously-bypass-approvals-and-sandbox when explicitly true', () => {
+    const flags = buildCodexArgs({ dangerouslyBypassApprovals: true })
+    expect(flags).toContain('--dangerously-bypass-approvals-and-sandbox')
+  })
+
+  it('omits bypass flag when explicitly false (caller opts out)', () => {
+    const flags = buildCodexArgs({ dangerouslyBypassApprovals: false })
+    expect(flags).not.toContain('--dangerously-bypass-approvals-and-sandbox')
   })
 
   it('includes -m flag when model is provided', () => {
@@ -53,21 +71,6 @@ describe('buildCodexArgs', () => {
   it('omits -m when model is empty', () => {
     const flags = buildCodexArgs({ model: '' })
     expect(flags.join(' ')).not.toContain('-m')
-  })
-
-  it('includes --dangerously-bypass-approvals-and-sandbox when dangerouslyBypassApprovals is true', () => {
-    const flags = buildCodexArgs({ dangerouslyBypassApprovals: true })
-    expect(flags).toContain('--dangerously-bypass-approvals-and-sandbox')
-  })
-
-  it('does not include bypass flag when false', () => {
-    const flags = buildCodexArgs({ dangerouslyBypassApprovals: false })
-    expect(flags).not.toContain('--dangerously-bypass-approvals-and-sandbox')
-  })
-
-  it('does not include bypass flag when omitted', () => {
-    const flags = buildCodexArgs({})
-    expect(flags).not.toContain('--dangerously-bypass-approvals-and-sandbox')
   })
 
   it('includes prompt as last quoted positional arg', () => {
@@ -92,13 +95,13 @@ describe('buildCodexArgs', () => {
   })
 
   it('omits prompt when empty string', () => {
-    const flags = buildCodexArgs({ prompt: '' })
-    expect(flags.join(' ')).not.toContain('"')
+    const flags = buildCodexArgs({ dangerouslyBypassApprovals: false, prompt: '' })
+    expect(flags).toEqual([])
   })
 
   it('omits prompt when undefined', () => {
-    const flags = buildCodexArgs({})
-    expect(flags.join(' ')).not.toContain('"')
+    const flags = buildCodexArgs({ dangerouslyBypassApprovals: false })
+    expect(flags).toEqual([])
   })
 
   it('builds the full flag set in the right order', () => {
@@ -119,8 +122,15 @@ describe('buildCodexArgs', () => {
 })
 
 describe('buildCodexCommand', () => {
-  it('returns just "codex" with no opts', () => {
-    expect(buildCodexCommand({})).toBe('codex')
+  it('includes bypass flag by default (no opts)', () => {
+    // Default prevents directory-trust prompts from blocking autonomous sessions.
+    expect(buildCodexCommand({})).toBe(
+      'codex --dangerously-bypass-approvals-and-sandbox',
+    )
+  })
+
+  it('returns just "codex" when bypass explicitly disabled and no other opts', () => {
+    expect(buildCodexCommand({ dangerouslyBypassApprovals: false })).toBe('codex')
   })
 
   it('prefixes with "codex " when flags are present', () => {
@@ -140,8 +150,11 @@ describe('buildCodexCommand', () => {
     )
   })
 
-  it('prompt-only invocation (no model, no bypass)', () => {
-    const cmd = buildCodexCommand({ prompt: 'Hello codex' })
+  it('prompt-only invocation with bypass explicitly disabled', () => {
+    const cmd = buildCodexCommand({
+      dangerouslyBypassApprovals: false,
+      prompt: 'Hello codex',
+    })
     expect(cmd).toBe('codex "Hello codex"')
   })
 })

--- a/electron/codex-command.test.ts
+++ b/electron/codex-command.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isClaudeModelName,
+  buildCodexArgs,
+  buildCodexCommand,
+} from './codex-command'
+
+describe('isClaudeModelName', () => {
+  it('returns true for claude- prefixed models', () => {
+    expect(isClaudeModelName('claude-opus-4-7')).toBe(true)
+    expect(isClaudeModelName('claude-sonnet-4-6')).toBe(true)
+    expect(isClaudeModelName('claude-haiku-4-5')).toBe(true)
+    expect(isClaudeModelName('claude-3-5-sonnet-20241022')).toBe(true)
+  })
+
+  it('returns false for codex / openai model names', () => {
+    expect(isClaudeModelName('o3')).toBe(false)
+    expect(isClaudeModelName('gpt-4o')).toBe(false)
+    expect(isClaudeModelName('o4-mini')).toBe(false)
+    expect(isClaudeModelName('o1-preview')).toBe(false)
+  })
+
+  it('returns false for empty string', () => {
+    expect(isClaudeModelName('')).toBe(false)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isClaudeModelName('Claude-opus-4-7')).toBe(true)
+    expect(isClaudeModelName('CLAUDE-sonnet-4-6')).toBe(true)
+  })
+
+  it('does not match when "claude-" appears mid-string', () => {
+    expect(isClaudeModelName('notclaude-something')).toBe(false)
+    expect(isClaudeModelName('my-claude-model')).toBe(false)
+  })
+})
+
+describe('buildCodexArgs', () => {
+  it('returns empty array when no opts provided', () => {
+    expect(buildCodexArgs({})).toEqual([])
+  })
+
+  it('includes -m flag when model is provided', () => {
+    const flags = buildCodexArgs({ model: 'o3' })
+    expect(flags.some((f) => f.includes('-m') && f.includes('o3'))).toBe(true)
+  })
+
+  it('quotes the model name', () => {
+    const flags = buildCodexArgs({ model: 'o3' })
+    expect(flags.some((f) => f === '-m "o3"')).toBe(true)
+  })
+
+  it('omits -m when model is empty', () => {
+    const flags = buildCodexArgs({ model: '' })
+    expect(flags.join(' ')).not.toContain('-m')
+  })
+
+  it('includes --dangerously-bypass-approvals-and-sandbox when dangerouslyBypassApprovals is true', () => {
+    const flags = buildCodexArgs({ dangerouslyBypassApprovals: true })
+    expect(flags).toContain('--dangerously-bypass-approvals-and-sandbox')
+  })
+
+  it('does not include bypass flag when false', () => {
+    const flags = buildCodexArgs({ dangerouslyBypassApprovals: false })
+    expect(flags).not.toContain('--dangerously-bypass-approvals-and-sandbox')
+  })
+
+  it('does not include bypass flag when omitted', () => {
+    const flags = buildCodexArgs({})
+    expect(flags).not.toContain('--dangerously-bypass-approvals-and-sandbox')
+  })
+
+  it('includes prompt as last quoted positional arg', () => {
+    const flags = buildCodexArgs({ prompt: 'Do the task' })
+    expect(flags[flags.length - 1]).toBe('"Do the task"')
+  })
+
+  it('puts prompt after all other flags', () => {
+    const flags = buildCodexArgs({
+      model: 'o3',
+      dangerouslyBypassApprovals: true,
+      prompt: 'Hello',
+    })
+    const promptIdx = flags.findIndex((f) => f.includes('Hello'))
+    const modelIdx = flags.findIndex((f) => f.includes('-m'))
+    const bypassIdx = flags.findIndex((f) =>
+      f.includes('--dangerously-bypass-approvals-and-sandbox'),
+    )
+    expect(promptIdx).toBe(flags.length - 1)
+    expect(modelIdx).toBeLessThan(promptIdx)
+    expect(bypassIdx).toBeLessThan(promptIdx)
+  })
+
+  it('omits prompt when empty string', () => {
+    const flags = buildCodexArgs({ prompt: '' })
+    expect(flags.join(' ')).not.toContain('"')
+  })
+
+  it('omits prompt when undefined', () => {
+    const flags = buildCodexArgs({})
+    expect(flags.join(' ')).not.toContain('"')
+  })
+
+  it('builds the full flag set in the right order', () => {
+    const flags = buildCodexArgs({
+      model: 'o3',
+      dangerouslyBypassApprovals: true,
+      prompt: 'Test prompt',
+    })
+    const str = flags.join(' ')
+    expect(str).toContain('-m "o3"')
+    expect(str).toContain('--dangerously-bypass-approvals-and-sandbox')
+    expect(str).toContain('"Test prompt"')
+    // Prompt is last
+    expect(str.lastIndexOf('"Test prompt"')).toBeGreaterThan(
+      str.indexOf('--dangerously-bypass-approvals-and-sandbox'),
+    )
+  })
+})
+
+describe('buildCodexCommand', () => {
+  it('returns just "codex" with no opts', () => {
+    expect(buildCodexCommand({})).toBe('codex')
+  })
+
+  it('prefixes with "codex " when flags are present', () => {
+    const cmd = buildCodexCommand({ model: 'o3' })
+    expect(cmd).toMatch(/^codex /)
+    expect(cmd).toContain('-m "o3"')
+  })
+
+  it('full invocation with model + bypass + prompt', () => {
+    const cmd = buildCodexCommand({
+      model: 'o3',
+      dangerouslyBypassApprovals: true,
+      prompt: 'Do work',
+    })
+    expect(cmd).toBe(
+      'codex -m "o3" --dangerously-bypass-approvals-and-sandbox "Do work"',
+    )
+  })
+
+  it('prompt-only invocation (no model, no bypass)', () => {
+    const cmd = buildCodexCommand({ prompt: 'Hello codex' })
+    expect(cmd).toBe('codex "Hello codex"')
+  })
+})

--- a/electron/codex-command.ts
+++ b/electron/codex-command.ts
@@ -17,11 +17,20 @@ export function isClaudeModelName(model: string): boolean {
   return model.toLowerCase().startsWith('claude-')
 }
 
+// Default bypass applied to every spawned Codex session when the caller doesn't
+// opt out. --dangerously-bypass-approvals-and-sandbox skips all confirmation
+// prompts (including directory-trust prompts) and disables the sandbox.
+// Analogous to Claude's DEFAULT_PERMISSION_MODE = 'bypassPermissions' —
+// MCP-spawned sessions run inside termhub are operator-controlled and should
+// not block on interactive confirmations.
+export const DEFAULT_CODEX_BYPASS_APPROVALS = true
+
 // Builds the flag list for a `codex` invocation.
 //
 // open_session field mapping:
 //   model                      → -m <model>
 //   dangerouslyBypassApprovals → --dangerously-bypass-approvals-and-sandbox
+//                                (defaults to true — see DEFAULT_CODEX_BYPASS_APPROVALS)
 //   prompt                     → positional <prompt> argument (must be last)
 //
 // Not mapped (no codex equivalent):
@@ -37,7 +46,10 @@ export function buildCodexArgs(opts: {
     flags.push(`-m "${opts.model}"`)
   }
 
-  if (opts.dangerouslyBypassApprovals) {
+  // Default to true so sessions don't block on directory-trust or command-
+  // approval prompts. Pass dangerouslyBypassApprovals: false to opt out.
+  const bypass = opts.dangerouslyBypassApprovals ?? DEFAULT_CODEX_BYPASS_APPROVALS
+  if (bypass) {
     flags.push('--dangerously-bypass-approvals-and-sandbox')
   }
 

--- a/electron/codex-command.ts
+++ b/electron/codex-command.ts
@@ -1,0 +1,61 @@
+// Pure helpers for spawning codex — flag construction. No electron, no PTY,
+// no I/O — testable in isolation.
+//
+// Codex CLI flag surface (relevant subset):
+//   codex [OPTIONS] [PROMPT]
+//   -m, --model <MODEL>                     Model to use
+//   -C, --cd <DIR>                          Working root (we rely on PTY cwd instead)
+//   -a, --ask-for-approval <POLICY>         Approval policy: untrusted | on-failure | on-request | never
+//   -s, --sandbox <MODE>                    Sandbox mode: read-only | workspace-write | danger-full-access
+//   --dangerously-bypass-approvals-and-sandbox  Skip all confirmations and sandbox
+//   [PROMPT]                                Initial prompt as positional arg (last)
+
+// Returns true if the model name looks like a Claude model (e.g. "claude-opus-4-7").
+// Used to detect misconfiguration when a caller passes a Claude model name with
+// cli: 'codex' — those two are incompatible.
+export function isClaudeModelName(model: string): boolean {
+  return model.toLowerCase().startsWith('claude-')
+}
+
+// Builds the flag list for a `codex` invocation.
+//
+// open_session field mapping:
+//   model                      → -m <model>
+//   dangerouslyBypassApprovals → --dangerously-bypass-approvals-and-sandbox
+//   prompt                     → positional <prompt> argument (must be last)
+//
+// Not mapped (no codex equivalent):
+//   agent, allowDangerouslySkipPermissions, permissionMode
+export function buildCodexArgs(opts: {
+  model?: string
+  dangerouslyBypassApprovals?: boolean
+  prompt?: string
+}): string[] {
+  const flags: string[] = []
+
+  if (opts.model && opts.model.length > 0) {
+    flags.push(`-m "${opts.model}"`)
+  }
+
+  if (opts.dangerouslyBypassApprovals) {
+    flags.push('--dangerously-bypass-approvals-and-sandbox')
+  }
+
+  // Prompt is the positional argument — must come last so the shell doesn't
+  // interpret it as a flag value.
+  if (opts.prompt && opts.prompt.length > 0) {
+    flags.push(`"${opts.prompt}"`)
+  }
+
+  return flags
+}
+
+// Concatenated form of buildCodexArgs — what session-manager writes to the PTY.
+export function buildCodexCommand(opts: {
+  model?: string
+  dangerouslyBypassApprovals?: boolean
+  prompt?: string
+}): string {
+  const flags = buildCodexArgs(opts)
+  return flags.length > 0 ? `codex ${flags.join(' ')}` : 'codex'
+}

--- a/electron/gemini-command.test.ts
+++ b/electron/gemini-command.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildGeminiArgs,
+  buildGeminiCommand,
+  DEFAULT_GEMINI_YOLO,
+} from './gemini-command'
+
+describe('buildGeminiArgs', () => {
+  it('DEFAULT_GEMINI_YOLO is true', () => {
+    expect(DEFAULT_GEMINI_YOLO).toBe(true)
+  })
+
+  it('includes --yolo and --skip-trust by default (no opts)', () => {
+    const flags = buildGeminiArgs({})
+    expect(flags).toContain('--yolo')
+    expect(flags).toContain('--skip-trust')
+  })
+
+  it('includes --yolo when explicitly true', () => {
+    expect(buildGeminiArgs({ yolo: true })).toContain('--yolo')
+  })
+
+  it('omits --yolo when explicitly false', () => {
+    expect(buildGeminiArgs({ yolo: false })).not.toContain('--yolo')
+  })
+
+  it('includes --skip-trust by default', () => {
+    expect(buildGeminiArgs({})).toContain('--skip-trust')
+  })
+
+  it('includes --skip-trust when explicitly true', () => {
+    expect(buildGeminiArgs({ skipTrust: true })).toContain('--skip-trust')
+  })
+
+  it('omits --skip-trust when explicitly false', () => {
+    expect(buildGeminiArgs({ skipTrust: false })).not.toContain('--skip-trust')
+  })
+
+  it('includes -m flag with quoted model name', () => {
+    const flags = buildGeminiArgs({ model: 'gemini-2.5-pro' })
+    expect(flags.some((f) => f === '-m "gemini-2.5-pro"')).toBe(true)
+  })
+
+  it('omits -m when model is empty', () => {
+    const flags = buildGeminiArgs({ model: '' })
+    expect(flags.join(' ')).not.toContain('-m')
+  })
+
+  it('omits -m when model is undefined', () => {
+    const flags = buildGeminiArgs({})
+    expect(flags.join(' ')).not.toContain('-m')
+  })
+
+  it('includes prompt as last quoted positional arg', () => {
+    const flags = buildGeminiArgs({ prompt: 'Do the task' })
+    expect(flags[flags.length - 1]).toBe('"Do the task"')
+  })
+
+  it('puts prompt after all flags', () => {
+    const flags = buildGeminiArgs({ model: 'gemini-2.5-pro', yolo: true, prompt: 'Hello' })
+    const promptIdx = flags.findIndex((f) => f.includes('Hello'))
+    expect(promptIdx).toBe(flags.length - 1)
+    expect(flags.findIndex((f) => f.includes('-m'))).toBeLessThan(promptIdx)
+    expect(flags.indexOf('--yolo')).toBeLessThan(promptIdx)
+    expect(flags.indexOf('--skip-trust')).toBeLessThan(promptIdx)
+  })
+
+  it('omits prompt when empty string', () => {
+    const flags = buildGeminiArgs({ yolo: false, skipTrust: false, prompt: '' })
+    expect(flags).toEqual([])
+  })
+
+  it('omits prompt when undefined', () => {
+    const flags = buildGeminiArgs({ yolo: false, skipTrust: false })
+    expect(flags).toEqual([])
+  })
+
+  it('builds the full flag set in the right order', () => {
+    const str = buildGeminiArgs({
+      model: 'gemini-2.5-pro',
+      yolo: true,
+      skipTrust: true,
+      prompt: 'Do work',
+    }).join(' ')
+    expect(str).toContain('-m "gemini-2.5-pro"')
+    expect(str).toContain('--yolo')
+    expect(str).toContain('--skip-trust')
+    expect(str).toContain('"Do work"')
+    expect(str.lastIndexOf('"Do work"')).toBeGreaterThan(str.indexOf('--skip-trust'))
+  })
+})
+
+describe('buildGeminiCommand', () => {
+  it('includes --yolo and --skip-trust by default', () => {
+    expect(buildGeminiCommand({})).toBe('gemini --yolo --skip-trust')
+  })
+
+  it('returns just "gemini" when all flags disabled and no prompt', () => {
+    expect(buildGeminiCommand({ yolo: false, skipTrust: false })).toBe('gemini')
+  })
+
+  it('prefixes with "gemini " when flags are present', () => {
+    const cmd = buildGeminiCommand({ model: 'gemini-2.5-pro' })
+    expect(cmd).toMatch(/^gemini /)
+    expect(cmd).toContain('-m "gemini-2.5-pro"')
+  })
+
+  it('full invocation with model + yolo + skip-trust + prompt', () => {
+    const cmd = buildGeminiCommand({
+      model: 'gemini-2.5-pro',
+      yolo: true,
+      skipTrust: true,
+      prompt: 'Do work',
+    })
+    expect(cmd).toBe('gemini -m "gemini-2.5-pro" --yolo --skip-trust "Do work"')
+  })
+
+  it('prompt-only invocation with flags disabled', () => {
+    const cmd = buildGeminiCommand({ yolo: false, skipTrust: false, prompt: 'Hello' })
+    expect(cmd).toBe('gemini "Hello"')
+  })
+})

--- a/electron/gemini-command.ts
+++ b/electron/gemini-command.ts
@@ -1,0 +1,72 @@
+// Pure helpers for spawning gemini — flag construction. No electron, no PTY,
+// no I/O — testable in isolation.
+//
+// Gemini CLI flag surface (relevant subset):
+//   gemini [OPTIONS] [query..]
+//   -m, --model <MODEL>          Model to use (e.g. "gemini-2.5-pro")
+//   -y, --yolo                   Auto-accept all actions (bypass approvals)
+//       --skip-trust             Trust the current workspace for this session
+//   -i, --prompt-interactive     Execute prompt and continue in interactive mode
+//   [query..]                    Initial prompt as positional arg (interactive by default)
+
+// Default bypass applied to every spawned Gemini session when the caller
+// doesn't opt out. --yolo auto-accepts all tool actions without prompting.
+// Analogous to Claude's DEFAULT_PERMISSION_MODE = 'bypassPermissions' and
+// Codex's DEFAULT_CODEX_BYPASS_APPROVALS.
+export const DEFAULT_GEMINI_YOLO = true
+
+// Builds the flag list for a `gemini` invocation.
+//
+// open_session field mapping:
+//   model                  → -m <model>
+//   yolo                   → --yolo (defaults to DEFAULT_GEMINI_YOLO)
+//   skipTrust              → --skip-trust (defaults to true — suppresses
+//                            workspace trust prompts)
+//   prompt                 → positional <prompt> argument (must be last)
+//
+// Not mapped (no gemini equivalent):
+//   agent, allowDangerouslySkipPermissions, permissionMode
+export function buildGeminiArgs(opts: {
+  model?: string
+  yolo?: boolean      // default: DEFAULT_GEMINI_YOLO
+  skipTrust?: boolean // default: true
+  prompt?: string
+}): string[] {
+  const flags: string[] = []
+
+  if (opts.model && opts.model.length > 0) {
+    flags.push(`-m "${opts.model}"`)
+  }
+
+  // Default to true so sessions don't block on approval prompts.
+  // Pass yolo: false to opt out.
+  const yolo = opts.yolo ?? DEFAULT_GEMINI_YOLO
+  if (yolo) {
+    flags.push('--yolo')
+  }
+
+  // Default to trusting the workspace so Gemini doesn't prompt on startup.
+  const skipTrust = opts.skipTrust ?? true
+  if (skipTrust) {
+    flags.push('--skip-trust')
+  }
+
+  // Prompt is the positional argument — must come last so it isn't
+  // interpreted as a flag value by the shell.
+  if (opts.prompt && opts.prompt.length > 0) {
+    flags.push(`"${opts.prompt}"`)
+  }
+
+  return flags
+}
+
+// Concatenated form of buildGeminiArgs — what session-manager writes to the PTY.
+export function buildGeminiCommand(opts: {
+  model?: string
+  yolo?: boolean
+  skipTrust?: boolean
+  prompt?: string
+}): string {
+  const flags = buildGeminiArgs(opts)
+  return flags.length > 0 ? `gemini ${flags.join(' ')}` : 'gemini'
+}

--- a/electron/ipc-session.ts
+++ b/electron/ipc-session.ts
@@ -83,6 +83,7 @@ export function registerSessionHandlers(): void {
       name: s.name,
       repoRoot: s.repoRoot,
       repoLabel: s.repoLabel,
+      cli: s.cli,
     })),
   )
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -13,6 +13,7 @@ import { stripAnsi } from './output-buffer'
 import { writeBracketedPasteAndSubmit } from './claude-command'
 import { getMcpConfigPath, loadConfig } from './config'
 import { loadPersistedSessions } from './persistence'
+import { isClaudeModelName } from './codex-command'
 import {
   createSessionInternal,
   findSessionByIdOrPrefix,
@@ -141,6 +142,7 @@ function bootstrapSessions(config: Config): void {
         permissionMode: s.permissionMode,
         dangerouslySkipPermissions: s.dangerouslySkipPermissions,
         allowDangerouslySkipPermissions: s.allowDangerouslySkipPermissions,
+        cli: s.cli,
         source: 'resume',
       })
       occupiedCwds.add(s.cwd)
@@ -170,6 +172,7 @@ function bootstrapSessions(config: Config): void {
         allowDangerouslySkipPermissions: entry.allowDangerouslySkipPermissions,
         permissionMode: entry.permissionMode,
         name: entry.name,
+        cli: entry.cli,
         source: 'startup',
       })
       occupiedCwds.add(entry.cwd)
@@ -210,7 +213,23 @@ app.whenReady().then(async () => {
           allowDangerouslySkipPermissions,
           permissionMode,
           name,
+          cli,
         }) => {
+          const resolvedCli = cli ?? 'claude'
+
+          // Reject claude model names when spawning a codex session — they
+          // are incompatible and the session would fail at runtime.
+          if (resolvedCli === 'codex' && model && isClaudeModelName(model)) {
+            console.warn(
+              `[termhub:session] open_session rejected: cli='codex' with Claude model '${model}'. ` +
+                `Use a Codex-compatible model (e.g. "o3") or omit model to use the Codex default.`,
+            )
+            throw new Error(
+              `Cannot use Claude model '${model}' with cli='codex'. ` +
+                `Pass a Codex-compatible model (e.g. "o3") or omit model.`,
+            )
+          }
+
           const myTurn = openSessionQueue.catch(() => {})
           let release!: (value: unknown) => void
           openSessionQueue = new Promise((resolve) => {
@@ -220,7 +239,7 @@ app.whenReady().then(async () => {
           try {
             const result = createSessionInternal({
               cwd,
-              command: 'claude',
+              command: resolvedCli,
               prompt,
               agent,
               model,
@@ -228,6 +247,7 @@ app.whenReady().then(async () => {
               allowDangerouslySkipPermissions,
               permissionMode,
               name,
+              cli: resolvedCli,
               source: 'mcp',
             })
             await result.promptSettled

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -217,16 +217,16 @@ app.whenReady().then(async () => {
         }) => {
           const resolvedCli = cli ?? 'claude'
 
-          // Reject claude model names when spawning a codex session — they
-          // are incompatible and the session would fail at runtime.
-          if (resolvedCli === 'codex' && model && isClaudeModelName(model)) {
+          // Reject claude model names when spawning a codex or gemini session —
+          // they are incompatible and the session would fail at runtime.
+          if (resolvedCli !== 'claude' && model && isClaudeModelName(model)) {
             console.warn(
-              `[termhub:session] open_session rejected: cli='codex' with Claude model '${model}'. ` +
-                `Use a Codex-compatible model (e.g. "o3") or omit model to use the Codex default.`,
+              `[termhub:session] open_session rejected: cli='${resolvedCli}' with Claude model '${model}'. ` +
+                `Use a ${resolvedCli}-compatible model or omit model to use the default.`,
             )
             throw new Error(
-              `Cannot use Claude model '${model}' with cli='codex'. ` +
-                `Pass a Codex-compatible model (e.g. "o3") or omit model.`,
+              `Cannot use Claude model '${model}' with cli='${resolvedCli}'. ` +
+                `Pass a ${resolvedCli}-compatible model or omit model.`,
             )
           }
 

--- a/electron/mcp-bridge.ts
+++ b/electron/mcp-bridge.ts
@@ -26,13 +26,15 @@ async function main() {
   server.registerTool(
     'open_session',
     {
-      title: 'Open a new termhub terminal running Claude',
+      title: 'Open a new termhub terminal session',
       description:
-        'Spawns a new terminal in termhub running `claude` (an interactive Claude Code session). ' +
-        'Use this to delegate work to a sub-agent. Provide an absolute working directory and an ' +
-        'optional initial prompt that the new claude will receive as its first user message. ' +
+        'Spawns a new terminal in termhub running `claude` (Claude Code) or `codex` (OpenAI Codex CLI). ' +
+        'Use `cli: "codex"` to spawn a Codex session; omit or set `cli: "claude"` (default) for Claude Code. ' +
+        'Provide an absolute working directory and an optional initial prompt. ' +
+        'For Claude Code: the prompt is delivered as the first user message once the TUI boots. ' +
+        'For Codex: the prompt is passed as a CLI argument at launch. ' +
         'To start in plan mode but allow flipping to bypass later (without restarting), use ' +
-        'permissionMode: "plan" together with allowDangerouslySkipPermissions: true.',
+        'permissionMode: "plan" together with allowDangerouslySkipPermissions: true (Claude only).',
       inputSchema: {
         cwd: z
           .string()
@@ -96,6 +98,17 @@ async function main() {
             'Display name for the session, shown in the termhub sidebar. ' +
               'Falls back to the cwd basename when omitted.',
           ),
+        cli: z
+          .enum(['claude', 'codex'])
+          .optional()
+          .describe(
+            'CLI runtime to use. "claude" (default) spawns Claude Code; ' +
+              '"codex" spawns the OpenAI Codex CLI. ' +
+              'When using "codex", pass a Codex-compatible model (e.g. "o3") — ' +
+              'passing a Claude model name with cli: "codex" is a configuration error. ' +
+              'The agent, permissionMode, and allowDangerouslySkipPermissions fields ' +
+              'are Claude-specific and are ignored when cli is "codex".',
+          ),
       },
     },
     async (args) => {
@@ -112,6 +125,7 @@ async function main() {
             allowDangerouslySkipPermissions: args.allowDangerouslySkipPermissions,
             permissionMode: args.permissionMode,
             name: args.name,
+            cli: args.cli,
           }),
         })
         if (!response.ok) {

--- a/electron/mcp-bridge.ts
+++ b/electron/mcp-bridge.ts
@@ -99,15 +99,16 @@ async function main() {
               'Falls back to the cwd basename when omitted.',
           ),
         cli: z
-          .enum(['claude', 'codex'])
+          .enum(['claude', 'codex', 'gemini'])
           .optional()
           .describe(
             'CLI runtime to use. "claude" (default) spawns Claude Code; ' +
-              '"codex" spawns the OpenAI Codex CLI. ' +
-              'When using "codex", pass a Codex-compatible model (e.g. "o3") — ' +
-              'passing a Claude model name with cli: "codex" is a configuration error. ' +
+              '"codex" spawns the OpenAI Codex CLI; ' +
+              '"gemini" spawns the Gemini CLI. ' +
+              'When using "codex" or "gemini", pass a compatible model — ' +
+              'passing a Claude model name with a non-claude cli is a configuration error. ' +
               'The agent, permissionMode, and allowDangerouslySkipPermissions fields ' +
-              'are Claude-specific and are ignored when cli is "codex".',
+              'are Claude-specific and are ignored for codex and gemini.',
           ),
       },
     },

--- a/electron/mcp.ts
+++ b/electron/mcp.ts
@@ -21,6 +21,7 @@ export type McpHooks = {
     allowDangerouslySkipPermissions?: boolean
     permissionMode?: string
     name?: string
+    cli?: 'claude' | 'codex'
   }) => Promise<OpenSessionResult> | OpenSessionResult
   sendInput: (req: { sessionId: string; text: string }) => {
     ok: boolean
@@ -76,6 +77,7 @@ export async function startMcpServer(opts: {
         allowDangerouslySkipPermissions?: unknown
         permissionMode?: unknown
         name?: unknown
+        cli?: unknown
       }
       try {
         parsed = body ? JSON.parse(body) : {}
@@ -102,6 +104,8 @@ export async function startMcpServer(opts: {
       const permissionMode =
         typeof parsed.permissionMode === 'string' ? parsed.permissionMode : undefined
       const name = typeof parsed.name === 'string' ? parsed.name : undefined
+      const cli =
+        parsed.cli === 'claude' || parsed.cli === 'codex' ? parsed.cli : undefined
       try {
         const result = await opts.hooks.openClaudeSession({
           cwd: parsed.cwd,
@@ -112,6 +116,7 @@ export async function startMcpServer(opts: {
           allowDangerouslySkipPermissions,
           permissionMode,
           name,
+          cli,
         })
         respondJson(res, 200, result)
       } catch (err) {

--- a/electron/mcp.ts
+++ b/electron/mcp.ts
@@ -21,7 +21,7 @@ export type McpHooks = {
     allowDangerouslySkipPermissions?: boolean
     permissionMode?: string
     name?: string
-    cli?: 'claude' | 'codex'
+    cli?: 'claude' | 'codex' | 'gemini'
   }) => Promise<OpenSessionResult> | OpenSessionResult
   sendInput: (req: { sessionId: string; text: string }) => {
     ok: boolean
@@ -105,7 +105,9 @@ export async function startMcpServer(opts: {
         typeof parsed.permissionMode === 'string' ? parsed.permissionMode : undefined
       const name = typeof parsed.name === 'string' ? parsed.name : undefined
       const cli =
-        parsed.cli === 'claude' || parsed.cli === 'codex' ? parsed.cli : undefined
+        parsed.cli === 'claude' || parsed.cli === 'codex' || parsed.cli === 'gemini'
+          ? parsed.cli
+          : undefined
       try {
         const result = await opts.hooks.openClaudeSession({
           cwd: parsed.cwd,

--- a/electron/persistence.ts
+++ b/electron/persistence.ts
@@ -15,7 +15,7 @@ export type PersistedSession = {
   permissionMode?: string
   dangerouslySkipPermissions?: boolean
   allowDangerouslySkipPermissions?: boolean
-  cli?: 'claude' | 'codex'
+  cli?: 'claude' | 'codex' | 'gemini'
 }
 
 // Type-guard parsing — we deliberately tolerate older / partial entries
@@ -39,7 +39,7 @@ export function loadPersistedSessions(): PersistedSession[] {
           typeof s.dangerouslySkipPermissions === 'boolean') &&
         (s.allowDangerouslySkipPermissions === undefined ||
           typeof s.allowDangerouslySkipPermissions === 'boolean') &&
-        (s.cli === undefined || s.cli === 'claude' || s.cli === 'codex'),
+        (s.cli === undefined || s.cli === 'claude' || s.cli === 'codex' || s.cli === 'gemini'),
     )
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {

--- a/electron/persistence.ts
+++ b/electron/persistence.ts
@@ -15,6 +15,7 @@ export type PersistedSession = {
   permissionMode?: string
   dangerouslySkipPermissions?: boolean
   allowDangerouslySkipPermissions?: boolean
+  cli?: 'claude' | 'codex'
 }
 
 // Type-guard parsing — we deliberately tolerate older / partial entries
@@ -37,7 +38,8 @@ export function loadPersistedSessions(): PersistedSession[] {
         (s.dangerouslySkipPermissions === undefined ||
           typeof s.dangerouslySkipPermissions === 'boolean') &&
         (s.allowDangerouslySkipPermissions === undefined ||
-          typeof s.allowDangerouslySkipPermissions === 'boolean'),
+          typeof s.allowDangerouslySkipPermissions === 'boolean') &&
+        (s.cli === undefined || s.cli === 'claude' || s.cli === 'codex'),
     )
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -19,7 +19,7 @@ type AddedPayload = {
   name?: string
   repoRoot?: string
   repoLabel?: string
-  cli?: 'claude' | 'codex'
+  cli?: 'claude' | 'codex' | 'gemini'
 }
 
 const api = {
@@ -115,7 +115,7 @@ const api = {
       name?: string,
       repoRoot?: string,
       repoLabel?: string,
-      cli?: 'claude' | 'codex',
+      cli?: 'claude' | 'codex' | 'gemini',
     ) => void,
   ): (() => void) => {
     const handler = (_e: Electron.IpcRendererEvent, p: AddedPayload) =>
@@ -127,7 +127,7 @@ const api = {
   },
 
   listSessions: (): Promise<
-    Array<{ id: string; cwd: string; command?: string; name?: string; repoRoot?: string; repoLabel?: string; cli?: 'claude' | 'codex' }>
+    Array<{ id: string; cwd: string; command?: string; name?: string; repoRoot?: string; repoLabel?: string; cli?: 'claude' | 'codex' | 'gemini' }>
   > => ipcRenderer.invoke('sessions:list'),
 
   appReady: (): void => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -19,6 +19,7 @@ type AddedPayload = {
   name?: string
   repoRoot?: string
   repoLabel?: string
+  cli?: 'claude' | 'codex'
 }
 
 const api = {
@@ -114,10 +115,11 @@ const api = {
       name?: string,
       repoRoot?: string,
       repoLabel?: string,
+      cli?: 'claude' | 'codex',
     ) => void,
   ): (() => void) => {
     const handler = (_e: Electron.IpcRendererEvent, p: AddedPayload) =>
-      cb(p.id, p.cwd, p.autoActivate ?? false, p.command, p.name, p.repoRoot, p.repoLabel)
+      cb(p.id, p.cwd, p.autoActivate ?? false, p.command, p.name, p.repoRoot, p.repoLabel, p.cli)
     ipcRenderer.on('session:added', handler)
     return () => {
       ipcRenderer.off('session:added', handler)
@@ -125,7 +127,7 @@ const api = {
   },
 
   listSessions: (): Promise<
-    Array<{ id: string; cwd: string; command?: string; name?: string; repoRoot?: string; repoLabel?: string }>
+    Array<{ id: string; cwd: string; command?: string; name?: string; repoRoot?: string; repoLabel?: string; cli?: 'claude' | 'codex' }>
   > => ipcRenderer.invoke('sessions:list'),
 
   appReady: (): void => {

--- a/electron/session-manager.ts
+++ b/electron/session-manager.ts
@@ -387,7 +387,8 @@ export function createSessionInternal(opts: {
       })
       console.info(
         `[termhub:session] ${id.slice(0, 8)} codex spawn — cwd=${opts.cwd}` +
-          (opts.model ? ` model=${opts.model}` : ''),
+          (opts.model ? ` model=${opts.model}` : '') +
+          ` cmd="${finalCommand}"`,
       )
     } else if (isClaudeCommand(opts.command)) {
       finalCommand = buildClaudeCommand({

--- a/electron/session-manager.ts
+++ b/electron/session-manager.ts
@@ -18,6 +18,7 @@ import {
   writeBracketedPasteAndSubmit,
 } from './claude-command'
 import { buildCodexCommand } from './codex-command'
+import { buildGeminiCommand } from './gemini-command'
 import { writePersistedSessions, type PersistedSession } from './persistence'
 import { getMcpConfigPath } from './config'
 
@@ -28,7 +29,7 @@ export type Session = {
   name?: string
   repoRoot?: string
   repoLabel?: string
-  cli?: 'claude' | 'codex'
+  cli?: 'claude' | 'codex' | 'gemini'
   model?: string
   permissionMode?: string
   dangerouslySkipPermissions?: boolean
@@ -167,7 +168,7 @@ export function createSessionInternal(opts: {
   allowDangerouslySkipPermissions?: boolean
   permissionMode?: string
   name?: string
-  cli?: 'claude' | 'codex'
+  cli?: 'claude' | 'codex' | 'gemini'
   source: 'ipc' | 'mcp' | 'startup' | 'resume'
 }): { id: string; cwd: string; promptSettled: Promise<void> } {
   const id = opts.id ?? randomUUID()
@@ -263,13 +264,13 @@ export function createSessionInternal(opts: {
   // promptSettled resolves once delivery is complete (paste + CR
   // written), or once we know it's never going to happen (fallback fired,
   // session exited, no prompt provided).
-  // Codex receives its prompt as a positional CLI arg embedded in the
-  // command string — no bracketed-paste delivery needed.
+  // Codex and Gemini receive their prompt as a positional CLI arg embedded in
+  // the command string — only Claude uses bracketed-paste delivery.
   const wantsPrompt =
     opts.source !== 'resume' &&
     opts.prompt !== undefined &&
     opts.prompt.length > 0 &&
-    cli !== 'codex'
+    cli === 'claude'
   let promptSent = false
   let resolvePromptSettled: () => void = () => {}
   const promptSettled: Promise<void> = wantsPrompt
@@ -306,8 +307,8 @@ export function createSessionInternal(opts: {
   // Watch the Claude Code JSONL file for ground-truth status updates. The
   // file is created by Claude Code shortly after startup; the watcher polls
   // and will begin emitting once the file appears.
-  // Codex does not produce a Claude Code JSONL file — skip the watcher.
-  if (cli !== 'codex' && opts.command && isClaudeCommand(opts.command)) {
+  // Codex and Gemini don't produce a Claude Code JSONL file — skip the watcher.
+  if (cli === 'claude' && opts.command && isClaudeCommand(opts.command)) {
     session.jsonlWatcher = watchSessionStatus(id, (next) => {
       // Send the initial prompt the first time claude reports 'idle'
       // (parked at the input prompt, submit handler wired). 'busy' and
@@ -387,6 +388,18 @@ export function createSessionInternal(opts: {
       })
       console.info(
         `[termhub:session] ${id.slice(0, 8)} codex spawn — cwd=${opts.cwd}` +
+          (opts.model ? ` model=${opts.model}` : '') +
+          ` cmd="${finalCommand}"`,
+      )
+    } else if (cli === 'gemini') {
+      finalCommand = buildGeminiCommand({
+        model: opts.model,
+        yolo: opts.dangerouslySkipPermissions,
+        // Prompt is embedded in the command as a positional arg.
+        prompt: opts.source !== 'resume' ? opts.prompt : undefined,
+      })
+      console.info(
+        `[termhub:session] ${id.slice(0, 8)} gemini spawn — cwd=${opts.cwd}` +
           (opts.model ? ` model=${opts.model}` : '') +
           ` cmd="${finalCommand}"`,
       )

--- a/electron/session-manager.ts
+++ b/electron/session-manager.ts
@@ -17,6 +17,7 @@ import {
   isClaudeCommand,
   writeBracketedPasteAndSubmit,
 } from './claude-command'
+import { buildCodexCommand } from './codex-command'
 import { writePersistedSessions, type PersistedSession } from './persistence'
 import { getMcpConfigPath } from './config'
 
@@ -27,6 +28,7 @@ export type Session = {
   name?: string
   repoRoot?: string
   repoLabel?: string
+  cli?: 'claude' | 'codex'
   model?: string
   permissionMode?: string
   dangerouslySkipPermissions?: boolean
@@ -141,6 +143,7 @@ export function persistSessions(): void {
     permissionMode: s.permissionMode,
     dangerouslySkipPermissions: s.dangerouslySkipPermissions,
     allowDangerouslySkipPermissions: s.allowDangerouslySkipPermissions,
+    cli: s.cli,
   }))
   writePersistedSessions(list)
 }
@@ -164,12 +167,14 @@ export function createSessionInternal(opts: {
   allowDangerouslySkipPermissions?: boolean
   permissionMode?: string
   name?: string
+  cli?: 'claude' | 'codex'
   source: 'ipc' | 'mcp' | 'startup' | 'resume'
 }): { id: string; cwd: string; promptSettled: Promise<void> } {
   const id = opts.id ?? randomUUID()
+  const cli = opts.cli ?? 'claude'
   const shell = process.env.COMSPEC || 'cmd.exe'
   console.log(
-    `[termhub] spawning ${shell} in ${opts.cwd} (id=${id.slice(0, 8)}, source=${opts.source})`,
+    `[termhub:session] spawning ${shell} in ${opts.cwd} (id=${id.slice(0, 8)}, cli=${cli}, source=${opts.source})`,
   )
   let term: pty.IPty
   try {
@@ -218,6 +223,7 @@ export function createSessionInternal(opts: {
     name: opts.name,
     repoRoot: repoInfo?.repoRoot,
     repoLabel: repoInfo?.repoLabel,
+    cli,
     model: opts.model,
     permissionMode: opts.permissionMode,
     dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
@@ -257,8 +263,13 @@ export function createSessionInternal(opts: {
   // promptSettled resolves once delivery is complete (paste + CR
   // written), or once we know it's never going to happen (fallback fired,
   // session exited, no prompt provided).
+  // Codex receives its prompt as a positional CLI arg embedded in the
+  // command string — no bracketed-paste delivery needed.
   const wantsPrompt =
-    opts.source !== 'resume' && opts.prompt !== undefined && opts.prompt.length > 0
+    opts.source !== 'resume' &&
+    opts.prompt !== undefined &&
+    opts.prompt.length > 0 &&
+    cli !== 'codex'
   let promptSent = false
   let resolvePromptSettled: () => void = () => {}
   const promptSettled: Promise<void> = wantsPrompt
@@ -295,7 +306,8 @@ export function createSessionInternal(opts: {
   // Watch the Claude Code JSONL file for ground-truth status updates. The
   // file is created by Claude Code shortly after startup; the watcher polls
   // and will begin emitting once the file appears.
-  if (opts.command && isClaudeCommand(opts.command)) {
+  // Codex does not produce a Claude Code JSONL file — skip the watcher.
+  if (cli !== 'codex' && opts.command && isClaudeCommand(opts.command)) {
     session.jsonlWatcher = watchSessionStatus(id, (next) => {
       // Send the initial prompt the first time claude reports 'idle'
       // (parked at the input prompt, submit handler wired). 'busy' and
@@ -366,7 +378,18 @@ export function createSessionInternal(opts: {
 
   if (opts.command && opts.command.trim().length > 0) {
     let finalCommand: string
-    if (isClaudeCommand(opts.command)) {
+    if (cli === 'codex') {
+      finalCommand = buildCodexCommand({
+        model: opts.model,
+        dangerouslyBypassApprovals: opts.dangerouslySkipPermissions,
+        // Prompt is embedded in the command for codex (positional arg).
+        prompt: opts.source !== 'resume' ? opts.prompt : undefined,
+      })
+      console.info(
+        `[termhub:session] ${id.slice(0, 8)} codex spawn — cwd=${opts.cwd}` +
+          (opts.model ? ` model=${opts.model}` : ''),
+      )
+    } else if (isClaudeCommand(opts.command)) {
       finalCommand = buildClaudeCommand({
         sessionId: id,
         mcpConfigPath: getMcpConfigPath(),
@@ -394,6 +417,7 @@ export function createSessionInternal(opts: {
       name: opts.name,
       repoRoot: repoInfo?.repoRoot,
       repoLabel: repoInfo?.repoLabel,
+      cli,
       autoActivate,
     })
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export type Session = {
   name?: string
   repoRoot?: string
   repoLabel?: string
-  cli?: 'claude' | 'codex'
+  cli?: 'claude' | 'codex' | 'gemini'
 }
 
 // Advisory, UI-only session status sourced from Claude Code's own JSONL file.
@@ -37,7 +37,7 @@ export type StartupSession = {
   allowDangerouslySkipPermissions?: boolean
   permissionMode?: string
   name?: string
-  cli?: 'claude' | 'codex'
+  cli?: 'claude' | 'codex' | 'gemini'
 }
 
 export type Config = {
@@ -85,11 +85,11 @@ export type TermhubApi = {
       name?: string,
       repoRoot?: string,
       repoLabel?: string,
-      cli?: 'claude' | 'codex',
+      cli?: 'claude' | 'codex' | 'gemini',
     ) => void,
   ) => () => void
   listSessions: () => Promise<
-    Array<{ id: string; cwd: string; command?: string; name?: string; repoRoot?: string; repoLabel?: string; cli?: 'claude' | 'codex' }>
+    Array<{ id: string; cwd: string; command?: string; name?: string; repoRoot?: string; repoLabel?: string; cli?: 'claude' | 'codex' | 'gemini' }>
   >
   appReady: () => void
   listAgents: () => Promise<AgentDef[]>

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type Session = {
   name?: string
   repoRoot?: string
   repoLabel?: string
+  cli?: 'claude' | 'codex'
 }
 
 // Advisory, UI-only session status sourced from Claude Code's own JSONL file.
@@ -36,6 +37,7 @@ export type StartupSession = {
   allowDangerouslySkipPermissions?: boolean
   permissionMode?: string
   name?: string
+  cli?: 'claude' | 'codex'
 }
 
 export type Config = {
@@ -83,10 +85,11 @@ export type TermhubApi = {
       name?: string,
       repoRoot?: string,
       repoLabel?: string,
+      cli?: 'claude' | 'codex',
     ) => void,
   ) => () => void
   listSessions: () => Promise<
-    Array<{ id: string; cwd: string; command?: string; name?: string; repoRoot?: string; repoLabel?: string }>
+    Array<{ id: string; cwd: string; command?: string; name?: string; repoRoot?: string; repoLabel?: string; cli?: 'claude' | 'codex' }>
   >
   appReady: () => void
   listAgents: () => Promise<AgentDef[]>

--- a/src/useSessions.ts
+++ b/src/useSessions.ts
@@ -111,11 +111,11 @@ export function useSessions(refs: SessionRefs): UseSessionsResult {
       shellPendingDataRef.current.delete(id)
     })
     const offAdded = window.termhub.onSessionAdded(
-      (id, cwd, autoActivate, command, name, repoRoot, repoLabel) => {
+      (id, cwd, autoActivate, command, name, repoRoot, repoLabel, cli) => {
         setSessions((prev) =>
           prev.some((s) => s.id === id)
             ? prev
-            : [...prev, { id, cwd, command, name, repoRoot, repoLabel }],
+            : [...prev, { id, cwd, command, name, repoRoot, repoLabel, cli }],
         )
         if (autoActivate) {
           setActiveId((curr) => curr ?? id)
@@ -141,6 +141,7 @@ export function useSessions(refs: SessionRefs): UseSessionsResult {
                 name: s.name,
                 repoRoot: s.repoRoot,
                 repoLabel: s.repoLabel,
+                cli: s.cli,
               })),
           ]
         })


### PR DESCRIPTION
## Summary

Adds an optional `cli` field to the `open_session` MCP tool, extending the supported runtimes from `claude` (Claude Code, unchanged default) to `'claude' | 'codex' | 'gemini'`. Fully backwards-compatible — omitting `cli` preserves existing behaviour exactly.

Each non-claude runtime embeds the prompt as a positional CLI arg at launch (no bracketed-paste delivery), skips the Claude Code JSONL status watcher, and defaults to bypassing approval prompts so MCP-spawned sessions run autonomously without blocking.

## CLI flag surfaces

**Codex** (`codex [OPTIONS] [PROMPT]`):

| Flag | Purpose |
|---|---|
| `[PROMPT]` | Initial prompt — positional arg |
| `-m / --model` | Model (e.g. `o3`) |
| `--dangerously-bypass-approvals-and-sandbox` | Skip all confirmations + sandbox — **default on** |

**Gemini** (`gemini [OPTIONS] [query..]`):

| Flag | Purpose |
|---|---|
| `[query..]` | Initial prompt — positional arg |
| `-m / --model` | Model (e.g. `gemini-2.5-pro`) |
| `-y / --yolo` | Auto-accept all actions — **default on** |
| `--skip-trust` | Trust workspace for this session — **always on** |

## open_session field mapping

| Field | `claude` | `codex` | `gemini` |
|---|---|---|---|
| `cwd` | ✅ PTY working dir | ✅ PTY working dir | ✅ PTY working dir |
| `prompt` | ✅ bracketed-paste after TUI idle | ✅ positional arg at launch | ✅ positional arg at launch |
| `model` | ✅ `--model` | ✅ `-m` | ✅ `-m` |
| `name` | ✅ sidebar label | ✅ sidebar label | ✅ sidebar label |
| `dangerouslySkipPermissions` | ✅ `--dangerously-skip-permissions` | ✅ `--dangerously-bypass-approvals-and-sandbox` | ✅ `--yolo` |
| `agent` | ✅ `--agent` | ❌ ignored | ❌ ignored |
| `permissionMode` | ✅ `--permission-mode` | ❌ ignored | ❌ ignored |
| `allowDangerouslySkipPermissions` | ✅ `--allow-dangerously-skip-permissions` | ❌ ignored | ❌ ignored |

**Model validation:** passing a `claude-*` model name with `cli: 'codex'` or `cli: 'gemini'` is rejected before spawn with a logged warning and a 500 error.

**Approval defaults:** both Codex and Gemini default to their respective bypass flags (analogous to Claude's `DEFAULT_PERMISSION_MODE = bypassPermissions`). Pass `dangerouslySkipPermissions: false` to opt out.

## Changes

- `electron/codex-command.ts` — `buildCodexArgs`, `buildCodexCommand`, `isClaudeModelName`, `DEFAULT_CODEX_BYPASS_APPROVALS`
- `electron/gemini-command.ts` — `buildGeminiArgs`, `buildGeminiCommand`, `DEFAULT_GEMINI_YOLO`
- `electron/codex-command.test.ts`, `electron/gemini-command.test.ts` — 38 tests across the two new modules
- `electron/session-manager.ts` — branches on `cli` for command building, prompt delivery, and JSONL watcher; `wantsPrompt` and the JSONL guard now use the positive `cli === 'claude'` check
- `electron/main.ts` — model validation covers all non-claude runtimes
- `electron/mcp-bridge.ts`, `electron/mcp.ts` — `cli` zod enum and HTTP parsing extended to three values
- `electron/persistence.ts`, `electron/ipc-session.ts` — `cli` persisted and listed
- `src/types.ts`, `electron/preload.ts`, `src/useSessions.ts` — `cli` threaded through renderer IPC contract

## Test plan

- [ ] `npx vitest run` — 166 tests pass (13 test files)
- [ ] `cli` omitted → Claude Code, behaviour unchanged
- [ ] `cli: 'codex'` + prompt → Codex launches, `--dangerously-bypass-approvals-and-sandbox` present in log, prompt executed
- [ ] `cli: 'gemini'` + prompt → Gemini launches, `--yolo --skip-trust` present in log, prompt executed
- [ ] `cli: 'codex'` + `model: 'claude-opus-4-7'` → warning logged, 500 returned, no session spawned
- [ ] `cli: 'gemini'` + `model: 'claude-sonnet-4-6'` → same rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)