### PR TITLE
fix(pr): treat local-sync failure as success when API merge worked

### DIFF
--- a/electron/ipc-pr.ts
+++ b/electron/ipc-pr.ts
@@ -12,7 +12,9 @@ import {
 import {
   buildCacheKey,
   fetchGhPrList,
+  fetchGhPrViewState,
   getGitBranch,
+  resolveMergeOutcome,
   runGhPrMerge,
 } from './pr-fetch'
 import type { SessionPr } from '../src/types'
@@ -134,21 +136,37 @@ export function registerPrHandlers(): void {
       const session = getSession(payload.id)
       if (!session) throw new Error(`Session not found: ${payload.id}`)
 
-      console.info(
-        `[termhub:pr] merge initiated — session ${payload.id.slice(0, 8)} PR #${payload.prNumber}`,
-      )
-      try {
-        await runGhPrMerge(session.cwd, payload.prNumber)
-        console.info(
-          `[termhub:pr] merge success — session ${payload.id.slice(0, 8)} PR #${payload.prNumber}`,
-        )
-      } catch (err) {
-        console.error(
-          `[termhub:pr] merge failed — session ${payload.id.slice(0, 8)} PR #${payload.prNumber}:`,
-          err,
-        )
-        throw err
+      const sessionTag = `session ${payload.id.slice(0, 8)} PR #${payload.prNumber}`
+      console.info(`[termhub:pr] merge initiated — ${sessionTag}`)
+
+      const { exitCode, stderr } = await runGhPrMerge(session.cwd, payload.prNumber)
+
+      if (exitCode !== 0) {
+        // gh exited non-zero. Check whether the API merge succeeded anyway —
+        // this happens when the local-sync step (git checkout base + pull) fails
+        // because the base branch is already checked out in another worktree.
+        let viewResult: { state: string; mergedAt: string | null } | null = null
+        try {
+          viewResult = await fetchGhPrViewState(session.cwd, payload.prNumber)
+        } catch (viewErr) {
+          console.warn(
+            `[termhub:pr] ${sessionTag}: gh pr view failed after merge error —`,
+            viewErr instanceof Error ? viewErr.message : String(viewErr),
+          )
+        }
+
+        if (resolveMergeOutcome(exitCode, viewResult)) {
+          // API merge confirmed. The local-sync failure is cosmetic — swallow it.
+          console.warn(
+            `[termhub:pr] ${sessionTag}: local-sync failed but API merge succeeded (base branch held by another worktree?). gh stderr: ${stderr}`,
+          )
+        } else {
+          console.error(`[termhub:pr] merge failed — ${sessionTag}: ${stderr}`)
+          throw new Error(`gh pr merge failed: ${stderr}`)
+        }
       }
+
+      console.info(`[termhub:pr] merge success — ${sessionTag}`)
 
       // Refresh PR state after merge (it will now show as merged/closed).
       await fetchAndCachePr(payload.id)

--- a/electron/pr-fetch.ts
+++ b/electron/pr-fetch.ts
@@ -154,21 +154,100 @@ export function fetchGhPrList(cwd: string, branch: string): Promise<SessionPr[]>
 
 /**
  * Spawn `gh pr merge <number> --squash --delete-branch` in the given cwd.
- * Resolves on success, rejects on failure.
+ * Always resolves — never rejects. Callers check exitCode to determine outcome.
  */
-export function runGhPrMerge(cwd: string, prNumber: number): Promise<void> {
-  return new Promise((resolve, reject) => {
+export function runGhPrMerge(
+  cwd: string,
+  prNumber: number,
+): Promise<{ exitCode: number; stderr: string }> {
+  return new Promise((resolve) => {
     execFile(
       'gh',
       ['pr', 'merge', String(prNumber), '--squash', '--delete-branch'],
       { cwd, shell: false },
       (err, _stdout, stderr) => {
         if (err) {
-          reject(new Error(`gh pr merge failed: ${stderr.trim() || err.message}`))
+          // err.code is the process exit code (number) for non-zero exits, or a
+          // string like 'ENOENT' for OS-level spawn errors.
+          const code = (err as { code?: unknown }).code
+          const exitCode = typeof code === 'number' ? code : 1
+          resolve({ exitCode, stderr: stderr.trim() || err.message })
           return
         }
-        resolve()
+        resolve({ exitCode: 0, stderr: '' })
       },
     )
   })
+}
+
+/**
+ * Parse the output of `gh pr view --json state,mergedAt`.
+ * Returns null on any parse failure.
+ */
+export function parseGhPrViewOutput(
+  raw: string,
+): { state: string; mergedAt: string | null } | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    typeof (parsed as Record<string, unknown>).state !== 'string'
+  ) {
+    return null
+  }
+  const obj = parsed as Record<string, unknown>
+  const mergedAt = typeof obj.mergedAt === 'string' ? obj.mergedAt : null
+  return { state: obj.state as string, mergedAt }
+}
+
+/**
+ * Run `gh pr view <number> --json state,mergedAt` in the given cwd.
+ * Rejects if gh is unavailable or the PR cannot be fetched.
+ */
+export function fetchGhPrViewState(
+  cwd: string,
+  prNumber: number,
+): Promise<{ state: string; mergedAt: string | null }> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'gh',
+      ['pr', 'view', String(prNumber), '--json', 'state,mergedAt'],
+      { cwd, shell: false },
+      (err, stdout, stderr) => {
+        if (err) {
+          reject(new Error(`gh pr view failed: ${stderr.trim() || err.message}`))
+          return
+        }
+        const result = parseGhPrViewOutput(stdout)
+        if (!result) {
+          reject(new Error(`gh pr view returned unparseable output: ${stdout.slice(0, 200)}`))
+          return
+        }
+        resolve(result)
+      },
+    )
+  })
+}
+
+/**
+ * Decide whether a merge should be treated as successful given the gh exit code
+ * and the post-call PR view result (null if the view call itself failed).
+ *
+ * exit 0 → success regardless of view result.
+ * exit non-zero, view shows MERGED or non-null mergedAt → the API merge worked;
+ *   local sync failed (e.g. base branch held by another worktree). Treat as success.
+ * exit non-zero, anything else → real failure.
+ */
+export function resolveMergeOutcome(
+  exitCode: number,
+  viewResult: { state: string; mergedAt: string | null } | null,
+): boolean {
+  if (exitCode === 0) return true
+  if (!viewResult) return false
+  return viewResult.state.toUpperCase() === 'MERGED' || viewResult.mergedAt !== null
 }

