### PR TITLE
feat: add token usage panel reading from session JSONL transcripts

### DIFF
--- a/electron/ipc-usage.ts
+++ b/electron/ipc-usage.ts
@@ -1,0 +1,158 @@
+// IPC handlers and poll loop for per-session token usage tracking.
+// Reads Claude Code's JSONL transcript files and emits 'session:usage'
+// events to the renderer whenever usage data changes.
+
+import * as fs from 'node:fs'
+import { ipcMain, BrowserWindow } from 'electron'
+import {
+  getSession,
+  getAllSessions,
+  onSessionCreatedHook,
+  onSessionClosedHook,
+} from './session-manager'
+import {
+  resolveJsonlPath,
+  readJsonlIncremental,
+  buildSummary,
+  makeEmptyParseState,
+  type UsageParseState,
+} from './usage-fetch'
+import type { SessionUsage } from '../src/types'
+
+// Per-session incremental parse state, keyed by session id.
+const parseStates = new Map<string, UsageParseState>()
+// Cached mtime per session — skip reads when the file hasn't changed.
+const lastMtimes = new Map<string, number>()
+// Cached summaries keyed by session id.
+const cachedSummaries = new Map<string, SessionUsage>()
+// Sessions for which we've successfully found and read the JSONL file at
+// least once. Used to distinguish "expected missing" from "unexpectedly gone".
+const hadFile = new Set<string>()
+
+// Per-session poll timer handles, keyed by session id.
+const pollTimers = new Map<string, ReturnType<typeof setInterval>>()
+
+let mainWindow: BrowserWindow | null = null
+
+export function setMainWindowForUsage(window: BrowserWindow | null): void {
+  mainWindow = window
+}
+
+function emitUsageChanged(sessionId: string, usage: SessionUsage): void {
+  mainWindow?.webContents.send('session:usage', { id: sessionId, usage })
+}
+
+async function fetchAndCacheUsage(sessionId: string): Promise<void> {
+  const session = getSession(sessionId)
+  if (!session) return
+
+  const jsonlPath = resolveJsonlPath(session.cwd, session.id)
+
+  // Mtime check — skip parse if nothing has changed since last poll.
+  let mtime: number
+  try {
+    mtime = fs.statSync(jsonlPath).mtimeMs
+  } catch {
+    if (hadFile.has(sessionId)) {
+      console.warn(
+        `[termhub:usage] session ${sessionId.slice(0, 8)}: JSONL gone — expected at ${jsonlPath}`,
+      )
+    }
+    return
+  }
+
+  if (lastMtimes.get(sessionId) === mtime) return
+
+  const currentState = parseStates.get(sessionId) ?? makeEmptyParseState()
+
+  let newState: UsageParseState | null
+  try {
+    newState = readJsonlIncremental(jsonlPath, currentState)
+  } catch (err) {
+    console.error(`[termhub:usage] session ${sessionId.slice(0, 8)}: parse error at ${jsonlPath}:`, err)
+    return
+  }
+
+  if (!newState) return
+
+  hadFile.add(sessionId)
+  parseStates.set(sessionId, newState)
+  lastMtimes.set(sessionId, mtime)
+
+  const summary = buildSummary(newState, jsonlPath)
+
+  // Only emit if the summary changed (shallow-compare by JSON).
+  const prev = cachedSummaries.get(sessionId)
+  if (prev && JSON.stringify(prev) === JSON.stringify(summary)) return
+
+  const isFirstParse = !prev
+  cachedSummaries.set(sessionId, summary)
+
+  if (isFirstParse && summary.turns > 0) {
+    console.info(
+      `[termhub:usage] session ${sessionId.slice(0, 8)}: first parse —`,
+      `turns=${summary.turns}`,
+      `output=${summary.cumulative.outputTokens}`,
+      `cache_hit=${(summary.cacheHitRate * 100).toFixed(0)}%`,
+    )
+  }
+
+  emitUsageChanged(sessionId, summary)
+}
+
+/** Start the 5-second poll loop for a session. Idempotent. */
+function startPollLoop(sessionId: string): void {
+  if (pollTimers.has(sessionId)) return
+  void fetchAndCacheUsage(sessionId)
+  const timer = setInterval(() => {
+    const session = getSession(sessionId)
+    if (!session) {
+      stopUsagePollLoop(sessionId)
+      return
+    }
+    void fetchAndCacheUsage(sessionId)
+  }, 5_000)
+  pollTimers.set(sessionId, timer)
+}
+
+/** Stop the poll loop and clean up state for a session. */
+export function stopUsagePollLoop(sessionId: string): void {
+  const timer = pollTimers.get(sessionId)
+  if (timer !== undefined) {
+    clearInterval(timer)
+    pollTimers.delete(sessionId)
+  }
+  parseStates.delete(sessionId)
+  lastMtimes.delete(sessionId)
+  cachedSummaries.delete(sessionId)
+  hadFile.delete(sessionId)
+}
+
+export function registerUsageHandlers(): void {
+  // Renderer requests current usage for a session (on-demand).
+  ipcMain.handle('session:usage:get', async (_event, payload: { id: string }) => {
+    const session = getSession(payload.id)
+    if (!session) return null
+
+    const cached = cachedSummaries.get(payload.id)
+    if (cached) return cached
+
+    // Not cached yet — do an immediate fetch for this IPC call.
+    await fetchAndCacheUsage(payload.id)
+    return cachedSummaries.get(payload.id) ?? null
+  })
+
+  // Start poll loops for sessions already open when handlers are registered.
+  for (const session of getAllSessions()) {
+    startPollLoop(session.id)
+  }
+
+  // Wire into session lifecycle.
+  onSessionCreatedHook((sessionId) => {
+    startPollLoop(sessionId)
+  })
+
+  onSessionClosedHook((sessionId) => {
+    stopUsagePollLoop(sessionId)
+  })
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -30,6 +30,10 @@ import {
   registerPrHandlers,
   setMainWindowForPr,
 } from './ipc-pr'
+import {
+  registerUsageHandlers,
+  setMainWindowForUsage,
+} from './ipc-usage'
 
 // Isolate dev builds so their sessions, config, and MCP port don't bleed
 // into the production instance running alongside. Must run before the
@@ -110,12 +114,14 @@ function createWindow(): void {
     setMainWindow(null)
     setAppHandlersMainWindow(null)
     setMainWindowForPr(null)
+    setMainWindowForUsage(null)
   })
 
   // Wire the new BrowserWindow into modules that broadcast events to it.
   setMainWindow(mainWindow)
   setAppHandlersMainWindow(mainWindow)
   setMainWindowForPr(mainWindow)
