### PR TITLE
fix(renderer): resync xterm viewport on session switch

### DIFF
--- a/src/useXterm.ts
+++ b/src/useXterm.ts
@@ -86,10 +86,16 @@ export function useXterm({
       const raf = requestAnimationFrame(() => {
         try {
           existing.fit.fit()
+          // Chromium resets scrollTop to 0 when the parent goes display:none,
+          // which updates xterm's _lastScrollTop but not buffer.ydisp (xterm
+          // guards against that). fit() only calls resize() when dims change;
+          // when they're the same it skips resize() entirely, so
+          // syncScrollArea() never runs and scrollTop stays 0 while ydisp
+          // stays at ybase. The result: scrollbar at top, content at bottom,
+          // any scroll interaction desyncs further. Calling syncScrollArea with
+          // immediate=true detects the mismatch and corrects scrollTop in place.
+          ;(existing.term as any)._core?.viewport?.syncScrollArea?.(true)
           if (behavior.focusOnReactivate) {
-            // Scroll to bottom after fit so the scrollbar extent is current
-            // before we jump — otherwise xterm may not be able to reach the
-            // last line.
             existing.term.scrollToBottom()
             existing.term.focus()
           }


### PR DESCRIPTION
## Summary

When switching to a session and then scrolling up in the terminal, the xterm.js scrollbar desynced from the visible content — the thumb appeared at the top while the content showed the bottom of the buffer, and scroll interactions (especially scrollbar drag) behaved unexpectedly. Resizing the Electron window fixed it immediately.

**Root cause**: Chromium resets `.xterm-viewport.scrollTop` to 0 when a parent element gets `display: none`. xterm's `_handleScroll` detects the non-visible state (`offsetParent === null`) and correctly does not update `buffer.ydisp`, but it *does* record the stale `_lastScrollTop = 0`. When the session is re-shown, two paths that should fix this both silently no-op:

1. `FitAddon.fit()` only calls `terminal.resize()` when cols/rows change — with identical window size, it returns early without ever calling `syncScrollArea()`.
2. `terminal.scrollToBottom()` calls `scrollLines(ybase − ydisp)` which is `scrollLines(0)` when already at the bottom; `Viewport.scrollLines(0)` has an explicit early-return guard.

Result: `scrollTop = 0` but `buffer.ydisp = ybase`, making the scrollbar show the top while the terminal renders the bottom.

**Fix**: After `fit()` in the re-activation rAF, call `viewport.syncScrollArea(immediate: true)` via xterm's private `_core` API (the same pattern FitAddon itself uses). `syncScrollArea` detects `_lastScrollTop !== ydisp × rowHeight` and calls `_innerRefresh()` synchronously, which sets `scrollTop = ydisp × rowHeight` and records the correct `_lastScrollTop`. After that, `scrollToBottom()` lands in the right place (or is a true no-op because `scrollTop` is already correct).

## Changes

- `src/useXterm.ts`: add `_core.viewport.syncScrollArea(true)` call in the existing-terminal re-activation rAF, between `fit()` and `scrollToBottom()`

## Test plan

This is a manual-verification fix — no meaningful unit-test surface for xterm viewport internals.

Repro steps:

1. `npm run dev`
2. Open at least two sessions
3. Switch to a second session via the sidebar
4. Scroll up in its terminal with the mouse wheel
5. **Before fix**: scrollbar thumb jumps to an incorrect position; dragging it doesn't track the visible content; scrolling back to the bottom is broken
6. **After fix**: scrollbar tracks scroll position correctly throughout; scroll-to-bottom works normally
7. Repeat cycling between sessions a few times to confirm it's not order-dependent