### PR TITLE
feat: add macOS build pipeline (arm64 DMG + ZIP)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Windows .exe
+name: Build desktop packages
 
 on:
   push:
@@ -53,4 +53,51 @@ jobs:
         with:
           name: termhub-windows-portable
           path: release/*-portable.exe
+          if-no-files-found: error
+
+  build-macos:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Package macOS app
+        run: npm run dist:mac
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: termhub-macos-dmg
+          path: release/*.dmg
+          if-no-files-found: error
+
+      - name: Upload ZIP artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: termhub-macos-zip
+          path: release/*-mac.zip
           if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ release
 .DS_Store
 *.log
 .vite
+.claude/worktrees/

--- a/package.json
+++ b/package.json
@@ -75,9 +75,6 @@
     },
     "dmg": {
       "artifactName": "${productName}-${version}-${arch}.${ext}"
-    },
-    "zip": {
-      "artifactName": "${productName}-${version}-${arch}-mac.${ext}"
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "start": "npm run build && electron .",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.electron.json",
     "dist:win": "npm run build && electron-builder --win --publish never",
+    "dist:mac": "npm run build && electron-builder --mac --publish never",
     "test": "vitest run",
     "prepare": "husky"
   },
@@ -57,6 +58,26 @@
     },
     "portable": {
       "artifactName": "${productName}-${version}-${arch}-portable.${ext}"
+    },
+    "mac": {
+      "category": "public.app-category.developer-tools",
+      "identity": null,
+      "target": [
+        {
+          "target": "dmg",
+          "arch": ["arm64"]
+        },
+        {
+          "target": "zip",
+          "arch": ["arm64"]
+        }
+      ]
+    },
+    "dmg": {
+      "artifactName": "${productName}-${version}-${arch}.${ext}"
+    },
+    "zip": {
+      "artifactName": "${productName}-${version}-${arch}-mac.${ext}"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## What this adds

- **`dist:mac` script** in `package.json`: runs `electron-builder --mac --publish never`
- **`mac` build target** in the `build` block: produces arm64 `.dmg` and `.zip` artifacts
  - `artifactName` patterns parallel the Windows naming: `TermHub-{version}-{arch}.dmg` / `TermHub-{version}-{arch}-mac.zip`
  - `category: public.app-category.developer-tools`
  - `identity: null` to explicitly disable code signing
- **`build-macos` CI job** on `macos-latest` mirroring the Windows job: checkout → setup-node → cache → npm ci → typecheck → `dist:mac` → upload DMG + ZIP artifacts
  - `CSC_IDENTITY_AUTO_DISCOVERY=false` env var prevents electron-builder from searching for a signing identity
- **Workflow renamed** from "Build Windows .exe" to "Build desktop packages"
- **`.claude/worktrees/` added to `.gitignore`**

## Why arm64 only (not universal)

`@lydell/node-pty` ships **per-arch** optional deps (`@lydell/node-pty-darwin-arm64`, `@lydell/node-pty-darwin-x64`) rather than a universal fat binary. On the arm64 `macos-latest` runner, `npm ci` only installs the arm64 binary; attempting to package for x64 would fail at the native module step. Per-arch arm64 is the right call for now — it covers Apple Silicon (the overwhelmingly common personal Mac in 2026) and avoids fragile cross-arch native module juggling.

## First-launch Gatekeeper bypass

The build is **unsigned** (no Apple Developer account, no notarization). On first launch, macOS Gatekeeper will block it. To bypass:

```sh
xattr -cr /Applications/TermHub.app
```

Or: right-click the app in Finder → Open → Open anyway.

## Windows pipeline

Unchanged in behavior. Only the workflow `name:` field was updated from "Build Windows .exe" to "Build desktop packages".