### PR TITLE
fix: track status of sessions resumed from prior run

### DIFF
--- a/electron/claude-command.test.ts
+++ b/electron/claude-command.test.ts
@@ -62,10 +62,12 @@ describe('buildClaudeArgs', () => {
     expect(flags.join(' ')).not.toContain('--resume')
   })
 
-  it('includes --resume for a resume call', () => {
+  it('includes both --session-id and --resume for a resume call', () => {
     const flags = buildClaudeArgs({ ...BUILD_ARGS_BASE, resume: true })
     expect(flags.some((f) => f.includes('--resume'))).toBe(true)
-    expect(flags.join(' ')).not.toContain('--session-id')
+    // --session-id must also be present so the status watcher can discover
+    // the Claude Code session file via its sessionId field.
+    expect(flags.some((f) => f.includes('--session-id'))).toBe(true)
   })
 
   it('includes --permission-mode with provided value', () => {

--- a/electron/claude-command.ts
+++ b/electron/claude-command.ts
@@ -33,6 +33,10 @@ export function buildClaudeArgs(opts: {
   const flags: string[] = [`--mcp-config "${opts.mcpConfigPath}"`]
 
   if (opts.resume) {
+    // --session-id is required even on resume so Claude Code writes the
+    // termhub session id into ~/.claude/sessions/<pid>.json, letting the
+    // status watcher discover the file via findSessionFileBySessionId.
+    flags.push(`--session-id "${opts.sessionId}"`)
     flags.push(`--resume "${opts.sessionId}"`)
     if (opts.model && opts.model.length > 0) {
       flags.push(`--model "${opts.model}"`)


### PR DESCRIPTION
## Summary

When termhub restarts and resumes a persisted session, the session's status indicator (working / awaiting / idle / failed) never changed — it stayed frozen at `working` for the lifetime of the resumed session. New sessions created after the restart worked correctly.

**Root cause:** The status watcher (`electron/status-watcher.ts`) discovers the Claude Code session file at `~/.claude/sessions/<pid>.json` by matching the file's `sessionId` field against the termhub session UUID. Claude Code only writes that field when invoked with `--session-id <id>`. The resume code path in `buildClaudeArgs` emitted `--resume <id>` but not `--session-id <id>`, so `findSessionFileBySessionId` never found a match, the watcher stayed idle, and status never updated.

## Changes

- `electron/claude-command.ts`: add `--session-id` to the resume branch of `buildClaudeArgs` so both flags are emitted on resume. Claude Code writes the termhub UUID into the session file; the watcher discovers it; status updates flow normally.
- `electron/claude-command.test.ts`: update the test that was asserting the broken behaviour (`not.toContain('--session-id')` on resume calls) to instead verify both flags are present.

## Test plan

Automated (all passing):
- [ ] `npm test` — 176 tests pass, including the updated `buildClaudeArgs` resume test

Manual verification (this is a PTY/IPC integration fix, no unit test can cover the full path):
- [ ] Open a session, confirm status dot changes (working → idle) as Claude runs
- [ ] Quit termhub cleanly, relaunch
- [ ] Confirm the resumed session's status dot now updates correctly as activity changes
- [ ] Open a new session in the relaunched instance — confirm the new-session path still works

> Note: the typecheck script exits non-zero due to pre-existing `Cannot find module 'vitest'` errors in both tsconfigs. These are identical before and after this change.