### PR TITLE
fix: don't pass --session-id when resuming a session

### DIFF
--- a/electron/claude-command.test.ts
+++ b/electron/claude-command.test.ts
@@ -62,12 +62,14 @@ describe('buildClaudeArgs', () => {
     expect(flags.join(' ')).not.toContain('--resume')
   })
 
-  it('includes both --session-id and --resume for a resume call', () => {
+  it('resume: includes --resume but not --session-id', () => {
     const flags = buildClaudeArgs({ ...BUILD_ARGS_BASE, resume: true })
     expect(flags.some((f) => f.includes('--resume'))).toBe(true)
-    // --session-id must also be present so the status watcher can discover
-    // the Claude Code session file via its sessionId field.
-    expect(flags.some((f) => f.includes('--session-id'))).toBe(true)
+    // --session-id must NOT be present on resume: Claude Code rejects the
+    // combination of --session-id + --resume without --fork-session. The
+    // resumed session's UUID is already established; Claude Code writes it
+    // into the sessions file so the status watcher can still find it.
+    expect(flags.some((f) => f.includes('--session-id'))).toBe(false)
   })
 
   it('includes --permission-mode with provided value', () => {

--- a/electron/claude-command.ts
+++ b/electron/claude-command.ts
@@ -33,10 +33,11 @@ export function buildClaudeArgs(opts: {
   const flags: string[] = [`--mcp-config "${opts.mcpConfigPath}"`]
 
   if (opts.resume) {
-    // --session-id is required even on resume so Claude Code writes the
-    // termhub session id into ~/.claude/sessions/<pid>.json, letting the
-    // status watcher discover the file via findSessionFileBySessionId.
-    flags.push(`--session-id "${opts.sessionId}"`)
+    // Don't pass --session-id on resume: Claude Code rejects the combination
+    // of --session-id + --resume without --fork-session. The resumed session
+    // already has an established UUID; Claude Code writes that same UUID into
+    // ~/.claude/sessions/<pid>.json, so the status watcher finds the file via
+    // the session ID termhub already holds.
     flags.push(`--resume "${opts.sessionId}"`)
     if (opts.model && opts.model.length > 0) {
       flags.push(`--model "${opts.model}"`)

--- a/electron/status-watcher.ts
+++ b/electron/status-watcher.ts
@@ -38,9 +38,10 @@ const SESSIONS_DIR = path.join(os.homedir(), '.claude', 'sessions')
 // Find the ~/.claude/sessions/<pid>.json file whose `sessionId` field matches
 // the given session ID. Returns the full path or null if not found.
 //
-// termhub passes --session-id <id> to every claude invocation, so the session
-// file written by Claude Code will always have sessionId === termhub's own id.
-// This makes the lookup exact and race-free.
+// For new sessions termhub passes --session-id <id> so Claude Code writes that
+// exact UUID. For resumed sessions the UUID is already established and Claude
+// Code writes the same UUID it resumed. Either way the lookup is exact and
+// race-free.
 export function findSessionFileBySessionId(sessionId: string): string | null {
   let files: string[]
   try {
@@ -68,9 +69,8 @@ export type WatcherHandle = {
 
 // Watch the status of a Claude Code session by looking up its runtime file at
 // ~/.claude/sessions/<pid>.json. The file is discovered by matching its
-// `sessionId` field against the termhub session id, which termhub passes as
-// --session-id to every claude invocation — making this lookup exact and
-// race-free with no cwd scanning or time-window heuristics.
+// `sessionId` field against the termhub session id — exact and race-free
+// with no cwd scanning or time-window heuristics.
 //
 // The file is a single JSON object rewritten in-place on every status change,
 // so each poll reads the whole file.


### PR DESCRIPTION
## Summary

Regression from #60. When termhub resumes a saved session via `--resume <id>`, it was also passing `--session-id <id>`, which Claude Code's CLI rejects unless `--fork-session` is also given. This caused every resumed session to exit immediately on startup with:

```
Error: --session-id can only be used with --continue or --resume if --fork-session is also specified.
```

The fix drops `--session-id` from the resume code path. For resumed sessions, the UUID is already established; Claude Code writes it into `~/.claude/sessions/<pid>.json` on its own, so the status watcher still finds the session file via the ID termhub already holds. New sessions (where `--session-id` pre-generates the UUID for token-usage tracking) are unaffected.

## Changes

- `electron/claude-command.ts`: remove `--session-id` from the `opts.resume` branch; update comment to explain why
- `electron/claude-command.test.ts`: flip the resume test to assert `--session-id` is absent (was asserting present — the wrong behavior)
- `electron/status-watcher.ts`: update stale comments that claimed `--session-id` is passed to every invocation

## Test plan

- [ ] Launch termhub with previously-saved sessions — sessions resume cleanly, no "Error: --session-id can only be used…" output
- [ ] Open a new session — `--session-id` still appears in the spawn args, token-usage panel shows real numbers
- [ ] Quit and relaunch — saved sessions resume + show usage history; new sessions still get `--session-id`
- [ ] `npm test` — 226 tests pass (including the flipped resume assertion)

Refs #60