### PR TITLE
feat(mcp): authenticate the internal HTTP endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ release
 *.log
 .vite
 .claude/worktrees/
+.claude/settings.local.json

--- a/electron/config.ts
+++ b/electron/config.ts
@@ -41,6 +41,13 @@ export function getSessionsPath(): string {
   return path.join(app.getPath('userData'), 'sessions.json')
 }
 
+// Shared secret for the internal HTTP endpoint. Deliberately its own file
+// rather than a config.json key — config.json is documented as user-editable
+// and gets pretty-printed on save; this one is 0600 and machine-managed.
+export function getMcpTokenPath(): string {
+  return path.join(app.getPath('userData'), 'mcp-token')
+}
+
 export function saveConfig(config: Config): void {
   const configPath = getConfigPath()
   try {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -11,7 +11,8 @@ import { startMcpServer, type McpHandle } from './mcp'
 import type { Config } from '../src/types'
 import { stripAnsi } from './output-buffer'
 import { writeBracketedPasteAndSubmit } from './claude-command'
-import { getMcpConfigPath, loadConfig } from './config'
+import { getMcpConfigPath, getMcpTokenPath, loadConfig } from './config'
+import { MCP_TOKEN_HEADER, getOrCreateToken } from './mcp-auth'
 import { resolveSessionCwd } from './cwd-resolve'
 import { loadPersistedSessions } from './persistence'
 import { isClaudeModelName } from './codex-command'
@@ -59,7 +60,7 @@ function getBridgePath(): string {
 // Write the MCP config file that claude reads to discover the termhub
 // MCP server. Uses stdio transport: claude spawns the bridge subprocess
 // and pipes JSON-RPC over stdin/stdout. No HTTP, no OAuth flow.
-function writeMcpConfigFile(port: number): void {
+function writeMcpConfigFile(port: number, token: string): void {
   const configPath = getMcpConfigPath()
   const body = {
     mcpServers: {
@@ -70,13 +71,20 @@ function writeMcpConfigFile(port: number): void {
         env: {
           ELECTRON_RUN_AS_NODE: '1',
           TERMHUB_PORT: String(port),
+          // Authenticates the bridge to the internal HTTP endpoint. This is
+          // how the bridge is distinguished from any other local process that
+          // could otherwise reach 127.0.0.1:<port>.
+          TERMHUB_TOKEN: token,
         },
       },
     },
   }
   fs.mkdirSync(path.dirname(configPath), { recursive: true })
-  fs.writeFileSync(configPath, JSON.stringify(body, null, 2))
-  console.log(`[termhub] wrote MCP config to ${configPath}`)
+  // 0600: the file carries the internal API token.
+  fs.writeFileSync(configPath, JSON.stringify(body, null, 2), { mode: 0o600 })
+  console.log(
+    `[termhub] wrote MCP config to ${configPath} (port ${port}, auth via ${MCP_TOKEN_HEADER})`,
+  )
 }
 
 function createWindow(): void {
@@ -211,7 +219,8 @@ app.whenReady().then(async () => {
 
   const config = loadConfig()
   initBottomShell()
-  writeMcpConfigFile(config.mcpPort)
+  const mcpToken = getOrCreateToken(getMcpTokenPath())
+  writeMcpConfigFile(config.mcpPort, mcpToken)
 
   // Serialize MCP open_session calls. The orchestrator can fan out N
   // parallel open_session requests; we chain each through this queue
@@ -227,6 +236,7 @@ app.whenReady().then(async () => {
   try {
     mcpHandle = await startMcpServer({
       port: config.mcpPort,
+      token: mcpToken,
       hooks: {
         openClaudeSession: async ({
           cwd,

--- a/electron/mcp-auth.test.ts
+++ b/electron/mcp-auth.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { generateToken, tokensMatch, getOrCreateToken } from './mcp-auth'
+
+const tempDirs: string[] = []
+
+function tempTokenPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'termhub-token-'))
+  tempDirs.push(dir)
+  return path.join(dir, 'mcp-token')
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    fs.rmSync(tempDirs.pop()!, { recursive: true, force: true })
+  }
+})
+
+describe('generateToken', () => {
+  it('returns 64 hex chars (32 bytes)', () => {
+    expect(generateToken()).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('does not repeat', () => {
+    const tokens = new Set(Array.from({ length: 50 }, generateToken))
+    expect(tokens.size).toBe(50)
+  })
+})
+
+describe('tokensMatch', () => {
+  it('accepts an exact match', () => {
+    const t = generateToken()
+    expect(tokensMatch(t, t)).toBe(true)
+  })
+
+  it('rejects a different token of the same length', () => {
+    expect(tokensMatch('a'.repeat(64), 'b'.repeat(64))).toBe(false)
+  })
+
+  it('rejects undefined, empty, and length-mismatched input without throwing', () => {
+    const t = generateToken()
+    expect(tokensMatch(t, undefined)).toBe(false)
+    expect(tokensMatch(t, '')).toBe(false)
+    // timingSafeEqual throws on length mismatch; the guard must catch this.
+    expect(tokensMatch(t, t.slice(0, 10))).toBe(false)
+    expect(tokensMatch(t, t + 'extra')).toBe(false)
+  })
+
+  it('rejects a prefix of the real token', () => {
+    const t = generateToken()
+    expect(tokensMatch(t, t.slice(0, -1))).toBe(false)
+  })
+})
+
+describe('getOrCreateToken', () => {
+  it('creates a token file on first call', () => {
+    const p = tempTokenPath()
+    const token = getOrCreateToken(p)
+
+    expect(token).toMatch(/^[0-9a-f]{64}$/)
+    expect(fs.readFileSync(p, 'utf8')).toBe(token)
+  })
+
+  it('is stable across calls — a restart must not invalidate a live bridge', () => {
+    const p = tempTokenPath()
+    expect(getOrCreateToken(p)).toBe(getOrCreateToken(p))
+  })
+
+  it('writes the file 0600', () => {
+    const p = tempTokenPath()
+    getOrCreateToken(p)
+    // Windows does not model POSIX permission bits; skip the assertion there.
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(p).mode & 0o777).toBe(0o600)
+    }
+  })
+
+  it('replaces a truncated token rather than trusting it', () => {
+    const p = tempTokenPath()
+    fs.writeFileSync(p, 'tooshort')
+
+    const token = getOrCreateToken(p)
+    expect(token).toMatch(/^[0-9a-f]{64}$/)
+    expect(fs.readFileSync(p, 'utf8')).toBe(token)
+  })
+
+  it('tolerates surrounding whitespace in an existing file', () => {
+    const p = tempTokenPath()
+    const existing = generateToken()
+    fs.writeFileSync(p, `  ${existing}\n`)
+
+    expect(getOrCreateToken(p)).toBe(existing)
+  })
+
+  it('creates the parent directory if missing', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'termhub-token-'))
+    tempDirs.push(dir)
+    const p = path.join(dir, 'nested', 'deeper', 'mcp-token')
+
+    const token = getOrCreateToken(p)
+    expect(fs.readFileSync(p, 'utf8')).toBe(token)
+  })
+})

--- a/electron/mcp-auth.ts
+++ b/electron/mcp-auth.ts
@@ -1,0 +1,68 @@
+// Shared secret guarding the internal HTTP endpoint (electron/mcp.ts).
+//
+// The endpoint binds 127.0.0.1, which keeps it off the network but does NOT
+// keep it away from other processes on this machine — any local program could
+// POST /internal/open_session and spawn a claude session with
+// dangerouslySkipPermissions in a directory of its choosing. The bridge is
+// spawned by claude with the token in its env (see writeMcpConfigFile in
+// main.ts), so it can present the header; nothing else on the box can.
+//
+// The token is persisted rather than regenerated per run: claude may already
+// have a bridge subprocess alive from before a termhub restart, and rotating
+// on every launch would 401 it until the user restarted their session too.
+
+import * as path from 'node:path'
+import * as fs from 'node:fs'
+import * as crypto from 'node:crypto'
+
+export const MCP_TOKEN_HEADER = 'x-termhub-token'
+
+const TOKEN_BYTES = 32
+// A hex-encoded 32-byte token; anything shorter is treated as corrupt and
+// replaced rather than trusted.
+const MIN_TOKEN_LENGTH = TOKEN_BYTES * 2
+
+export function generateToken(): string {
+  return crypto.randomBytes(TOKEN_BYTES).toString('hex')
+}
+
+// Constant-time compare that tolerates length mismatch. timingSafeEqual throws
+// when the buffers differ in length, which would itself leak length via the
+// exception path, so the length check is folded into the result instead.
+export function tokensMatch(expected: string, provided: string | undefined): boolean {
+  if (typeof provided !== 'string' || provided.length === 0) return false
+  const a = Buffer.from(expected, 'utf8')
+  const b = Buffer.from(provided, 'utf8')
+  if (a.length !== b.length) return false
+  return crypto.timingSafeEqual(a, b)
+}
+
+// Read the token from `tokenPath`, creating it on first run. Written 0600 so
+// other users on a shared machine can't read it. A truncated or unreadable
+// file is replaced rather than reused.
+export function getOrCreateToken(tokenPath: string): string {
+  try {
+    const existing = fs.readFileSync(tokenPath, 'utf8').trim()
+    if (existing.length >= MIN_TOKEN_LENGTH) return existing
+    console.warn(
+      `[termhub:mcp] token at ${tokenPath} is too short (${existing.length} chars) — regenerating`,
+    )
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (code !== 'ENOENT') {
+      console.warn(`[termhub:mcp] could not read token at ${tokenPath} — regenerating:`, err)
+    }
+  }
+
+  const token = generateToken()
+  try {
+    fs.mkdirSync(path.dirname(tokenPath), { recursive: true })
+    fs.writeFileSync(tokenPath, token, { mode: 0o600 })
+    console.log(`[termhub:mcp] wrote new internal API token to ${tokenPath}`)
+  } catch (err) {
+    // Non-fatal: the in-memory token still guards this run, it just won't
+    // survive a restart (the bridge re-reads mcp-config.json each spawn).
+    console.error(`[termhub:mcp] failed to persist token to ${tokenPath}:`, err)
+  }
+  return token
+}

--- a/electron/mcp-bridge.ts
+++ b/electron/mcp-bridge.ts
@@ -13,9 +13,21 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod'
 import { MCP_ROUTES } from './mcp-routes'
+import { MCP_TOKEN_HEADER } from './mcp-auth'
 
 const port = Number.parseInt(process.env.TERMHUB_PORT ?? '7787', 10)
 const baseUrl = `http://127.0.0.1:${port}`
+
+// Set by termhub when it writes mcp-config.json (see writeMcpConfigFile in
+// electron/main.ts). Without it every /internal/* call comes back 401 — that
+// is the intended failure mode for anything that isn't the bridge termhub
+// itself configured.
+const token = process.env.TERMHUB_TOKEN ?? ''
+
+const jsonHeaders = {
+  'Content-Type': 'application/json',
+  [MCP_TOKEN_HEADER]: token,
+}
 
 async function main() {
   const server = new McpServer({
@@ -116,7 +128,7 @@ async function main() {
       try {
         const response = await fetch(`${baseUrl}${MCP_ROUTES.OPEN_SESSION}`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: jsonHeaders,
           body: JSON.stringify({
             cwd: args.cwd,
             prompt: args.prompt,
@@ -181,7 +193,7 @@ async function main() {
       try {
         const response = await fetch(`${baseUrl}${MCP_ROUTES.SEND_INPUT}`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: jsonHeaders,
           body: JSON.stringify({ sessionId: args.sessionId, text: args.text }),
         })
         const json = (await response.json().catch(() => ({}))) as {
@@ -233,7 +245,7 @@ async function main() {
       try {
         const response = await fetch(`${baseUrl}${MCP_ROUTES.READ_OUTPUT}`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: jsonHeaders,
           body: JSON.stringify({
             sessionId: args.sessionId,
             maxChars: args.maxChars,

--- a/electron/mcp.test.ts
+++ b/electron/mcp.test.ts
@@ -4,12 +4,15 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { startMcpServer, type McpHooks } from './mcp'
 import { MCP_ROUTES } from './mcp-routes'
+import { MCP_TOKEN_HEADER } from './mcp-auth'
 
 // Port 0 asks the OS for a free port; startMcpServer reports the real one back
 // on the handle. Fixed ports used to collide when more than one copy of this
 // suite ran at once (e.g. a stale worktree checkout) or when a dev instance of
 // termhub was already listening.
 const EPHEMERAL = 0
+
+const TOKEN = 'test-token-0123456789abcdef'
 
 function makeHooks(overrides: Partial<McpHooks> = {}): McpHooks {
   return {
@@ -23,7 +26,7 @@ function makeHooks(overrides: Partial<McpHooks> = {}): McpHooks {
 async function post(port: number, path: string, body: unknown): Promise<{ status: number; json: unknown }> {
   const res = await fetch(`http://127.0.0.1:${port}${path}`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', [MCP_TOKEN_HEADER]: TOKEN },
     body: JSON.stringify(body),
   })
   const json = await res.json()
@@ -37,7 +40,7 @@ describe('mcp HTTP server — error sanitization', () => {
   // Each test stands up its own server via start(); these hold the most
   // recent one so afterEach can tear it down.
   async function start(hooks: McpHooks) {
-    const handle = await startMcpServer({ port: EPHEMERAL, hooks })
+    const handle = await startMcpServer({ port: EPHEMERAL, token: TOKEN, hooks })
     port = handle.port
     close = handle.close
     return handle
@@ -76,7 +79,7 @@ describe('mcp HTTP server — error sanitization', () => {
 
     const res = await fetch(`http://127.0.0.1:${port}${MCP_ROUTES.OPEN_SESSION}`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', [MCP_TOKEN_HEADER]: TOKEN },
       body: '{ not valid json !!!',
     })
     const json = await res.json()
@@ -95,7 +98,7 @@ describe('mcp HTTP server — error sanitization', () => {
 
     const res = await fetch(`http://127.0.0.1:${port}${MCP_ROUTES.SEND_INPUT}`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', [MCP_TOKEN_HEADER]: TOKEN },
       body: '<<bad>>',
     })
     const json = await res.json()
@@ -114,7 +117,7 @@ describe('mcp HTTP server — error sanitization', () => {
 
     const res = await fetch(`http://127.0.0.1:${port}${MCP_ROUTES.READ_OUTPUT}`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', [MCP_TOKEN_HEADER]: TOKEN },
       body: 'not-json',
     })
     const json = await res.json()
@@ -124,6 +127,50 @@ describe('mcp HTTP server — error sanitization', () => {
     expect(body).not.toContain('at /')
     expect(body).not.toContain('SyntaxError')
     expect((json as { error: string }).error).toBe('invalid_json')
+  })
+
+  // ── auth ─────────────────────────────────────────────────────────────────
+
+  it('rejects a request with no token', async () => {
+    let opened = false
+    await start(makeHooks({ openClaudeSession: () => { opened = true; return { id: 'x', cwd: '/tmp' } } }))
+
+    const res = await fetch(`http://127.0.0.1:${port}${MCP_ROUTES.OPEN_SESSION}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cwd: '/tmp' }),
+    })
+
+    expect(res.status).toBe(401)
+    expect((await res.json() as { error: string }).error).toBe('unauthorized')
+    // The hook must not have run — a 401 that still spawned a session would
+    // defeat the point of the check.
+    expect(opened).toBe(false)
+  })
+
+  it('rejects a request with the wrong token', async () => {
+    await start(makeHooks())
+
+    const res = await fetch(`http://127.0.0.1:${port}${MCP_ROUTES.OPEN_SESSION}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', [MCP_TOKEN_HEADER]: 'not-the-token' },
+      body: JSON.stringify({ cwd: '/tmp' }),
+    })
+
+    expect(res.status).toBe(401)
+  })
+
+  it('authenticates send_input and read_output too, not just open_session', async () => {
+    await start(makeHooks())
+
+    for (const route of [MCP_ROUTES.SEND_INPUT, MCP_ROUTES.READ_OUTPUT]) {
+      const res = await fetch(`http://127.0.0.1:${port}${route}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 'a', text: 'b' }),
+      })
+      expect(res.status, `${route} must require auth`).toBe(401)
+    }
   })
 
   // ── regression: happy paths still work ───────────────────────────────────

--- a/electron/mcp.ts
+++ b/electron/mcp.ts
@@ -5,6 +5,7 @@
 
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
 import { MCP_ROUTES } from './mcp-routes'
+import { MCP_TOKEN_HEADER, tokensMatch } from './mcp-auth'
 
 export type OpenSessionResult = { id: string; cwd: string }
 
@@ -61,10 +62,23 @@ function respondJson(res: ServerResponse, status: number, body: unknown) {
 
 export async function startMcpServer(opts: {
   port: number
+  token: string
   hooks: McpHooks
 }): Promise<McpHandle> {
   const httpServer = createServer(async (req, res) => {
     console.log(`[termhub:mcp] ${req.method} ${req.url}`)
+
+    // Every /internal/* route is authenticated. Binding 127.0.0.1 keeps this
+    // off the network but not away from other local processes, and these
+    // routes can spawn a permission-bypassing session in any directory.
+    const presented = req.headers[MCP_TOKEN_HEADER]
+    if (!tokensMatch(opts.token, Array.isArray(presented) ? presented[0] : presented)) {
+      console.warn(
+        `[termhub:mcp] rejected unauthenticated ${req.method} ${req.url} from ${req.socket.remoteAddress}`,
+      )
+      respondJson(res, 401, { error: 'unauthorized' })
+      return
+    }
 
     if (req.url === MCP_ROUTES.OPEN_SESSION && req.method === 'POST') {
       const body = await readBody(req).catch(() => '')


### PR DESCRIPTION
## Problem

`electron/mcp.ts` binds `127.0.0.1:7787`, which keeps it off the network but **not** away from other processes on the same machine. Any local program could:

```
POST /internal/open_session {"cwd": "/anywhere", "dangerouslySkipPermissions": true}
```

…and termhub would spawn a permission-bypassing Claude session in that directory. Low practical risk on a single-user box, but the bridge already receives an env block from `writeMcpConfigFile`, so closing it is nearly free.

## Changes

- **`electron/mcp-auth.ts`** (new) — token generation, a constant-time compare that tolerates length mismatch (`timingSafeEqual` *throws* on it, which would itself leak length via the exception path), and `getOrCreateToken` backed by a `0600` file. Imports no electron, so the bridge bundle stays a plain Node script.
- **`electron/mcp.ts`** — `startMcpServer` takes a `token` and 401s any `/internal/*` request without a matching `x-termhub-token`. The check runs **before** routing, so no hook fires on a rejected request.
- **`electron/mcp-bridge.ts`** — sends the header from `TERMHUB_TOKEN` on all three calls.
- **`electron/main.ts`** — resolves the token at startup, passes it to the server, and writes it into the bridge env in `mcp-config.json` (now `0600`, since that file carries the secret).
- **`electron/config.ts`** — `getMcpTokenPath()`, alongside the other userData path getters.

## Why the token is persisted, not per-run

Rotating on every launch would 401 any bridge subprocess claude already had alive from before a termhub restart — turning "restart termhub" into "restart termhub *and* every claude session". The token lives in `userData/mcp-token` at `0600` instead.

## Verification

- 15 new tests: the auth module (generation, constant-time compare incl. length-mismatch and prefix cases, file creation/permissions/reuse/truncation) plus endpoint-level rejection for **all three** routes, including an assertion that a 401 does not run the hook.
- `npm test` — 281 tests green. `npm run typecheck` clean. `npm run build` clean.
- Confirmed `dist/mcp-bridge.js` still has no `require("electron")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)