### PR TITLE
fix(usage): encode dots in cwd path so worktree sessions find their JSONL

### DIFF
--- a/electron/usage-fetch.test.ts
+++ b/electron/usage-fetch.test.ts
@@ -33,6 +33,16 @@ describe('encodeCwdForPath', () => {
   it('handles a root drive path', () => {
     expect(encodeCwdForPath('D:\\')).toBe('D--')
   })
+
+  it('encodes dots in path segments (hidden directories like .claude)', () => {
+    expect(
+      encodeCwdForPath('E:\\Apps\\termhub\\.claude\\worktrees\\my-feature'),
+    ).toBe('E--Apps-termhub--claude-worktrees-my-feature')
+  })
+
+  it('encodes dots in POSIX hidden directories', () => {
+    expect(encodeCwdForPath('/home/user/.config')).toBe('-home-user--config')
+  })
 })
 
 describe('resolveJsonlPath', () => {

--- a/electron/usage-fetch.ts
+++ b/electron/usage-fetch.ts
@@ -23,13 +23,14 @@ export function getModelContextMax(model: string | null): number | null {
 
 /**
  * Encode a cwd path into the sanitized directory name Claude Code uses under
- * ~/.claude/projects/. Replaces \, /, and : each with -.
+ * ~/.claude/projects/. Replaces \, /, :, and . each with -.
  *
  * E.g. "E:\Apps\termhub" → "E--Apps-termhub"
+ *      "E:\Apps\termhub\.claude\worktrees\x" → "E--Apps-termhub--claude-worktrees-x"
  *      "/home/user/repo" → "-home-user-repo"
  */
 export function encodeCwdForPath(cwd: string): string {
-  return cwd.replace(/[\\/:]/g, '-')
+  return cwd.replace(/[\\/:.]/g, '-')
 }
 
 /**


### PR DESCRIPTION
## Summary

The Token Usage panel showed "no usage data yet" indefinitely for sessions spawned from worktree directories (the common case when termhub is running inside a \`.claude/worktrees/\` path). The root cause was a one-character omission in the cwd-to-project-directory encoder.

`encodeCwdForPath` in `electron/usage-fetch.ts` replaced `\`, `/`, and `:` with `-`, but missed `.`. Claude Code's own encoding also replaces `.`, so a cwd like `E:\Apps\termhub\.claude\worktrees\my-feature` produces the project directory `E--Apps-termhub--claude-worktrees-my-feature` — but the broken encoder gave `E--Apps-termhub-.claude-worktrees-my-feature`. termhub looked for the JSONL in a directory that didn't exist and silently returned null for every poll.

Sessions whose cwd didn't contain dots (e.g. the root `E:\Apps\termhub`) worked fine, which is why the orchestrator session showed usage but spawned sessions in worktrees did not.

## Changes
- `electron/usage-fetch.ts`: add `.` to the character class in `encodeCwdForPath` (`/[\/:]/g` → `/[\/:.]/g`)
- `electron/usage-fetch.test.ts`: two new regression tests for the dot-encoding case (Windows worktree path and POSIX hidden directory)

## Test plan
- [ ] Open a session whose cwd is inside a worktree (e.g. `.claude/worktrees/...`) — Token Usage should populate within ~5 seconds of the first response
- [ ] Sessions in non-dotted cwds (e.g. `E:\Apps\termhub`) continue to show usage — no regression
- [ ] `npm test` passes (226 tests, 2 new)