### PR TITLE
fix: persist session metadata across macOS window close + ignore .claude/worktrees in dev watchers

### DIFF
--- a/electron/ipc-pr.ts
+++ b/electron/ipc-pr.ts
@@ -47,7 +47,12 @@ async function fetchAndCachePr(sessionId: string): Promise<void> {
   try {
     branch = await getGitBranch(session.cwd)
   } catch (err) {
-    console.warn(`[termhub:pr] session ${sessionId.slice(0, 8)}: cannot determine branch:`, err instanceof Error ? err.message : String(err))
+    const msg = err instanceof Error ? err.message : String(err)
+    // "not a git repository" is expected for sessions rooted outside a
+    // repo (e.g. an orchestrator session at ~/Repos) — skip the warn so
+    // the poll loop doesn't spam the log every interval.
+    if (/not a git repository/i.test(msg)) return
+    console.warn(`[termhub:pr] session ${sessionId.slice(0, 8)}: cannot determine branch:`, msg)
     return
   }
 

--- a/electron/session-manager.test.ts
+++ b/electron/session-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // session-manager imports electron + @lydell/node-pty + node:crypto at the
 // top level. None of those are loadable in Vitest's node env without
@@ -10,7 +10,22 @@ vi.mock('electron', () => ({
 }))
 vi.mock('@lydell/node-pty', () => ({ spawn: () => ({}) }))
 
-import { defaultPrimaryShell, shouldEmitStatus } from './session-manager'
+// Capture persistence writes so the killAllSessions ordering test can
+// assert on what got written (and how many times).
+const writePersistedSessionsMock = vi.fn()
+vi.mock('./persistence', () => ({
+  loadPersistedSessions: () => [],
+  writePersistedSessions: (list: unknown[]) => writePersistedSessionsMock(list),
+}))
+
+import {
+  __addSessionForTest,
+  __resetSessionsForTest,
+  defaultPrimaryShell,
+  killAllSessions,
+  shouldEmitStatus,
+  type Session,
+} from './session-manager'
 
 // Regression: pre-fix, sessions starting at 'working' that first reported
 // 'busy' (which maps to 'working') would never emit a 'session:status'
@@ -74,5 +89,55 @@ describe('defaultPrimaryShell', () => {
     expect(
       defaultPrimaryShell('darwin', { COMSPEC: 'cmd.exe', SHELL: '/bin/zsh' }),
     ).toBe('/bin/zsh')
+  })
+})
+
+// Regression: on macOS, closing the window fires window-all-closed →
+// killAllSessions, but the app stays alive. Pre-fix, killAllSessions
+// killed PTYs and cleared the map without persisting first. The async
+// term.onExit callbacks then fired and called persistSessions() against
+// the now-empty map, clobbering sessions.json. On next launch, nothing
+// was restored.
+describe('killAllSessions persistence', () => {
+  function fakeSession(id: string, cwd: string): Session {
+    const noopPty = { kill: () => {} }
+    return {
+      id,
+      cwd,
+      term: noopPty,
+      shellTerm: noopPty,
+      outputBuffer: '',
+      status: 'working',
+      jsonlWatcher: null,
+    } as unknown as Session
+  }
+
+  beforeEach(() => {
+    writePersistedSessionsMock.mockClear()
+    __resetSessionsForTest()
+  })
+
+  it('persists session metadata before clearing the live map', () => {
+    __addSessionForTest(fakeSession('id-1', '/tmp/a'))
+    __addSessionForTest(fakeSession('id-2', '/tmp/b'))
+
+    killAllSessions()
+
+    expect(writePersistedSessionsMock).toHaveBeenCalledTimes(1)
+    const list = writePersistedSessionsMock.mock.calls[0][0] as Array<{ id: string }>
+    expect(list.map((s) => s.id).sort()).toEqual(['id-1', 'id-2'])
+  })
+
+  it('does not overwrite the snapshot with an empty list on a redundant second call', () => {
+    // On non-macOS, window-all-closed → killAllSessions → app.quit() →
+    // before-quit → killAllSessions. The second invocation must not
+    // clobber the good snapshot from the first with an empty list.
+    __addSessionForTest(fakeSession('id-1', '/tmp/a'))
+
+    killAllSessions()
+    expect(writePersistedSessionsMock).toHaveBeenCalledTimes(1)
+
+    killAllSessions()
+    expect(writePersistedSessionsMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/electron/session-manager.ts
+++ b/electron/session-manager.ts
@@ -160,6 +160,19 @@ export function findSessionByIdOrPrefix(idOrPrefix: string): FindSessionResult {
   }
 }
 
+// Test-only — seeds the live sessions map without spawning a PTY.
+// Avoids the cost of building a full createSessionInternal mock just to
+// exercise shutdown / persistence ordering. Not part of the runtime API.
+export function __addSessionForTest(session: Session): void {
+  sessions.set(session.id, session)
+}
+
+// Test-only — drains the sessions map between cases.
+export function __resetSessionsForTest(): void {
+  sessions.clear()
+  statusEmitted.clear()
+}
+
 // Snapshot the live sessions Map into the persistence wire format and
 // hand off to writePersistedSessions. Called whenever session state
 // changes (create / close / rename / exit).
@@ -387,10 +400,15 @@ export function createSessionInternal(opts: {
     } catch {
       // already dead
     }
-    sessions.delete(id)
+    // If the session was already removed from the map (e.g. by
+    // killAllSessions during shutdown), skip persistSessions — otherwise
+    // the snapshot of the now-empty map would clobber the metadata that
+    // killAllSessions just wrote. wasPresent distinguishes a normal exit
+    // from a shutdown-triggered exit.
+    const wasPresent = sessions.delete(id)
     statusEmitted.delete(id)
     for (const cb of sessionClosedCallbacks) cb(id)
-    persistSessions()
+    if (wasPresent) persistSessions()
   })
 
   // Shell PTY data/exit live on a parallel IPC channel. We deliberately do
@@ -547,7 +565,15 @@ export function respawnAllShells(shell: { command: string; args: string[] }): vo
   }
 }
 
+// Tear down every live session at app shutdown. Persists the metadata
+// snapshot BEFORE killing/clearing so sessions.json reflects the live
+// list and can be restored on next launch — without this, on macOS the
+// app stays alive after window-all-closed and reopens to an empty list.
+// The persist is skipped when the map is already empty (e.g. a second
+// call from before-quit after window-all-closed has already drained it),
+// so we don't overwrite a good snapshot with an empty one.
 export function killAllSessions(): void {
+  if (sessions.size > 0) persistSessions()
   for (const s of sessions.values()) {
     try {
       s.term.kill()

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -12,5 +12,6 @@
     "resolveJsonModule": true,
     "types": ["node"]
   },
-  "include": ["electron", "src/types.ts"]
+  "include": ["electron", "src/types.ts"],
+  "exclude": ["node_modules", "dist", ".claude"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,6 @@
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true
   },
-  "include": ["src", "vite.config.mts"]
+  "include": ["src", "vite.config.mts"],
+  "exclude": ["node_modules", "dist", ".claude"]
 }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -15,5 +15,19 @@ export default defineConfig({
   server: {
     port: 5173,
     strictPort: true,
+    watch: {
+      // Orchestrator subagents create git worktrees under
+      // .claude/worktrees/<branch>/, each a full duplicate of the
+      // termhub source. Without this, Vite's chokidar picks up the
+      // duplicate index.html / tsconfig and force-reloads the page.
+      // Vite's default ignored is replaced (not merged), so re-state
+      // the standard ignores.
+      ignored: [
+        '**/node_modules/**',
+        '**/.git/**',
+        '**/dist/**',
+        '**/.claude/**',
+      ],
+    },
   },
 })


### PR DESCRIPTION
## Summary

Two related fixes that came up while running orchestrator subagents under `.claude/worktrees/`:

- **`fix(session-manager)`** — On macOS, closing the termhub window emptied `sessions.json`, so nothing restored on next launch. `killAllSessions()` now snapshots the live map *before* killing PTYs and clearing, and `term.onExit` skips its persist when the session was already removed by `killAllSessions` so the late async exit callbacks can't clobber the good snapshot. A redundant second call (`window-all-closed` → `before-quit` on non-darwin) no-ops the persist when the map is already empty. Also softens the `[termhub:pr]` poll-loop warning when a session's cwd isn't a git repo (expected for orchestrator sessions rooted outside any repo).

- **`chore`** — Vite's chokidar and `tsc` were picking up duplicate `index.html` / `tsconfig.json` / `electron/**` / `src/**` from worktrees under `.claude/worktrees/<branch>/` and force-reloading the dev page. `vite.config.mts` now sets `server.watch.ignored` to include `**/.claude/**` (Vite replaces the default ignored, so the standard ignores are restated). `tsconfig.json` and `tsconfig.electron.json` add `.claude` to `exclude`.

## Test plan

- [x] `npm run typecheck` (both renderer + electron tsconfigs)
- [x] `npm test` — 254 tests pass, including the new `killAllSessions persistence` regression cases (snapshot before clear; redundant second call is a no-op)
- [x] `npm run build` — main, bridge, and renderer all build clean
- [ ] Manual: open termhub on macOS with one or two sessions, close the window, reopen — sessions restored from `sessions.json`
- [ ] Manual: run `npm run dev` from the main checkout, then `git worktree add .claude/worktrees/__sanity-check -b __sanity-check` — Vite should not log a page reload or "changed tsconfig file detected" for the worktree path

🤖 Generated with [Claude Code](https://claude.com/claude-code)