+  setMainWindowForUsage(mainWindow)
 }
 
 // Renderer signals readiness via 'app:ready' once it has subscribed to
@@ -302,6 +308,7 @@ app.whenReady().then(async () => {
   registerDiscoveryHandlers()
   registerAppHandlers({ config })
   registerPrHandlers()
+  registerUsageHandlers()
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -4,6 +4,7 @@ import type {
   Config,
   SessionPr,
   SessionStatus,
+  SessionUsage,
   SkillDef,
 } from '../src/types'
 
@@ -11,6 +12,7 @@ type DataPayload = { id: string; data: string }
 type ExitPayload = { id: string; exitCode: number }
 type StatusPayload = { id: string; status: SessionStatus }
 type PrPayload = { id: string; pr: SessionPr | null }
+type UsagePayload = { id: string; usage: SessionUsage }
 type AddedPayload = {
   id: string
   cwd: string
@@ -178,6 +180,20 @@ const api = {
     ipcRenderer.on('session:pr', handler)
     return () => {
       ipcRenderer.off('session:pr', handler)
+    }
+  },
+
+  getSessionUsage: (sessionId: string): Promise<SessionUsage | null> =>
+    ipcRenderer.invoke('session:usage:get', { id: sessionId }),
+
+  onSessionUsageChanged: (
+    cb: (sessionId: string, usage: SessionUsage) => void,
+  ): (() => void) => {
+    const handler = (_e: Electron.IpcRendererEvent, p: UsagePayload) =>
+      cb(p.id, p.usage)
+    ipcRenderer.on('session:usage', handler)
+    return () => {
+      ipcRenderer.off('session:usage', handler)
     }
   },
 }

--- a/electron/usage-fetch.test.ts
+++ b/electron/usage-fetch.test.ts
@@ -1,0 +1,403 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import {
+  encodeCwdForPath,
+  resolveJsonlPath,
+  MODEL_CONTEXT_LIMITS,
+  getModelContextMax,
+  parseAssistantLine,
+  readJsonlIncremental,
+  buildSummary,
+  makeEmptyParseState,
+} from './usage-fetch'
+
+// ---------------------------------------------------------------------------
+// Path resolver
+// ---------------------------------------------------------------------------
+
+describe('encodeCwdForPath', () => {
+  it('encodes a Windows path with drive letter', () => {
+    expect(encodeCwdForPath('E:\\Apps\\termhub')).toBe('E--Apps-termhub')
+  })
+
+  it('encodes a nested Windows path', () => {
+    expect(encodeCwdForPath('C:\\Users\\alex')).toBe('C--Users-alex')
+  })
+
+  it('encodes a POSIX path', () => {
+    expect(encodeCwdForPath('/home/user/repo')).toBe('-home-user-repo')
+  })
+
+  it('handles a root drive path', () => {
+    expect(encodeCwdForPath('D:\\')).toBe('D--')
+  })
+})
+
+describe('resolveJsonlPath', () => {
+  it('builds the correct path for a Windows cwd', () => {
+    const result = resolveJsonlPath('E:\\Apps\\termhub', 'abc-123')
+    const expected = path.join(os.homedir(), '.claude', 'projects', 'E--Apps-termhub', 'abc-123.jsonl')
+    expect(result).toBe(expected)
+  })
+
+  it('builds the correct path for a POSIX cwd', () => {
+    const result = resolveJsonlPath('/home/user/repo', 'def-456')
+    const expected = path.join(os.homedir(), '.claude', 'projects', '-home-user-repo', 'def-456.jsonl')
+    expect(result).toBe(expected)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Model context limits
+// ---------------------------------------------------------------------------
+
+describe('getModelContextMax', () => {
+  it('returns the correct limit for a known model', () => {
+    expect(getModelContextMax('claude-sonnet-4-6')).toBe(200_000)
+    expect(getModelContextMax('claude-haiku-4-5-20251001')).toBe(200_000)
+    expect(getModelContextMax('claude-opus-4-7')).toBe(1_000_000)
+  })
+
+  it('returns null for an unknown model', () => {
+    expect(getModelContextMax('some-future-model-xyz')).toBeNull()
+  })
+
+  it('returns null when model is null', () => {
+    expect(getModelContextMax(null)).toBeNull()
+  })
+
+  it('covers every model in MODEL_CONTEXT_LIMITS', () => {
+    for (const [model, limit] of Object.entries(MODEL_CONTEXT_LIMITS)) {
+      expect(getModelContextMax(model)).toBe(limit)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseAssistantLine
+// ---------------------------------------------------------------------------
+
+const ASSISTANT_LINE = JSON.stringify({
+  type: 'assistant',
+  message: {
+    model: 'claude-sonnet-4-6',
+    role: 'assistant',
+    usage: {
+      input_tokens: 10,
+      cache_creation_input_tokens: 5000,
+      cache_read_input_tokens: 100000,
+      output_tokens: 800,
+      server_tool_use: { web_search_requests: 1, web_fetch_requests: 2 },
+    },
+  },
+})
+
+describe('parseAssistantLine', () => {
+  it('parses a valid assistant line', () => {
+    const result = parseAssistantLine(ASSISTANT_LINE)
+    expect(result).toEqual({
+      inputTokens: 10,
+      cacheCreateTokens: 5000,
+      cacheReadTokens: 100000,
+      outputTokens: 800,
+      webSearches: 1,
+      webFetches: 2,
+      model: 'claude-sonnet-4-6',
+    })
+  })
+
+  it('returns null for a non-assistant type', () => {
+    const line = JSON.stringify({ type: 'user', message: { role: 'user' } })
+    expect(parseAssistantLine(line)).toBeNull()
+  })
+
+  it('returns null for malformed JSON', () => {
+    expect(parseAssistantLine('{ not valid json')).toBeNull()
+  })
+
+  it('returns null when usage is missing', () => {
+    const line = JSON.stringify({ type: 'assistant', message: { model: 'x', role: 'assistant' } })
+    expect(parseAssistantLine(line)).toBeNull()
+  })
+
+  it('returns null for an empty string', () => {
+    expect(parseAssistantLine('')).toBeNull()
+  })
+
+  it('treats missing server_tool_use fields as zero', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        model: 'claude-sonnet-4-6',
+        usage: { input_tokens: 5, output_tokens: 10 },
+      },
+    })
+    const result = parseAssistantLine(line)
+    expect(result?.webSearches).toBe(0)
+    expect(result?.webFetches).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cache hit rate via buildSummary
+// ---------------------------------------------------------------------------
+
+describe('cache hit rate', () => {
+  it('computes correct cache hit rate', () => {
+    const state = makeEmptyParseState()
+    state.cacheReadTokens = 900
+    state.cacheCreateTokens = 100
+    const summary = buildSummary(state, '/path/to/file.jsonl')
+    expect(summary.cacheHitRate).toBeCloseTo(0.9)
+  })
+
+  it('returns 0 when no cache activity (denominator zero)', () => {
+    const state = makeEmptyParseState()
+    state.cacheReadTokens = 0
+    state.cacheCreateTokens = 0
+    const summary = buildSummary(state, '/path')
+    expect(summary.cacheHitRate).toBe(0)
+    expect(isNaN(summary.cacheHitRate)).toBe(false)
+  })
+
+  it('returns 0 cache hit rate when only creates (no reads)', () => {
+    const state = makeEmptyParseState()
+    state.cacheCreateTokens = 5000
+    const summary = buildSummary(state, '/path')
+    expect(summary.cacheHitRate).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Context window percent
+// ---------------------------------------------------------------------------
+
+describe('context window percent threshold colors (via buildSummary)', () => {
+  it('returns percent < 0.60 for low usage', () => {
+    const state = makeEmptyParseState()
+    state.lastModel = 'claude-sonnet-4-6'
+    state.lastContextUsed = 100_000  // 50% of 200K
+    const summary = buildSummary(state, '/path')
+    expect(summary.contextWindow.percent).toBeCloseTo(0.5)
+  })
+
+  it('returns percent >= 0.60 for medium usage', () => {
+    const state = makeEmptyParseState()
+    state.lastModel = 'claude-sonnet-4-6'
+    state.lastContextUsed = 140_000  // 70% of 200K
+    const summary = buildSummary(state, '/path')
+    expect(summary.contextWindow.percent).toBeCloseTo(0.7)
+  })
+
+  it('returns percent >= 0.80 for high usage', () => {
+    const state = makeEmptyParseState()
+    state.lastModel = 'claude-sonnet-4-6'
+    state.lastContextUsed = 170_000  // 85% of 200K
+    const summary = buildSummary(state, '/path')
+    expect(summary.contextWindow.percent).toBeCloseTo(0.85)
+  })
+
+  it('returns max=0 and percent=0 for unknown model', () => {
+    const state = makeEmptyParseState()
+    state.lastModel = 'unknown-model'
+    state.lastContextUsed = 50_000
+    const summary = buildSummary(state, '/path')
+    expect(summary.contextWindow.max).toBe(0)
+    expect(summary.contextWindow.percent).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// JSONL file parsing (incremental reads with temp files)
+// ---------------------------------------------------------------------------
+
+const tmpFiles: string[] = []
+
+function writeTmpJsonl(lines: unknown[]): string {
+  const filePath = path.join(os.tmpdir(), `usage-test-${Math.random().toString(36).slice(2)}.jsonl`)
+  fs.writeFileSync(filePath, lines.map((l) => JSON.stringify(l)).join('\n') + '\n', 'utf8')
+  tmpFiles.push(filePath)
+  return filePath
+}
+
+afterEach(() => {
+  for (const f of tmpFiles) {
+    try { fs.unlinkSync(f) } catch { /* ignore */ }
+  }
+  tmpFiles.length = 0
+})
+
+function makeAssistantEntry(overrides: Partial<{
+  inputTokens: number
+  cacheCreate: number
+  cacheRead: number
+  outputTokens: number
+  webSearch: number
+  webFetch: number
+  model: string
+}> = {}) {
+  return {
+    type: 'assistant',
+    message: {
+      model: overrides.model ?? 'claude-sonnet-4-6',
+      role: 'assistant',
+      usage: {
+        input_tokens: overrides.inputTokens ?? 10,
+        cache_creation_input_tokens: overrides.cacheCreate ?? 1000,
+        cache_read_input_tokens: overrides.cacheRead ?? 50000,
+        output_tokens: overrides.outputTokens ?? 500,
+        server_tool_use: {
+          web_search_requests: overrides.webSearch ?? 0,
+          web_fetch_requests: overrides.webFetch ?? 0,
+        },
+      },
+    },
+  }
+}
+
+describe('readJsonlIncremental', () => {
+  it('returns null when the file does not exist', () => {
+    const state = makeEmptyParseState()
+    const result = readJsonlIncremental('/nonexistent/path/abc.jsonl', state)
+    expect(result).toBeNull()
+  })
+
+  it('parses zero assistant turns and returns zeros', () => {
+    const filePath = writeTmpJsonl([
+      { type: 'user', message: { role: 'user', content: 'hi' } },
+      { type: 'agent-setting', agentSetting: 'termhub' },
+    ])
+    const state = makeEmptyParseState()
+    const result = readJsonlIncremental(filePath, state)
+    expect(result).not.toBeNull()
+    expect(result!.turns).toBe(0)
+    expect(result!.outputTokens).toBe(0)
+  })
+
+  it('parses N assistant turns and returns correct sums', () => {
+    const filePath = writeTmpJsonl([
+      { type: 'user', message: { content: 'prompt' } },
+      makeAssistantEntry({ outputTokens: 300, cacheCreate: 2000, cacheRead: 10000 }),
+      { type: 'user', message: { content: 'follow-up' } },
+      makeAssistantEntry({ outputTokens: 500, cacheCreate: 0, cacheRead: 12000 }),
+    ])
+    const state = makeEmptyParseState()
+    const result = readJsonlIncremental(filePath, state)!
+    expect(result.turns).toBe(2)
+    expect(result.outputTokens).toBe(800)
+    expect(result.cacheCreateTokens).toBe(2000)
+    expect(result.cacheReadTokens).toBe(22000)
+  })
+
+  it('skips malformed lines without crashing', () => {
+    const filePath = path.join(
+      os.tmpdir(),
+      `usage-test-malformed-${Math.random().toString(36).slice(2)}.jsonl`,
+    )
+    const validLine = JSON.stringify(makeAssistantEntry({ outputTokens: 100 }))
+    // Write one valid, one malformed, one valid
+    fs.writeFileSync(filePath, `${validLine}\n{ broken json\n${validLine}\n`, 'utf8')
+    tmpFiles.push(filePath)
+
+    const state = makeEmptyParseState()
+    const result = readJsonlIncremental(filePath, state)!
+    expect(result.turns).toBe(2)
+    expect(result.outputTokens).toBe(200)
+  })
+
+  it('skips assistant lines missing usage', () => {
+    const noUsageLine = { type: 'assistant', message: { model: 'x', role: 'assistant' } }
+    const filePath = writeTmpJsonl([noUsageLine, makeAssistantEntry({ outputTokens: 200 })])
+    const state = makeEmptyParseState()
+    const result = readJsonlIncremental(filePath, state)!
+    expect(result.turns).toBe(1)
+    expect(result.outputTokens).toBe(200)
+  })
+
+  it('returns unchanged state when file has not grown', () => {
+    const filePath = writeTmpJsonl([makeAssistantEntry()])
+    const state = makeEmptyParseState()
+    const first = readJsonlIncremental(filePath, state)!
+
+    // Second call with updated offset — file unchanged
+    const second = readJsonlIncremental(filePath, first)
+    expect(second).toBe(first)  // same reference — no re-parse
+  })
+
+  it('reads only new lines on incremental calls', () => {
+    const filePath = path.join(
+      os.tmpdir(),
+      `usage-test-incremental-${Math.random().toString(36).slice(2)}.jsonl`,
+    )
+    tmpFiles.push(filePath)
+
+    const line1 = JSON.stringify(makeAssistantEntry({ outputTokens: 100 }))
+    fs.writeFileSync(filePath, `${line1}\n`, 'utf8')
+
+    const state = makeEmptyParseState()
+    const afterFirst = readJsonlIncremental(filePath, state)!
+    expect(afterFirst.turns).toBe(1)
+    expect(afterFirst.outputTokens).toBe(100)
+
+    // Append a second line
+    const line2 = JSON.stringify(makeAssistantEntry({ outputTokens: 200 }))
+    fs.appendFileSync(filePath, `${line2}\n`, 'utf8')
+
+    const afterSecond = readJsonlIncremental(filePath, afterFirst)!
+    expect(afterSecond.turns).toBe(2)
+    expect(afterSecond.outputTokens).toBe(300)
+  })
+
+  it('tracks the last model seen', () => {
+    const filePath = writeTmpJsonl([
+      makeAssistantEntry({ model: 'claude-opus-4-7' }),
+      makeAssistantEntry({ model: 'claude-sonnet-4-6' }),
+    ])
+    const state = makeEmptyParseState()
+    const result = readJsonlIncremental(filePath, state)!
+    expect(result.lastModel).toBe('claude-sonnet-4-6')
+  })
+
+  it('accumulates web search and fetch counts', () => {
+    const filePath = writeTmpJsonl([
+      makeAssistantEntry({ webSearch: 2, webFetch: 1 }),
+      makeAssistantEntry({ webSearch: 0, webFetch: 3 }),
+    ])
+    const state = makeEmptyParseState()
+    const result = readJsonlIncremental(filePath, state)!
+    expect(result.webSearches).toBe(2)
+    expect(result.webFetches).toBe(4)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildSummary
+// ---------------------------------------------------------------------------
+
+describe('buildSummary', () => {
+  it('includes the jsonlPath verbatim', () => {
+    const state = makeEmptyParseState()
+    const summary = buildSummary(state, '/some/path/session.jsonl')
+    expect(summary.jsonlPath).toBe('/some/path/session.jsonl')
+  })
+
+  it('computes contextWindow.used as lastContextUsed', () => {
+    const state = makeEmptyParseState()
+    state.lastModel = 'claude-sonnet-4-6'
+    state.lastContextUsed = 80_000
+    const summary = buildSummary(state, '/p')
+    expect(summary.contextWindow.used).toBe(80_000)
+    expect(summary.contextWindow.max).toBe(200_000)
+    expect(summary.contextWindow.percent).toBeCloseTo(0.4)
+  })
+
+  it('sets max=0 and percent=0 when model is null', () => {
+    const state = makeEmptyParseState()
+    state.lastContextUsed = 50_000
+    const summary = buildSummary(state, '/p')
+    expect(summary.contextWindow.max).toBe(0)
+    expect(summary.contextWindow.percent).toBe(0)
+  })
+})

--- a/electron/usage-fetch.ts
+++ b/electron/usage-fetch.ts
@@ -1,0 +1,242 @@
+// Pure helpers for reading and parsing Claude Code JSONL usage data.
+// No Electron or IPC dependencies — importable in tests without mocking.
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import type { SessionUsage } from '../src/types'
+
+export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
+  'claude-opus-4-7': 1_000_000,
+  'claude-sonnet-4-6': 200_000,
+  'claude-haiku-4-5-20251001': 200_000,
+  'claude-opus-4-5': 200_000,
+  'claude-sonnet-4-5': 200_000,
+  'claude-haiku-4-5': 200_000,
+}
+
+/** Map a model id to its max context window in tokens, or null if unknown. */
+export function getModelContextMax(model: string | null): number | null {
+  if (!model) return null
+  return MODEL_CONTEXT_LIMITS[model] ?? null
+}
+
+/**
+ * Encode a cwd path into the sanitized directory name Claude Code uses under
+ * ~/.claude/projects/. Replaces \, /, and : each with -.
+ *
+ * E.g. "E:\Apps\termhub" → "E--Apps-termhub"
+ *      "/home/user/repo" → "-home-user-repo"
+ */
+export function encodeCwdForPath(cwd: string): string {
+  return cwd.replace(/[\\/:]/g, '-')
+}
+
+/**
+ * Resolve the absolute path to the JSONL transcript for a session.
+ * The file may not exist yet for new sessions.
+ */
+export function resolveJsonlPath(cwd: string, sessionId: string): string {
+  const encoded = encodeCwdForPath(cwd)
+  return path.join(os.homedir(), '.claude', 'projects', encoded, `${sessionId}.jsonl`)
+}
+
+// ---------------------------------------------------------------------------
+// Internal parsing types
+// ---------------------------------------------------------------------------
+
+type RawServerToolUse = {
+  web_search_requests?: unknown
+  web_fetch_requests?: unknown
+}
+
+type RawUsage = {
+  input_tokens?: unknown
+  cache_creation_input_tokens?: unknown
+  cache_read_input_tokens?: unknown
+  output_tokens?: unknown
+  server_tool_use?: RawServerToolUse
+}
+
+type AssistantTurnData = {
+  inputTokens: number
+  cacheCreateTokens: number
+  cacheReadTokens: number
+  outputTokens: number
+  webSearches: number
+  webFetches: number
+  model: string | null
+}
+
+function toNum(v: unknown): number {
+  return typeof v === 'number' && isFinite(v) ? Math.max(0, v) : 0
+}
+
+/**
+ * Parse a single JSONL line. Returns data if it's an assistant turn with usage,
+ * null otherwise (including malformed lines and non-assistant types).
+ */
+export function parseAssistantLine(line: string): AssistantTurnData | null {
+  let obj: unknown
+  try {
+    obj = JSON.parse(line)
+  } catch {
+    return null
+  }
+  if (!obj || typeof obj !== 'object') return null
+  const rec = obj as Record<string, unknown>
+  if (rec['type'] !== 'assistant') return null
+
+  const message = rec['message']
+  if (!message || typeof message !== 'object') return null
+  const msg = message as Record<string, unknown>
+
+  const usage = msg['usage'] as RawUsage | undefined
+  if (!usage || typeof usage !== 'object') return null
+
+  const model = typeof msg['model'] === 'string' ? msg['model'] : null
+  const stu = usage.server_tool_use as RawServerToolUse | undefined
+
+  return {
+    inputTokens: toNum(usage.input_tokens),
+    cacheCreateTokens: toNum(usage.cache_creation_input_tokens),
+    cacheReadTokens: toNum(usage.cache_read_input_tokens),
+    outputTokens: toNum(usage.output_tokens),
+    webSearches: toNum(stu?.web_search_requests),
+    webFetches: toNum(stu?.web_fetch_requests),
+    model,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Incremental parse state
+// ---------------------------------------------------------------------------
+
+export type UsageParseState = {
+  /** Byte offset into the JSONL file — next read starts here. */
+  fileOffset: number
+  turns: number
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheCreateTokens: number
+  webFetches: number
+  webSearches: number
+  lastModel: string | null
+  /** Total input tokens for the last assistant turn (context window proxy). */
+  lastContextUsed: number
+}
+
+export function makeEmptyParseState(): UsageParseState {
+  return {
+    fileOffset: 0,
+    turns: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreateTokens: 0,
+    webFetches: 0,
+    webSearches: 0,
+    lastModel: null,
+    lastContextUsed: 0,
+  }
+}
+
+/**
+ * Accumulate assistant-turn data from `text` (one or more complete newline-
+ * separated JSONL lines) into `state`. Mutates state in place.
+ */
+export function accumulate(text: string, state: UsageParseState): void {
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const data = parseAssistantLine(trimmed)
+    if (!data) continue
+    state.turns++
+    state.inputTokens += data.inputTokens
+    state.outputTokens += data.outputTokens
+    state.cacheReadTokens += data.cacheReadTokens
+    state.cacheCreateTokens += data.cacheCreateTokens
+    state.webFetches += data.webFetches
+    state.webSearches += data.webSearches
+    if (data.model) state.lastModel = data.model
+    // Context window = all input tokens consumed in this turn
+    state.lastContextUsed = data.cacheReadTokens + data.cacheCreateTokens + data.inputTokens
+  }
+}
+
+/**
+ * Read the JSONL file from `state.fileOffset` onward, parse any new complete
+ * lines, and return an updated state.
+ *
+ * Returns null if the file doesn't exist.
+ * Returns the same state object (reference-equal) if there is nothing new.
+ */
+export function readJsonlIncremental(
+  jsonlPath: string,
+  state: UsageParseState,
+): UsageParseState | null {
+  let fd: number
+  try {
+    fd = fs.openSync(jsonlPath, 'r')
+  } catch {
+    return null
+  }
+
+  try {
+    const stat = fs.fstatSync(fd)
+    const fileSize = stat.size
+
+    if (fileSize <= state.fileOffset) return state
+
+    const toRead = fileSize - state.fileOffset
+    const buf = Buffer.allocUnsafe(toRead)
+    const bytesRead = fs.readSync(fd, buf, 0, toRead, state.fileOffset)
+    const text = buf.subarray(0, bytesRead).toString('utf8')
+
+    // Only process up to the last complete line so we don't parse a line that
+    // is still being written.
+    const lastNl = text.lastIndexOf('\n')
+    if (lastNl === -1) return state
+
+    const completeText = text.slice(0, lastNl)
+    const processedBytes = Buffer.byteLength(text.slice(0, lastNl + 1), 'utf8')
+
+    const newState: UsageParseState = { ...state, fileOffset: state.fileOffset + processedBytes }
+    accumulate(completeText, newState)
+    return newState
+  } finally {
+    fs.closeSync(fd)
+  }
+}
+
+/** Build a `SessionUsage` snapshot from the current parse state. */
+export function buildSummary(state: UsageParseState, jsonlPath: string): SessionUsage {
+  const model = state.lastModel
+  const maxCtx = getModelContextMax(model)
+  const used = state.lastContextUsed
+  const percent = maxCtx && maxCtx > 0 ? used / maxCtx : 0
+
+  const cacheTotal = state.cacheReadTokens + state.cacheCreateTokens
+  const cacheHitRate = cacheTotal > 0 ? state.cacheReadTokens / cacheTotal : 0
+
+  return {
+    contextWindow: {
+      used,
+      max: maxCtx ?? 0,
+      percent,
+    },
+    cumulative: {
+      inputTokens: state.inputTokens,
+      outputTokens: state.outputTokens,
+      cacheReadTokens: state.cacheReadTokens,
+      cacheCreateTokens: state.cacheCreateTokens,
+    },
+    cacheHitRate,
+    webFetches: state.webFetches,
+    webSearches: state.webSearches,
+    turns: state.turns,
+    model,
+    jsonlPath,
+  }
+}

--- a/src/RightPanel.tsx
+++ b/src/RightPanel.tsx
@@ -3,6 +3,7 @@ import { AgentList } from './AgentList'
 import { SkillList } from './SkillList'
 import { McpList } from './McpList'
 import { SessionPrPanel } from './SessionPrPanel'
+import { SessionUsagePanel } from './SessionUsagePanel'
 import type { Session } from './types'
 
 type Props = {
@@ -24,6 +25,9 @@ export function RightPanel({ activeSession }: Props) {
         </CollapsibleSection>
         <CollapsibleSection title="Pull Request">
           <SessionPrPanel session={activeSession} />
+        </CollapsibleSection>
+        <CollapsibleSection title="Token Usage">
+          <SessionUsagePanel session={activeSession} />
         </CollapsibleSection>
       </div>
     </aside>

--- a/src/SessionUsagePanel.tsx
+++ b/src/SessionUsagePanel.tsx
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { Session, SessionUsage } from './types'
+
+type Props = {
+  session: Session | null
+}
+
+function fmt(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`
+  return String(n)
+}
+
+function pct(value: number): string {
+  return `${(value * 100).toFixed(0)}%`
+}
+
+function contextBarColor(percent: number): string {
+  if (percent >= 0.80) return '#f85149'
+  if (percent >= 0.60) return '#e3b341'
+  return '#3fb950'
+}
+
+export function SessionUsagePanel({ session }: Props) {
+  const [usage, setUsage] = useState<SessionUsage | null>(null)
+  const [loading, setLoading] = useState(false)
+  const sessionIdRef = useRef<string | null>(null)
+
+  const fetchUsage = useCallback(async (id: string) => {
+    setLoading(true)
+    try {
+      const result = await window.termhub.getSessionUsage(id)
+      if (sessionIdRef.current === id) {
+        setUsage(result)
+      }
+    } catch {
+      // Usage data is non-critical; silently ignore fetch errors.
+    } finally {
+      if (sessionIdRef.current === id) {
+        setLoading(false)
+      }
+    }
+  }, [])
+
+  // Reset and fetch when the active session changes.
+  useEffect(() => {
+    if (!session) {
+      sessionIdRef.current = null
+      setUsage(null)
+      setLoading(false)
+      return
+    }
+    sessionIdRef.current = session.id
+    setUsage(null)
+    void fetchUsage(session.id)
+  }, [session, fetchUsage])
+
+  // Subscribe to push events from the poll loop.
+  useEffect(() => {
+    const unsub = window.termhub.onSessionUsageChanged((sessionId, updatedUsage) => {
+      if (sessionIdRef.current === sessionId) {
+        setUsage(updatedUsage)
+      }
+    })
+    return unsub
+  }, [])
+
+  if (!session) return <p className="hint">No active session.</p>
+
+  if (loading && usage === null) return <p className="hint">Loading…</p>
+
+  if (usage === null) return <p className="hint">No usage data yet.</p>
+
+  const { contextWindow, cumulative, cacheHitRate, webFetches, webSearches, turns, model } = usage
+  const hasMax = contextWindow.max > 0
+  const barColor = contextBarColor(contextWindow.percent)
+  const isHighUsage = hasMax && contextWindow.percent >= 0.80
+
+  return (
+    <div className="usage-panel">
+      <div className="usage-ctx-row">
+        <span className="usage-label">Context</span>
+        <span className="usage-ctx-nums">
+          {fmt(contextWindow.used)}
+          {hasMax ? ` / ${fmt(contextWindow.max)}` : ''}
+          {hasMax ? ` (${pct(contextWindow.percent)})` : ''}
+        </span>
+      </div>
+
+      {hasMax && (
+        <div className="usage-bar-track">
+          <div
+            className="usage-bar-fill"
+            style={{
+              width: `${Math.min(contextWindow.percent * 100, 100).toFixed(1)}%`,
+              background: barColor,
+            }}
+          />
+        </div>
+      )}
+
+      {isHighUsage && (
+        <p className="usage-warn">Context window ≥80% full</p>
+      )}
+
+      <div className="usage-stat-row">
+        <span className="usage-stat-label">Output tokens</span>
+        <span className="usage-stat-val">{fmt(cumulative.outputTokens)}</span>
+      </div>
+
+      <div className="usage-stat-row">
+        <span className="usage-stat-label">Cache hit rate</span>
+        <span className="usage-stat-val">{pct(cacheHitRate)}</span>
+      </div>
+
+      <div className="usage-meta-row">
+        <span className="usage-meta">{turns} turn{turns !== 1 ? 's' : ''}</span>
+        {webSearches > 0 && <span className="usage-meta">{webSearches} search</span>}
+        {webFetches > 0 && <span className="usage-meta">{webFetches} fetch</span>}
+      </div>
+
+      {model && (
+        <div className="usage-footer" title={usage.jsonlPath}>
+          {model}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -728,6 +728,94 @@ body,
   justify-content: flex-end;
 }
 
+/* ---------- Usage panel ---------- */
+
+.usage-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.usage-ctx-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.usage-label {
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.usage-ctx-nums {
+  font-size: 11px;
+  color: var(--text);
+  text-align: right;
+}
+
+.usage-bar-track {
+  height: 4px;
+  background: var(--border);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-bottom: 2px;
+}
+
+.usage-bar-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.3s ease, background 0.3s ease;
+}
+
+.usage-warn {
+  margin: 0;
+  font-size: 10px;
+  color: #f85149;
+  text-align: right;
+}
+
+.usage-stat-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.usage-stat-label {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.usage-stat-val {
+  font-size: 11px;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+.usage-meta-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 2px;
+}
+
+.usage-meta {
+  font-size: 10px;
+  color: var(--text-dim);
+}
+
+.usage-footer {
+  font-size: 10px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 2px;
+  cursor: default;
+}
+
 /* ---------- Main pane ---------- */
 
 .main {

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,22 @@ export type SessionPr = {
   ciState: 'pending' | 'success' | 'failure' | null
 }
 
+export type SessionUsage = {
+  contextWindow: { used: number; max: number; percent: number }
+  cumulative: {
+    inputTokens: number
+    outputTokens: number
+    cacheReadTokens: number
+    cacheCreateTokens: number
+  }
+  cacheHitRate: number
+  webFetches: number
+  webSearches: number
+  turns: number
+  model: string | null
+  jsonlPath: string
+}
+
 export type TermhubApi = {
   createSession: (cwd: string) => Promise<{ id: string; cwd: string }>
   sendInput: (id: string, data: string) => void
@@ -108,6 +124,10 @@ export type TermhubApi = {
   mergeSessionPr: (sessionId: string, prNumber: number) => Promise<void>
   onSessionPrChanged: (
     cb: (sessionId: string, pr: SessionPr | null) => void,
+  ) => () => void
+  getSessionUsage: (sessionId: string) => Promise<SessionUsage | null>
+  onSessionUsageChanged: (
+    cb: (sessionId: string, usage: SessionUsage) => void,
   ) => () => void
 }
 


### PR DESCRIPTION
## Summary

Adds a **Token Usage** collapsible section to the right-hand sidebar. It reads Claude Code's JSONL transcript files (`~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`) on a 5-second poll loop and surfaces:

- **Context window**: used / max with a color-coded progress bar (green < 60%, yellow 60–80%, red ≥ 80%) and a warning when ≥ 80% full
- **Cumulative output tokens**: total output this session
- **Cache hit rate**: `cache_read / (cache_read + cache_create)`
- **Turn count**, web searches, web fetches
- **Model name** as a footer (with the JSONL path in the title attribute for diagnostics)

Pattern mirrors the PR-tracking panel (#45): pure fetch helpers → IPC handler + poll loop → React component → CollapsibleSection in RightPanel.

## IPC contract additions

**New type** in `src/types.ts`:
```ts
type SessionUsage = {
  contextWindow: { used: number; max: number; percent: number }
  cumulative: {
    inputTokens: number; outputTokens: number
    cacheReadTokens: number; cacheCreateTokens: number
  }
  cacheHitRate: number
  webFetches: number; webSearches: number
  turns: number
  model: string | null
  jsonlPath: string
}
```

**New IPC methods** in `TermhubApi`:
```ts
getSessionUsage(sessionId: string): Promise<SessionUsage | null>
onSessionUsageChanged(cb: (sessionId: string, usage: SessionUsage) => void): () => void
```

## Model context-limit table

```ts
const MODEL_CONTEXT_LIMITS: Record<string, number> = {
  'claude-opus-4-7': 1_000_000,
  'claude-sonnet-4-6': 200_000,
  'claude-haiku-4-5-20251001': 200_000,
  'claude-opus-4-5': 200_000,
  'claude-sonnet-4-5': 200_000,
  'claude-haiku-4-5': 200_000,
}
```

If the model isn't in the table, context bar/percent are hidden; used tokens are still shown.

## Panel layout (approximate)

```
▾ Token Usage
  Context      87K / 200K (44%)
  [████░░░░░░░░░░░░░░░░]  ← green bar
  Output tokens          45K
  Cache hit rate         94%
  12 turns  2 search  0 fetch
  claude-sonnet-4-6
```

## Polling behaviour

- Polls every **5 seconds** per active session, compared to the PR panel's 30 s.
- Uses mtime check as a fast-path: if the file hasn't changed since the last read, no file I/O happens.
- Uses incremental byte-offset reads so only new JSONL lines are parsed on each poll.
- Poll loop stops and state is cleaned up when the session closes — no inactive-session polling.

## Changes

- `electron/usage-fetch.ts` — pure helpers: path encoder, JSONL parser, incremental reader, summary builder (no Electron deps)
- `electron/ipc-usage.ts` — IPC handler (`session:usage:get`) + 5 s poll loop, hooks into session lifecycle
- `electron/preload.ts` — `getSessionUsage` / `onSessionUsageChanged` bridge methods
- `electron/main.ts` — registers usage handlers and wires `setMainWindowForUsage`
- `src/types.ts` — `SessionUsage` type + `TermhubApi` additions
- `src/SessionUsagePanel.tsx` — React component mirroring `SessionPrPanel` pattern
- `src/RightPanel.tsx` — adds Token Usage `CollapsibleSection`
- `src/styles.css` — `.usage-*` CSS classes

## Test plan

- [x] `npm test` — 35 new tests in `electron/usage-fetch.test.ts`, 211 total passing
- [x] `npm run typecheck` — clean
- [ ] `npm run dev` — open a session with JSONL history; right panel shows Token Usage with real numbers; switch sessions and section updates; context bar color changes at 60%/80% thresholds