--- a/src/pr-utils.test.ts
+++ b/src/pr-utils.test.ts
@@ -9,6 +9,8 @@ import {
   parseGhPrListOutput,
   parseGhPrState,
   parseGhCiState,
+  parseGhPrViewOutput,
+  resolveMergeOutcome,
 } from '../electron/pr-fetch'
 
 // ---------------------------------------------------------------------------
@@ -218,5 +220,82 @@ describe('isMergeEnabled', () => {
 
   it('returns false when PR is closed', () => {
     expect(isMergeEnabled({ ...base, state: 'closed', ciState: 'success' })).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseGhPrViewOutput
+// ---------------------------------------------------------------------------
+
+describe('parseGhPrViewOutput', () => {
+  it('parses a merged PR response', () => {
+    const raw = JSON.stringify({ state: 'MERGED', mergedAt: '2024-01-01T00:00:00Z' })
+    expect(parseGhPrViewOutput(raw)).toEqual({ state: 'MERGED', mergedAt: '2024-01-01T00:00:00Z' })
+  })
+
+  it('parses an open PR with null mergedAt', () => {
+    const raw = JSON.stringify({ state: 'OPEN', mergedAt: null })
+    expect(parseGhPrViewOutput(raw)).toEqual({ state: 'OPEN', mergedAt: null })
+  })
+
+  it('returns null for invalid JSON', () => {
+    expect(parseGhPrViewOutput('not json')).toBe(null)
+    expect(parseGhPrViewOutput('')).toBe(null)
+  })
+
+  it('returns null when state field is missing', () => {
+    expect(parseGhPrViewOutput(JSON.stringify({ mergedAt: '2024-01-01T00:00:00Z' }))).toBe(null)
+  })
+
+  it('returns null for non-object values', () => {
+    expect(parseGhPrViewOutput('null')).toBe(null)
+    expect(parseGhPrViewOutput('"MERGED"')).toBe(null)
+    expect(parseGhPrViewOutput('[]')).toBe(null)
+  })
+
+  it('treats absent mergedAt as null', () => {
+    const raw = JSON.stringify({ state: 'OPEN' })
+    expect(parseGhPrViewOutput(raw)).toEqual({ state: 'OPEN', mergedAt: null })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveMergeOutcome
+// ---------------------------------------------------------------------------
+
+describe('resolveMergeOutcome', () => {
+  it('exit 0 → success regardless of view result', () => {
+    expect(resolveMergeOutcome(0, null)).toBe(true)
+    expect(resolveMergeOutcome(0, { state: 'OPEN', mergedAt: null })).toBe(true)
+    expect(resolveMergeOutcome(0, { state: 'MERGED', mergedAt: '2024-01-01T00:00:00Z' })).toBe(true)
+  })
+
+  it('exit non-zero, view state MERGED → success (local-sync failed, API worked)', () => {
+    expect(
+      resolveMergeOutcome(1, { state: 'MERGED', mergedAt: '2024-01-01T00:00:00Z' }),
+    ).toBe(true)
+  })
+
+  it('exit non-zero, non-null mergedAt → success even if state is unexpected', () => {
+    expect(
+      resolveMergeOutcome(1, { state: 'OPEN', mergedAt: '2024-01-01T00:00:00Z' }),
+    ).toBe(true)
+  })
+
+  it('exit non-zero, view state OPEN → failure (real merge error)', () => {
+    expect(resolveMergeOutcome(1, { state: 'OPEN', mergedAt: null })).toBe(false)
+  })
+
+  it('exit non-zero, view itself failed (null) → failure', () => {
+    expect(resolveMergeOutcome(1, null)).toBe(false)
+  })
+
+  it('exit non-zero, view state CLOSED without mergedAt → failure', () => {
+    expect(resolveMergeOutcome(1, { state: 'CLOSED', mergedAt: null })).toBe(false)
+  })
+
+  it('resolveMergeOutcome is case-insensitive for state', () => {
+    expect(resolveMergeOutcome(1, { state: 'merged', mergedAt: null })).toBe(true)
+    expect(resolveMergeOutcome(1, { state: 'Merged', mergedAt: null })).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

The Merge button in the session right-panel reported an error even when the PR had successfully merged on GitHub. `gh pr merge --squash --delete-branch` performs two steps: the API merge (which succeeds), then a local sync (git checkout base branch + pull). When the session's cwd is a worktree of a repo whose base branch is already checked out at the parent path, git refuses the checkout — same class of error as running `git checkout main` in a worktree where `main` is already live elsewhere. This caused the IPC handler to throw, surfacing a spurious failure to the user.

## Changes
- `electron/pr-fetch.ts`: `runGhPrMerge` now always resolves (never rejects), returning `{ exitCode, stderr }` so callers can inspect the outcome without a try/catch
- `electron/pr-fetch.ts`: add `fetchGhPrViewState` — calls `gh pr view --json state,mergedAt` to confirm post-merge PR state
- `electron/pr-fetch.ts`: add pure `resolveMergeOutcome(exitCode, viewResult)` — returns true if exit 0, or if exit non-zero but view confirms the PR is MERGED
- `electron/pr-fetch.ts`: add `parseGhPrViewOutput` — pure parser for the `gh pr view` JSON response
- `electron/ipc-pr.ts`: updated `session:pr:merge` handler to use the above: on non-zero exit, verify via `gh pr view`; if confirmed merged, warn-log the local-sync error and return success; only propagate failure if the PR is genuinely not merged or the view call itself fails
- `src/pr-utils.test.ts`: unit tests for `resolveMergeOutcome` and `parseGhPrViewOutput` covering the four key cases

## Test plan
- [ ] `npm test` — 189 tests, all green
- [ ] `npm run typecheck` — clean
- [ ] Manual: open a session whose branch has a CI-green PR; click Merge; should succeed without error dialog even when the base branch is held by another worktree