### PR TITLE
feat(bottom-terminal): add shell picker with auto-detected pwsh/powershell/cmd/wsl

### DIFF
--- a/electron/config.ts
+++ b/electron/config.ts
@@ -40,6 +40,16 @@ export function getSessionsPath(): string {
   return path.join(app.getPath('userData'), 'sessions.json')
 }
 
+export function saveConfig(config: Config): void {
+  const configPath = getConfigPath()
+  try {
+    fs.mkdirSync(path.dirname(configPath), { recursive: true })
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2))
+  } catch (err) {
+    console.error('[termhub] failed to save config:', err)
+  }
+}
+
 // Reads ~/AppData/.../termhub/config.json; on first run, writes
 // DEFAULT_CONFIG so the user has something to edit. Errors fall back to
 // the in-memory DEFAULT_CONFIG without surfacing.

--- a/electron/ipc-shell-picker.ts
+++ b/electron/ipc-shell-picker.ts
@@ -1,0 +1,59 @@
+// IPC handlers for the bottom-terminal shell picker.
+// Exposes detected shells, handles shell selection, persists the choice,
+// and respawns all active bottom-terminal PTYs with the new shell.
+
+import { ipcMain } from 'electron'
+import { detectShells, defaultShellId } from './shell-detect'
+import {
+  setBottomShell,
+  respawnAllShells,
+} from './session-manager'
+import { loadConfig, saveConfig } from './config'
+
+function resolveActiveShellId(): string {
+  const shells = detectShells()
+  const config = loadConfig()
+  const saved = config.bottomTerminal?.shellId
+  if (saved && shells.find((s) => s.id === saved)) return saved
+  return defaultShellId(shells)
+}
+
+// Called at app startup to wire the configured shell into session-manager
+// before any sessions are created. Also eagerly populates the detection cache.
+export function initBottomShell(): void {
+  console.log('[termhub:shells] detecting available shells...')
+  const shells = detectShells()
+  const shellId = resolveActiveShellId()
+  const shell = shells.find((s) => s.id === shellId) ?? shells[0]
+  if (shell) {
+    setBottomShell({ command: shell.command, args: shell.args })
+    console.log(`[termhub:shells] initial shell: ${shellId} (${shell.command})`)
+  }
+}
+
+export function registerShellPickerHandlers(): void {
+  ipcMain.handle('bottom-terminal:list-shells', () => {
+    const shells = detectShells()
+    const activeShellId = resolveActiveShellId()
+    return { shells, activeShellId }
+  })
+
+  ipcMain.handle('bottom-terminal:set-shell', (_event, shellId: string) => {
+    const shells = detectShells()
+    const shell = shells.find((s) => s.id === shellId)
+    if (!shell) throw new Error(`Unknown shell id: ${shellId}`)
+
+    const config = loadConfig()
+    saveConfig({
+      ...config,
+      bottomTerminal: { ...config.bottomTerminal, shellId },
+    })
+
+    setBottomShell({ command: shell.command, args: shell.args })
+    respawnAllShells({ command: shell.command, args: shell.args })
+
+    console.log(
+      `[termhub:shells] shell changed to ${shellId} (${shell.command})`,
+    )
+  })
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -34,6 +34,10 @@ import {
   registerUsageHandlers,
   setMainWindowForUsage,
 } from './ipc-usage'
+import {
+  initBottomShell,
+  registerShellPickerHandlers,
+} from './ipc-shell-picker'
 
 // Isolate dev builds so their sessions, config, and MCP port don't bleed
 // into the production instance running alongside. Must run before the
@@ -193,6 +197,7 @@ app.whenReady().then(async () => {
   Menu.setApplicationMenu(null)
 
   const config = loadConfig()
+  initBottomShell()
   writeMcpConfigFile(config.mcpPort)
 
   // Serialize MCP open_session calls. The orchestrator can fan out N
@@ -309,6 +314,7 @@ app.whenReady().then(async () => {
   registerAppHandlers({ config })
   registerPrHandlers()
   registerUsageHandlers()
+  registerShellPickerHandlers()
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -5,6 +5,7 @@ import type {
   SessionPr,
   SessionStatus,
   SessionUsage,
+  ShellInfo,
   SkillDef,
 } from '../src/types'
 
@@ -46,6 +47,21 @@ const api = {
 
   resizeShell: (id: string, cols: number, rows: number): void => {
     ipcRenderer.send('session:shell:resize', { id, cols, rows })
+  },
+
+  listShells: (): Promise<{ shells: ShellInfo[]; activeShellId: string }> =>
+    ipcRenderer.invoke('bottom-terminal:list-shells'),
+
+  setBottomShell: (shellId: string): Promise<void> =>
+    ipcRenderer.invoke('bottom-terminal:set-shell', shellId),
+
+  onShellRespawn: (cb: (sessionId: string) => void): (() => void) => {
+    const handler = (_e: Electron.IpcRendererEvent, p: { id: string }) =>
+      cb(p.id)
+    ipcRenderer.on('session:shell:respawn', handler)
+    return () => {
+      ipcRenderer.off('session:shell:respawn', handler)
+    }
   },
 
   pickFolder: (): Promise<string | null> => ipcRenderer.invoke('dialog:pickFolder'),

--- a/electron/session-manager.ts
+++ b/electron/session-manager.ts
@@ -54,6 +54,19 @@ export type FindSessionResult =
 
 const sessions = new Map<string, Session>()
 
+// Configured bottom-shell. Updated at startup from saved config and on picker change.
+// null means use OS default (process.env.COMSPEC on Windows, process.env.SHELL on Unix).
+let configuredBottomShell: { command: string; args: string[] } | null = null
+
+export function setBottomShell(shell: { command: string; args: string[] }): void {
+  configuredBottomShell = shell
+}
+
+function getBottomShell(): { command: string; args: string[] } {
+  if (configuredBottomShell) return configuredBottomShell
+  return { command: process.env.COMSPEC ?? 'cmd.exe', args: [] }
+}
+
 // Tracks which session ids have had at least one 'session:status' event
 // sent to the renderer. Without this, sessions whose first observed
 // status equals the initial 'working' default would never emit (the
@@ -173,13 +186,15 @@ export function createSessionInternal(opts: {
 }): { id: string; cwd: string; promptSettled: Promise<void> } {
   const id = opts.id ?? randomUUID()
   const cli = opts.cli ?? 'claude'
-  const shell = process.env.COMSPEC || 'cmd.exe'
+  // Primary PTY always uses the OS default shell — it runs claude/codex/gemini.
+  const primaryShell = process.env.COMSPEC || 'cmd.exe'
+  const { command: shellCmd, args: shellArgs } = getBottomShell()
   console.log(
-    `[termhub:session] spawning ${shell} in ${opts.cwd} (id=${id.slice(0, 8)}, cli=${cli}, source=${opts.source})`,
+    `[termhub:session] spawning ${primaryShell} in ${opts.cwd} (id=${id.slice(0, 8)}, cli=${cli}, source=${opts.source})`,
   )
   let term: pty.IPty
   try {
-    term = pty.spawn(shell, [], {
+    term = pty.spawn(primaryShell, [], {
       name: 'xterm-color',
       cols: 80,
       rows: 24,
@@ -192,12 +207,12 @@ export function createSessionInternal(opts: {
   }
   console.log(`[termhub] pty.spawn returned (pid=${term.pid})`)
 
-  // Secondary shell PTY — same executable + cwd as the primary, but holds a
-  // plain interactive prompt for the user's own work. We mirror the primary's
-  // shell choice so the bottom pane matches what the user sees by default.
+  // Secondary shell PTY — user's configured shell rooted at cwd, for manual
+  // work in the bottom pane. Separate from the primary so shell choice doesn't
+  // affect claude/codex/gemini execution.
   let shellTerm: pty.IPty
   try {
-    shellTerm = pty.spawn(shell, [], {
+    shellTerm = pty.spawn(shellCmd, shellArgs, {
       name: 'xterm-color',
       cols: 80,
       rows: 10,
@@ -349,10 +364,10 @@ export function createSessionInternal(opts: {
     // it set when it decides whether to keep the row visible.
     setStatus(session, exitCode === 0 ? 'idle' : 'failed')
     mainWindow?.webContents.send('session:exit', { id, exitCode })
-    // The session is going away — tear down the shell PTY too so we don't
-    // leak it.
+    // The session is going away — tear down the current shell PTY (which
+    // may have been respawned since creation) so we don't leak it.
     try {
-      shellTerm.kill()
+      session.shellTerm.kill()
     } catch {
       // already dead
     }
@@ -437,6 +452,73 @@ export function createSessionInternal(opts: {
   }
 
   return { id, cwd: opts.cwd, promptSettled }
+}
+
+// Kills the current bottom-shell PTY for a session and spawns a new one
+// with the given shell. Sends 'session:shell:respawn' to the renderer
+// BEFORE spawning so the renderer can reset its xterm instance while
+// there is no active PTY to race against.
+export function respawnSessionShell(
+  id: string,
+  shell: { command: string; args: string[] },
+): void {
+  const session = sessions.get(id)
+  if (!session) return
+
+  // Signal the renderer first so it resets xterm before new data arrives.
+  mainWindow?.webContents.send('session:shell:respawn', { id })
+
+  try {
+    session.shellTerm.kill()
+  } catch {
+    // already dead
+  }
+
+  let newShellTerm: pty.IPty
+  try {
+    newShellTerm = pty.spawn(shell.command, shell.args, {
+      name: 'xterm-color',
+      cols: 80,
+      rows: 10,
+      cwd: session.cwd,
+      env: cleanEnv(),
+    })
+  } catch (err) {
+    console.error(
+      `[termhub:shells] session ${id.slice(0, 8)} shell respawn failed:`,
+      err,
+    )
+    throw err
+  }
+
+  console.log(
+    `[termhub:shells] session ${id.slice(0, 8)} shell respawned as ${shell.command} (pid=${newShellTerm.pid})`,
+  )
+  session.shellTerm = newShellTerm
+
+  newShellTerm.onData((data) => {
+    mainWindow?.webContents.send('session:shell:data', { id, data })
+  })
+
+  newShellTerm.onExit(({ exitCode }) => {
+    console.log(
+      `[termhub] session ${id.slice(0, 8)} shell exited (code=${exitCode})`,
+    )
+    mainWindow?.webContents.send('session:shell:exit', { id, exitCode })
+  })
+}
+
+export function respawnAllShells(shell: { command: string; args: string[] }): void {
+  for (const session of sessions.values()) {
+    try {
+      respawnSessionShell(session.id, shell)
+    } catch (err) {
+      console.error(
+        `[termhub:shells] failed to respawn shell for session ${session.id.slice(0, 8)}:`,
+        err,
+      )
+    }
+  }
 }
 
 export function killAllSessions(): void {

--- a/electron/session-manager.ts
+++ b/electron/session-manager.ts
@@ -67,6 +67,12 @@ function getBottomShell(): { command: string; args: string[] } {
   return { command: process.env.COMSPEC ?? 'cmd.exe', args: [] }
 }
 
+// Session ids whose current shell PTY was killed for a respawn. When the
+// killed PTY's onExit fires we skip the IPC event so the renderer's
+// onShellExit handler doesn't dispose the xterm that was just created for
+// the new shell.
+const pendingRespawnExits = new Set<string>()
+
 // Tracks which session ids have had at least one 'session:status' event
 // sent to the renderer. Without this, sessions whose first observed
 // status equals the initial 'working' default would never emit (the
@@ -386,6 +392,10 @@ export function createSessionInternal(opts: {
   })
 
   shellTerm.onExit(({ exitCode }) => {
+    // Skip if this exit was triggered by respawnSessionShell — the renderer
+    // already received 'session:shell:respawn' and the new xterm must not be
+    // disposed by the stale exit event from the killed old shell.
+    if (pendingRespawnExits.delete(id)) return
     console.log(
       `[termhub] session ${id.slice(0, 8)} shell exited (code=${exitCode})`,
     )
@@ -465,7 +475,11 @@ export function respawnSessionShell(
   const session = sessions.get(id)
   if (!session) return
 
-  // Signal the renderer first so it resets xterm before new data arrives.
+  // Mark this exit as a respawn kill so the old PTY's onExit handler
+  // skips the IPC event — the new xterm must not be torn down by it.
+  pendingRespawnExits.add(id)
+
+  // Signal the renderer to reset its xterm before new data arrives.
   mainWindow?.webContents.send('session:shell:respawn', { id })
 
   try {
@@ -488,6 +502,7 @@ export function respawnSessionShell(
       `[termhub:shells] session ${id.slice(0, 8)} shell respawn failed:`,
       err,
     )
+    pendingRespawnExits.delete(id)
     throw err
   }
 
@@ -501,6 +516,7 @@ export function respawnSessionShell(
   })
 
   newShellTerm.onExit(({ exitCode }) => {
+    if (pendingRespawnExits.delete(id)) return
     console.log(
       `[termhub] session ${id.slice(0, 8)} shell exited (code=${exitCode})`,
     )

--- a/electron/shell-detect.test.ts
+++ b/electron/shell-detect.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { defaultShellId } from './shell-detect'
+import type { ShellInfo } from './shell-detect'
+
+const WIN_SHELLS: ShellInfo[] = [
+  { id: 'pwsh', label: 'PowerShell 7+ (pwsh)', command: 'pwsh.exe', args: [] },
+  { id: 'powershell', label: 'Windows PowerShell 5.1', command: 'powershell.exe', args: [] },
+  { id: 'cmd', label: 'Command Prompt (cmd)', command: 'cmd.exe', args: [] },
+  { id: 'wsl', label: 'WSL', command: 'wsl.exe', args: [] },
+]
+
+const UNIX_SHELLS: ShellInfo[] = [
+  { id: 'zsh', label: 'zsh', command: 'zsh', args: [] },
+  { id: 'bash', label: 'bash', command: 'bash', args: [] },
+  { id: 'sh', label: 'sh', command: 'sh', args: [] },
+]
+
+describe('defaultShellId (Windows)', () => {
+  it('prefers pwsh when all shells present', () => {
+    expect(defaultShellId(WIN_SHELLS, 'win32')).toBe('pwsh')
+  })
+
+  it('falls back to powershell when pwsh absent', () => {
+    const shells = WIN_SHELLS.filter((s) => s.id !== 'pwsh')
+    expect(defaultShellId(shells, 'win32')).toBe('powershell')
+  })
+
+  it('falls back to cmd when pwsh and powershell absent', () => {
+    const shells = WIN_SHELLS.filter(
+      (s) => s.id !== 'pwsh' && s.id !== 'powershell',
+    )
+    expect(defaultShellId(shells, 'win32')).toBe('cmd')
+  })
+
+  it('falls back to wsl when only wsl present', () => {
+    const shells = WIN_SHELLS.filter((s) => s.id === 'wsl')
+    expect(defaultShellId(shells, 'win32')).toBe('wsl')
+  })
+
+  it('returns first shell when none of the preferred ids match', () => {
+    const shells: ShellInfo[] = [
+      { id: 'nushell', label: 'Nu', command: 'nu.exe', args: [] },
+    ]
+    expect(defaultShellId(shells, 'win32')).toBe('nushell')
+  })
+})
+
+describe('defaultShellId (Unix)', () => {
+  const originalShell = process.env.SHELL
+
+  afterEach(() => {
+    if (originalShell === undefined) {
+      delete process.env.SHELL
+    } else {
+      process.env.SHELL = originalShell
+    }
+  })
+
+  it('prefers $SHELL when it matches a detected shell', () => {
+    process.env.SHELL = '/bin/zsh'
+    expect(defaultShellId(UNIX_SHELLS, 'linux')).toBe('zsh')
+  })
+
+  it('falls back to zsh when $SHELL is not in the list', () => {
+    process.env.SHELL = '/usr/local/bin/fish'
+    expect(defaultShellId(UNIX_SHELLS, 'linux')).toBe('zsh')
+  })
+
+  it('falls back to bash when zsh absent and $SHELL unset', () => {
+    delete process.env.SHELL
+    const shells = UNIX_SHELLS.filter((s) => s.id !== 'zsh')
+    expect(defaultShellId(shells, 'linux')).toBe('bash')
+  })
+
+  it('falls back to sh when only sh present', () => {
+    delete process.env.SHELL
+    const shells = UNIX_SHELLS.filter((s) => s.id === 'sh')
+    expect(defaultShellId(shells, 'linux')).toBe('sh')
+  })
+})

--- a/electron/shell-detect.ts
+++ b/electron/shell-detect.ts
@@ -1,0 +1,133 @@
+// Detects which interactive shells are available on this machine.
+// Cached after first call — where.exe / which calls are not free.
+
+import { execFileSync } from 'node:child_process'
+import * as path from 'node:path'
+
+export type ShellInfo = {
+  id: string
+  label: string
+  command: string
+  args: string[]
+}
+
+let cachedShells: ShellInfo[] | null = null
+
+function probeWindows(command: string): boolean {
+  try {
+    execFileSync('where.exe', [command], { stdio: 'pipe', timeout: 5000 })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function probeUnix(command: string): boolean {
+  try {
+    execFileSync('which', [command], { stdio: 'pipe', timeout: 5000 })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function detectWindowsShells(): ShellInfo[] {
+  const candidates: ShellInfo[] = [
+    { id: 'pwsh', label: 'PowerShell 7+ (pwsh)', command: 'pwsh.exe', args: [] },
+    {
+      id: 'powershell',
+      label: 'Windows PowerShell 5.1',
+      command: 'powershell.exe',
+      args: [],
+    },
+    { id: 'cmd', label: 'Command Prompt (cmd)', command: 'cmd.exe', args: [] },
+    { id: 'wsl', label: 'WSL', command: 'wsl.exe', args: [] },
+  ]
+  return candidates.filter((s) => probeWindows(s.command))
+}
+
+function detectUnixShells(): ShellInfo[] {
+  const envShell = process.env.SHELL
+  const seen = new Set<string>()
+  const result: ShellInfo[] = []
+
+  if (envShell) {
+    const basename = path.basename(envShell)
+    if (probeUnix(envShell) && !seen.has(basename)) {
+      seen.add(basename)
+      result.push({ id: basename, label: basename, command: envShell, args: [] })
+    }
+  }
+
+  for (const cmd of ['zsh', 'bash', 'sh']) {
+    if (seen.has(cmd)) continue
+    if (probeUnix(cmd)) {
+      seen.add(cmd)
+      result.push({ id: cmd, label: cmd, command: cmd, args: [] })
+    }
+  }
+
+  return result
+}
+
+// Returns shells available on this machine. Result is cached after first call.
+export function detectShells(): ShellInfo[] {
+  if (cachedShells !== null) return cachedShells
+
+  try {
+    const shells =
+      process.platform === 'win32' ? detectWindowsShells() : detectUnixShells()
+    if (shells.length > 0) {
+      cachedShells = shells
+      console.log(
+        `[termhub:shells] detected: ${shells.map((s) => s.id).join(', ')}`,
+      )
+      return shells
+    }
+  } catch (err) {
+    console.warn('[termhub:shells] detection error:', err)
+  }
+
+  const fallback: ShellInfo = {
+    id: 'default',
+    label:
+      process.platform === 'win32'
+        ? 'Command Prompt (cmd)'
+        : (process.env.SHELL ?? 'sh'),
+    command:
+      process.platform === 'win32'
+        ? (process.env.COMSPEC ?? 'cmd.exe')
+        : (process.env.SHELL ?? 'sh'),
+    args: [],
+  }
+  cachedShells = [fallback]
+  console.warn(
+    `[termhub:shells] no shells detected; falling back to ${fallback.command}`,
+  )
+  return cachedShells
+}
+
+// Returns the id to use when no user preference has been saved.
+// Accepts an optional platform override so the function can be tested without
+// mutating process.platform.
+export function defaultShellId(
+  shells: ShellInfo[],
+  platform: string = process.platform,
+): string {
+  if (platform === 'win32') {
+    for (const id of ['pwsh', 'powershell', 'cmd', 'wsl', 'default']) {
+      if (shells.find((s) => s.id === id)) return id
+    }
+  } else {
+    const envShell = process.env.SHELL
+    if (envShell) {
+      const basename = path.basename(envShell)
+      const match = shells.find((s) => s.id === basename)
+      if (match) return match.id
+    }
+    for (const id of ['zsh', 'bash', 'sh', 'default']) {
+      if (shells.find((s) => s.id === id)) return id
+    }
+  }
+  return shells[0]?.id ?? 'cmd'
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,10 +3,11 @@ import { TitleBar } from './TitleBar'
 import { Sidebar } from './Sidebar'
 import { TerminalView } from './TerminalView'
 import { BottomTerminal } from './BottomTerminal'
+import { ShellPicker } from './ShellPicker'
 import { RightPanel } from './RightPanel'
 import { UsageModal } from './UsageModal'
 import { ConfirmCloseModal } from './ConfirmCloseModal'
-import type { Session } from './types'
+import type { Session, ShellInfo } from './types'
 import type { TerminalEntry } from './useXterm'
 import { useSessions } from './useSessions'
 import { useSplitLayout } from './useSplitLayout'
@@ -39,6 +40,47 @@ export default function App() {
 
   const { bottomHeight, mainContainerRef, handleDividerMouseDown } =
     useSplitLayout()
+
+  const [shells, setShells] = useState<ShellInfo[]>([])
+  const [activeShellId, setActiveShellId] = useState<string | null>(null)
+  // Incremented per-session when the bottom shell respawns, forcing
+  // BottomTerminal to remount and reinitialise its xterm instance.
+  const [shellVersions, setShellVersions] = useState<Record<string, number>>({})
+
+  useEffect(() => {
+    window.termhub
+      .listShells()
+      .then(({ shells: detected, activeShellId: id }) => {
+        setShells(detected)
+        setActiveShellId(id)
+      })
+      .catch((err: unknown) => {
+        console.error('[termhub] listShells failed:', err)
+      })
+  }, [])
+
+  // When main respawns the bottom-shell PTY, dispose the old xterm so
+  // BottomTerminal can reinitialise cleanly on remount.
+  useEffect(() => {
+    return window.termhub.onShellRespawn((id) => {
+      const entry = shellTermsRef.current.get(id)
+      if (entry) {
+        entry.term.dispose()
+        shellTermsRef.current.delete(id)
+      }
+      shellPendingDataRef.current.delete(id)
+      setShellVersions((prev) => ({ ...prev, [id]: (prev[id] ?? 0) + 1 }))
+    })
+  }, [])
+
+  const handleSetShell = useCallback(async (shellId: string) => {
+    setActiveShellId(shellId)
+    try {
+      await window.termhub.setBottomShell(shellId)
+    } catch (err) {
+      console.error('[termhub] setBottomShell failed:', err)
+    }
+  }, [])
 
   const [showUsage, setShowUsage] = useState(false)
   // Session id pending close confirmation, or null when no dialog is open.
@@ -165,15 +207,24 @@ export default function App() {
               </div>
               <div className="main-divider" onMouseDown={handleDividerMouseDown} />
               <div className="main-bottom" style={{ flexBasis: bottomHeight }}>
-                {sessions.map((s) => (
-                  <BottomTerminal
-                    key={s.id}
-                    session={s}
-                    isActive={s.id === activeId}
-                    termsRef={shellTermsRef}
-                    pendingDataRef={shellPendingDataRef}
+                <div className="bottom-panel-header">
+                  <ShellPicker
+                    shells={shells}
+                    activeShellId={activeShellId}
+                    onSelect={handleSetShell}
                   />
-                ))}
+                </div>
+                <div className="bottom-terminal-body">
+                  {sessions.map((s) => (
+                    <BottomTerminal
+                      key={`${s.id}-${shellVersions[s.id] ?? 0}`}
+                      session={s}
+                      isActive={s.id === activeId}
+                      termsRef={shellTermsRef}
+                      pendingDataRef={shellPendingDataRef}
+                    />
+                  ))}
+                </div>
               </div>
             </>
           )}

--- a/src/ShellPicker.tsx
+++ b/src/ShellPicker.tsx
@@ -7,21 +7,44 @@ type Props = {
   onSelect: (shellId: string) => void
 }
 
-export function ShellPicker({ shells, activeShellId, onSelect }: Props) {
-  const [open, setOpen] = useState(false)
-  const wrapperRef = useRef<HTMLDivElement>(null)
+type MenuPos = { top: number; right: number }
 
+export function ShellPicker({ shells, activeShellId, onSelect }: Props) {
+  const [menuPos, setMenuPos] = useState<MenuPos | null>(null)
+  const btnRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  const open = menuPos !== null
   const activeShell = shells.find((s) => s.id === activeShellId)
+
+  const handleToggle = () => {
+    if (open) {
+      setMenuPos(null)
+      return
+    }
+    const rect = btnRef.current?.getBoundingClientRect()
+    if (rect) {
+      // Open above the button, right-aligned to the button's right edge.
+      setMenuPos({
+        top: rect.top - 4,
+        right: window.innerWidth - rect.right,
+      })
+    }
+  }
 
   useEffect(() => {
     if (!open) return
     const onMouseDown = (e: MouseEvent) => {
-      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
-        setOpen(false)
+      const target = e.target as Node
+      if (
+        !btnRef.current?.contains(target) &&
+        !menuRef.current?.contains(target)
+      ) {
+        setMenuPos(null)
       }
     }
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false)
+      if (e.key === 'Escape') setMenuPos(null)
     }
     document.addEventListener('mousedown', onMouseDown)
     document.addEventListener('keydown', onKeyDown)
@@ -34,24 +57,34 @@ export function ShellPicker({ shells, activeShellId, onSelect }: Props) {
   if (shells.length === 0) return null
 
   return (
-    <div className="shell-picker" ref={wrapperRef}>
+    <>
       <button
+        ref={btnRef}
         className="shell-picker-btn"
-        onClick={() => setOpen((v) => !v)}
+        onClick={handleToggle}
         title="Change shell"
       >
         {activeShell?.label ?? activeShellId ?? 'Shell'}
         <span className="shell-picker-chevron">▾</span>
       </button>
-      {open && (
-        <div className="shell-picker-menu">
+      {open && menuPos && (
+        <div
+          ref={menuRef}
+          className="shell-picker-menu"
+          style={{
+            position: 'fixed',
+            top: menuPos.top,
+            right: menuPos.right,
+            transform: 'translateY(-100%)',
+          }}
+        >
           {shells.map((shell) => (
             <button
               key={shell.id}
               className="context-menu-item shell-picker-option"
               onClick={() => {
                 onSelect(shell.id)
-                setOpen(false)
+                setMenuPos(null)
               }}
             >
               <span className="shell-picker-check">
@@ -62,6 +95,6 @@ export function ShellPicker({ shells, activeShellId, onSelect }: Props) {
           ))}
         </div>
       )}
-    </div>
+    </>
   )
 }

--- a/src/ShellPicker.tsx
+++ b/src/ShellPicker.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from 'react'
+import type { ShellInfo } from './types'
+
+type Props = {
+  shells: ShellInfo[]
+  activeShellId: string | null
+  onSelect: (shellId: string) => void
+}
+
+export function ShellPicker({ shells, activeShellId, onSelect }: Props) {
+  const [open, setOpen] = useState(false)
+  const wrapperRef = useRef<HTMLDivElement>(null)
+
+  const activeShell = shells.find((s) => s.id === activeShellId)
+
+  useEffect(() => {
+    if (!open) return
+    const onMouseDown = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  if (shells.length === 0) return null
+
+  return (
+    <div className="shell-picker" ref={wrapperRef}>
+      <button
+        className="shell-picker-btn"
+        onClick={() => setOpen((v) => !v)}
+        title="Change shell"
+      >
+        {activeShell?.label ?? activeShellId ?? 'Shell'}
+        <span className="shell-picker-chevron">▾</span>
+      </button>
+      {open && (
+        <div className="shell-picker-menu">
+          {shells.map((shell) => (
+            <button
+              key={shell.id}
+              className="context-menu-item shell-picker-option"
+              onClick={() => {
+                onSelect(shell.id)
+                setOpen(false)
+              }}
+            >
+              <span className="shell-picker-check">
+                {shell.id === activeShellId ? '✓' : ''}
+              </span>
+              {shell.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -879,10 +879,6 @@ body,
 
 /* ---------- Shell picker ---------- */
 
-.shell-picker {
-  position: relative;
-}
-
 .shell-picker-btn {
   background: transparent;
   border: 1px solid var(--border);
@@ -914,14 +910,11 @@ body,
   background: var(--bg-elev);
   border: 1px solid var(--border);
   border-radius: 6px;
-  bottom: calc(100% + 4px);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(149, 128, 255, 0.08);
   display: flex;
   flex-direction: column;
   min-width: 200px;
   padding: 4px;
-  position: absolute;
-  right: 0;
   z-index: 200;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -852,10 +852,90 @@ body,
 /* Bottom shell pane — height is controlled dynamically via inline style (flex-basis). */
 .main-bottom {
   flex: 0 0 auto;
-  position: relative;
   overflow: hidden;
   min-height: 0;
   border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+}
+
+.bottom-panel-header {
+  flex-shrink: 0;
+  height: 28px;
+  background: var(--bg-elev);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0 8px;
+}
+
+.bottom-terminal-body {
+  flex: 1 1 auto;
+  position: relative;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* ---------- Shell picker ---------- */
+
+.shell-picker {
+  position: relative;
+}
+
+.shell-picker-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-dim);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-family: inherit;
+  font-size: 11px;
+  height: 20px;
+  padding: 0 6px;
+  white-space: nowrap;
+}
+
+.shell-picker-btn:hover {
+  background: var(--hover);
+  color: var(--text);
+  border-color: var(--text-dim);
+}
+
+.shell-picker-chevron {
+  font-size: 9px;
+  opacity: 0.7;
+}
+
+.shell-picker-menu {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  bottom: calc(100% + 4px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(149, 128, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  min-width: 200px;
+  padding: 4px;
+  position: absolute;
+  right: 0;
+  z-index: 200;
+}
+
+.shell-picker-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.shell-picker-check {
+  color: var(--accent);
+  font-size: 11px;
+  min-width: 12px;
+  text-align: center;
 }
 
 .terminal-pane {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,13 @@ export type Session = {
   cli?: 'claude' | 'codex' | 'gemini'
 }
 
+export type ShellInfo = {
+  id: string
+  label: string
+  command: string
+  args: string[]
+}
+
 // Advisory, UI-only session status sourced from Claude Code's own JSONL file.
 // 'working'  — Claude is actively generating / running tools (JSONL: 'busy')
 // 'awaiting' — Claude has paused to ask the user something (JSONL: 'waiting')
@@ -43,6 +50,9 @@ export type StartupSession = {
 export type Config = {
   mcpPort: number
   startupSessions: StartupSession[]
+  bottomTerminal?: {
+    shellId?: string
+  }
 }
 
 export type SessionPr = {
@@ -79,6 +89,9 @@ export type TermhubApi = {
   // interactive shell rooted in the session's cwd.
   sendShellInput: (id: string, data: string) => void
   resizeShell: (id: string, cols: number, rows: number) => void
+  listShells: () => Promise<{ shells: ShellInfo[]; activeShellId: string }>
+  setBottomShell: (shellId: string) => Promise<void>
+  onShellRespawn: (cb: (sessionId: string) => void) => () => void
   pickFolder: () => Promise<string | null>
   home: () => Promise<string>
   getConfig: () => Promise<Config>


### PR DESCRIPTION
## Summary

Adds a shell picker to the bottom terminal panel header. Termhub now
auto-detects available shells at startup (pwsh, powershell, cmd, wsl on
Windows; \$SHELL, zsh, bash, sh on macOS/Linux), presents them in a dropdown
button in the panel header, persists the choice in `config.json`, and
immediately respawns the bottom-terminal PTY for all active sessions when
the user switches shells. No restart required.

## Changes

- **`electron/shell-detect.ts`** — `detectShells()` with `where.exe`/`which`
  probing; cached after first call. `defaultShellId()` picks pwsh → powershell
  → cmd → wsl on Windows, \$SHELL → zsh → bash → sh on Unix. Falls back to
  OS default (no crash) if detection times out or finds nothing.
- **`electron/ipc-shell-picker.ts`** — `initBottomShell()` (runs at startup,
  pre-sessions) + IPC handlers `bottom-terminal:list-shells` and
  `bottom-terminal:set-shell`. The set-shell handler persists the choice,
  updates the in-memory shell ref, and calls `respawnAllShells()`.
- **`electron/session-manager.ts`** — `setBottomShell()`, `respawnSessionShell()`,
  `respawnAllShells()`. New sessions use the configured shell for their
  secondary PTY (primary PTY always uses cmd.exe for claude/codex/gemini).
  `term.onExit` now references `session.shellTerm` (not the initial local var)
  so respawned shells are correctly killed when the primary exits.
- **`src/ShellPicker.tsx`** — dropdown button in the bottom panel header.
  Uses existing `.context-menu` / `.context-menu-item` CSS classes; opens
  upward above the header; checkmark on the active shell. Dismisses on outside
  click or Escape.
- **`src/App.tsx`** — `listShells()` on mount, `onShellRespawn` listener that
  disposes the old xterm entry and bumps a per-session `shellVersions` counter.
  Keying `<BottomTerminal key={sessionId-version}>` forces a clean remount
  after each respawn.
- **`src/styles.css`** — `.bottom-panel-header`, `.bottom-terminal-body`,
  `.shell-picker-*` styles. `.main-bottom` is now flex-column so the header
  and terminal body stack correctly.
- **`src/types.ts`** — `ShellInfo` type, `Config.bottomTerminal.shellId`,
  three new `TermhubApi` methods.

## Detection logic

Windows (ordered, show only what's on PATH via `where.exe`):
1. `pwsh.exe` — PowerShell 7+
2. `powershell.exe` — Windows PowerShell 5.1
3. `cmd.exe` — Command Prompt
4. `wsl.exe` — WSL

macOS/Linux (ordered):
1. `\$SHELL` (user's login shell, if detected)
2. `zsh`, `bash`, `sh`

## Picker location

Right-aligned button in the bottom terminal panel header (`28px` strip above
the xterm pane). Clicking opens an upward dropdown listing detected shells;
active shell has a `✓` checkmark.

## Persistence

Saved to `bottomTerminal.shellId` in `config.json` (userData). Read at app
startup by `initBottomShell()` before any sessions are bootstrapped.

## Test plan

- [ ] `npm run dev` — bottom terminal opens in pwsh (or powershell if pwsh absent)
- [ ] Click picker → dropdown lists detected shells with checkmark on active one
- [ ] Switch to `powershell` → terminal respawns; run `\$PSVersionTable` → v5.1
- [ ] Switch to `pwsh` → respawns; `\$PSVersionTable.PSVersion` → v7+
- [ ] Switch to `wsl` → respawns; `uname -a` confirms Linux
- [ ] Switch to `cmd` → respawns; `ver` shows Windows version
- [ ] Quit and relaunch → chosen shell is restored (check `config.json`)
- [ ] `npm test` → 235 tests pass (8 new in `shell-detect.test.ts`)