### PR TITLE
feat(mcp): add list_sessions, get_session_status, close_session

### DIFF
--- a/electron/ipc-session.ts
+++ b/electron/ipc-session.ts
@@ -5,8 +5,8 @@
 
 import { ipcMain } from 'electron'
 import {
+  closeSession,
   createSessionInternal,
-  deleteSession,
   getAllSessions,
   getSession,
   persistSessions,
@@ -39,24 +39,7 @@ export function registerSessionHandlers(): void {
   )
 
   ipcMain.on('session:close', (_event, payload: { id: string }) => {
-    const s = getSession(payload.id)
-    if (!s) return
-    if (s.jsonlWatcher) {
-      s.jsonlWatcher.stop()
-      s.jsonlWatcher = null
-    }
-    try {
-      s.term.kill()
-    } catch {
-      // already dead
-    }
-    try {
-      s.shellTerm.kill()
-    } catch {
-      // already dead
-    }
-    deleteSession(payload.id)
-    persistSessions()
+    closeSession(payload.id)
   })
 
   ipcMain.on(

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -7,7 +7,7 @@
 import { app, BrowserWindow, ipcMain, Menu } from 'electron'
 import * as path from 'node:path'
 import * as fs from 'node:fs'
-import { startMcpServer, type McpHandle } from './mcp'
+import { startMcpServer, type McpHandle, type SessionSummary } from './mcp'
 import type { Config } from '../src/types'
 import { stripAnsi } from './output-buffer'
 import { writeBracketedPasteAndSubmit } from './claude-command'
@@ -17,10 +17,13 @@ import { resolveSessionCwd } from './cwd-resolve'
 import { loadPersistedSessions } from './persistence'
 import { isClaudeModelName } from './codex-command'
 import {
+  closeSession,
   createSessionInternal,
   findSessionByIdOrPrefix,
+  getAllSessions,
   killAllSessions,
   setMainWindow,
+  type Session,
 } from './session-manager'
 import { registerSessionHandlers } from './ipc-session'
 import { registerDiscoveryHandlers } from './ipc-discovery'
@@ -51,6 +54,22 @@ if (!app.isPackaged) {
 
 let mainWindow: BrowserWindow | null = null
 let mcpHandle: McpHandle | null = null
+
+// Project a live Session onto the MCP wire shape. Deliberately omits the PTY
+// handles, the output buffer, and the JSONL watcher — none of which are
+// serializable, and the buffer has its own tool (read_output).
+function toSessionSummary(s: Session): SessionSummary {
+  return {
+    id: s.id,
+    name: s.name,
+    cwd: s.cwd,
+    cli: s.cli,
+    status: s.status,
+    model: s.model,
+    permissionMode: s.permissionMode,
+    repoLabel: s.repoLabel,
+  }
+}
 
 function getBridgePath(): string {
   // dist/main/main.js → ../mcp-bridge.js → dist/mcp-bridge.js
@@ -316,6 +335,20 @@ app.whenReady().then(async () => {
             text = text.slice(text.length - maxChars)
           }
           return { text }
+        },
+        listSessions: () => ({ sessions: getAllSessions().map(toSessionSummary) }),
+        getSessionStatus: ({ sessionId }) => {
+          const result = findSessionByIdOrPrefix(sessionId)
+          if (!result.found) return { error: result.error }
+          return { session: toSessionSummary(result.session) }
+        },
+        closeSession: ({ sessionId }) => {
+          const result = findSessionByIdOrPrefix(sessionId)
+          if (!result.found) return { ok: false, error: result.error }
+          const closed = closeSession(result.session.id)
+          return closed
+            ? { ok: true }
+            : { ok: false, error: `Session ${result.session.id} could not be closed` }
         },
       },
     })

--- a/electron/mcp-bridge.test.ts
+++ b/electron/mcp-bridge.test.ts
@@ -1,0 +1,53 @@
+// The bridge is what an orchestrator actually reads, so the shape of what it
+// prints is a contract of its own. formatSession is the only pure piece;
+// the tool handlers are thin fetch wrappers covered by mcp.test.ts.
+
+import { describe, it, expect } from 'vitest'
+import { formatSession } from './mcp-bridge'
+import type { SessionSummary } from './mcp'
+
+const base: SessionSummary = {
+  id: 'abc123',
+  cwd: '/repo',
+  status: 'idle',
+}
+
+describe('formatSession', () => {
+  it('leads with id and status — the two fields a caller acts on', () => {
+    expect(formatSession(base)).toMatch(/^abc123\s+\[idle]/)
+  })
+
+  it('includes the name when set', () => {
+    expect(formatSession({ ...base, name: 'worker-1' })).toContain('worker-1')
+  })
+
+  it('omits the metadata parens entirely when cli/model/mode are all absent', () => {
+    expect(formatSession(base)).not.toContain('(')
+  })
+
+  it('collects cli, model and permissionMode into one parenthesised group', () => {
+    const line = formatSession({
+      ...base,
+      cli: 'claude',
+      model: 'claude-opus-5',
+      permissionMode: 'plan',
+    })
+    expect(line).toContain('(claude, claude-opus-5, plan)')
+  })
+
+  it('skips absent metadata fields rather than emitting blanks', () => {
+    const line = formatSession({ ...base, cli: 'codex' })
+    expect(line).toContain('(codex)')
+    expect(line).not.toContain(', ,')
+  })
+
+  it('renders each status verbatim so callers can match on it', () => {
+    for (const status of ['working', 'awaiting', 'idle', 'failed'] as const) {
+      expect(formatSession({ ...base, status })).toContain(`[${status}]`)
+    }
+  })
+
+  it('always includes the cwd', () => {
+    expect(formatSession(base)).toContain('/repo')
+  })
+})

--- a/electron/mcp-bridge.ts
+++ b/electron/mcp-bridge.ts
@@ -14,6 +14,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod'
 import { MCP_ROUTES } from './mcp-routes'
 import { MCP_TOKEN_HEADER } from './mcp-auth'
+import type { SessionSummary } from './mcp'
 
 const port = Number.parseInt(process.env.TERMHUB_PORT ?? '7787', 10)
 const baseUrl = `http://127.0.0.1:${port}`
@@ -27,6 +28,17 @@ const token = process.env.TERMHUB_TOKEN ?? ''
 const jsonHeaders = {
   'Content-Type': 'application/json',
   [MCP_TOKEN_HEADER]: token,
+}
+
+// One line per session. Kept terse on purpose: an orchestrator polling a dozen
+// workers pays for every token, and the id + status + name are what it acts on.
+export function formatSession(s: SessionSummary): string {
+  const bits = [`${s.id}  [${s.status}]`]
+  if (s.name) bits.push(s.name)
+  bits.push(s.cwd)
+  const meta = [s.cli, s.model, s.permissionMode].filter(Boolean)
+  if (meta.length > 0) bits.push(`(${meta.join(', ')})`)
+  return bits.join('  ')
 }
 
 async function main() {
@@ -265,6 +277,151 @@ async function main() {
         return {
           content: [{ type: 'text', text: json.text ?? '(no output)' }],
         }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        return {
+          content: [{ type: 'text', text: `Failed to reach termhub: ${msg}` }],
+          isError: true,
+        }
+      }
+    },
+  )
+
+  server.registerTool(
+    'list_sessions',
+    {
+      title: 'List all termhub sessions',
+      description:
+        'Returns every session termhub currently has open — including ones this ' +
+        'orchestrator did not spawn, and ones resumed from a previous run. Each entry ' +
+        'carries id, name, cwd, cli, model, permissionMode and current status. ' +
+        'Use this to recover session ids after a restart, or to survey what is running ' +
+        'before deciding what to steer.',
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const response = await fetch(`${baseUrl}${MCP_ROUTES.LIST_SESSIONS}`, {
+          method: 'POST',
+          headers: jsonHeaders,
+        })
+        const json = (await response.json().catch(() => ({}))) as {
+          sessions?: SessionSummary[]
+          error?: string
+        }
+        if (!response.ok || json.error) {
+          return {
+            content: [
+              { type: 'text', text: `Failed: ${json.error ?? `HTTP ${response.status}`}` },
+            ],
+            isError: true,
+          }
+        }
+        const sessions = json.sessions ?? []
+        if (sessions.length === 0) {
+          return { content: [{ type: 'text', text: 'No sessions open.' }] }
+        }
+        return {
+          content: [
+            {
+              type: 'text',
+              text: sessions.map(formatSession).join('\n'),
+            },
+          ],
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        return {
+          content: [{ type: 'text', text: `Failed to reach termhub: ${msg}` }],
+          isError: true,
+        }
+      }
+    },
+  )
+
+  server.registerTool(
+    'get_session_status',
+    {
+      title: 'Get the current status of a termhub session',
+      description:
+        'Returns the advisory status of one session without pulling its output. ' +
+        "Values: 'working' (generating or running tools), 'awaiting' (paused for a " +
+        "permission prompt or question — needs you), 'idle' (at the input prompt, " +
+        "ready for the next message), 'failed' (process died non-zero). " +
+        'Prefer this over polling read_output and guessing from the text. ' +
+        'Status is sourced from Claude Code\'s own session file, so it is only ' +
+        "meaningful for cli: 'claude' sessions.",
+      inputSchema: {
+        sessionId: z
+          .string()
+          .describe('Full session id (or unambiguous prefix) returned by open_session'),
+      },
+    },
+    async (args) => {
+      try {
+        const response = await fetch(`${baseUrl}${MCP_ROUTES.SESSION_STATUS}`, {
+          method: 'POST',
+          headers: jsonHeaders,
+          body: JSON.stringify({ sessionId: args.sessionId }),
+        })
+        const json = (await response.json().catch(() => ({}))) as {
+          session?: SessionSummary
+          error?: string
+        }
+        if (!response.ok || json.error || !json.session) {
+          return {
+            content: [
+              { type: 'text', text: `Failed: ${json.error ?? `HTTP ${response.status}`}` },
+            ],
+            isError: true,
+          }
+        }
+        return { content: [{ type: 'text', text: formatSession(json.session) }] }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        return {
+          content: [{ type: 'text', text: `Failed to reach termhub: ${msg}` }],
+          isError: true,
+        }
+      }
+    },
+  )
+
+  server.registerTool(
+    'close_session',
+    {
+      title: 'Close a termhub session',
+      description:
+        'Terminates a session and removes it from the sidebar. Kills the underlying ' +
+        'CLI process and the session\'s docked shell. This is not reversible — the ' +
+        'session is gone, though claude can be resumed later in the same directory. ' +
+        'Use it to reap finished workers so the sidebar reflects live work.',
+      inputSchema: {
+        sessionId: z
+          .string()
+          .describe('Full session id (or unambiguous prefix) returned by open_session'),
+      },
+    },
+    async (args) => {
+      try {
+        const response = await fetch(`${baseUrl}${MCP_ROUTES.CLOSE_SESSION}`, {
+          method: 'POST',
+          headers: jsonHeaders,
+          body: JSON.stringify({ sessionId: args.sessionId }),
+        })
+        const json = (await response.json().catch(() => ({}))) as {
+          ok?: boolean
+          error?: string
+        }
+        if (!response.ok || !json.ok) {
+          return {
+            content: [
+              { type: 'text', text: `Failed: ${json.error ?? `HTTP ${response.status}`}` },
+            ],
+            isError: true,
+          }
+        }
+        return { content: [{ type: 'text', text: `Closed session ${args.sessionId}.` }] }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         return {

--- a/electron/mcp-routes.test.ts
+++ b/electron/mcp-routes.test.ts
@@ -9,6 +9,9 @@ describe('MCP_ROUTES', () => {
     expect(MCP_ROUTES.OPEN_SESSION).toBe('/internal/open_session')
     expect(MCP_ROUTES.SEND_INPUT).toBe('/internal/send_input')
     expect(MCP_ROUTES.READ_OUTPUT).toBe('/internal/read_output')
+    expect(MCP_ROUTES.LIST_SESSIONS).toBe('/internal/list_sessions')
+    expect(MCP_ROUTES.SESSION_STATUS).toBe('/internal/session_status')
+    expect(MCP_ROUTES.CLOSE_SESSION).toBe('/internal/close_session')
   })
 
   it('routes are unique', () => {

--- a/electron/mcp-routes.ts
+++ b/electron/mcp-routes.ts
@@ -7,6 +7,9 @@ export const MCP_ROUTES = {
   OPEN_SESSION: '/internal/open_session',
   SEND_INPUT: '/internal/send_input',
   READ_OUTPUT: '/internal/read_output',
+  LIST_SESSIONS: '/internal/list_sessions',
+  SESSION_STATUS: '/internal/session_status',
+  CLOSE_SESSION: '/internal/close_session',
 } as const
 
 export type McpRoute = (typeof MCP_ROUTES)[keyof typeof MCP_ROUTES]

--- a/electron/mcp.test.ts
+++ b/electron/mcp.test.ts
@@ -2,7 +2,7 @@
 // (CodeQL js/stack-trace-exposure: error details must not reach the caller).
 
 import { describe, it, expect, afterEach } from 'vitest'
-import { startMcpServer, type McpHooks } from './mcp'
+import { startMcpServer, type McpHooks, type SessionSummary } from './mcp'
 import { MCP_ROUTES } from './mcp-routes'
 import { MCP_TOKEN_HEADER } from './mcp-auth'
 
@@ -14,11 +14,24 @@ const EPHEMERAL = 0
 
 const TOKEN = 'test-token-0123456789abcdef'
 
+const SESSION: SessionSummary = {
+  id: 'sess-1',
+  name: 'worker',
+  cwd: '/tmp/repo',
+  cli: 'claude',
+  status: 'awaiting',
+  model: 'claude-opus-5',
+  permissionMode: 'plan',
+}
+
 function makeHooks(overrides: Partial<McpHooks> = {}): McpHooks {
   return {
     openClaudeSession: () => ({ id: 'test-id', cwd: '/tmp' }),
     sendInput: () => ({ ok: true }),
     readOutput: () => ({ text: 'output' }),
+    listSessions: () => ({ sessions: [SESSION] }),
+    getSessionStatus: () => ({ session: SESSION }),
+    closeSession: () => ({ ok: true }),
     ...overrides,
   }
 }
@@ -127,6 +140,106 @@ describe('mcp HTTP server — error sanitization', () => {
     expect(body).not.toContain('at /')
     expect(body).not.toContain('SyntaxError')
     expect((json as { error: string }).error).toBe('invalid_json')
+  })
+
+  // ── list_sessions / session_status / close_session ───────────────────────
+
+  it('list_sessions returns every session, including ones the caller did not spawn', async () => {
+    const others: SessionSummary[] = [
+      SESSION,
+      { id: 'sess-2', cwd: '/tmp/other', status: 'idle', cli: 'codex' },
+    ]
+    await start(makeHooks({ listSessions: () => ({ sessions: others }) }))
+
+    const { status, json } = await post(port, MCP_ROUTES.LIST_SESSIONS, {})
+
+    expect(status).toBe(200)
+    expect((json as { sessions: SessionSummary[] }).sessions).toEqual(others)
+  })
+
+  it('list_sessions returns an empty list rather than erroring when nothing is open', async () => {
+    await start(makeHooks({ listSessions: () => ({ sessions: [] }) }))
+
+    const { status, json } = await post(port, MCP_ROUTES.LIST_SESSIONS, {})
+
+    expect(status).toBe(200)
+    expect((json as { sessions: SessionSummary[] }).sessions).toEqual([])
+  })
+
+  it('session_status surfaces the advisory status for one session', async () => {
+    await start(makeHooks())
+
+    const { status, json } = await post(port, MCP_ROUTES.SESSION_STATUS, {
+      sessionId: 'sess-1',
+    })
+
+    expect(status).toBe(200)
+    expect((json as { session: SessionSummary }).session.status).toBe('awaiting')
+  })
+
+  it('session_status 400s on an unknown session', async () => {
+    await start(makeHooks({ getSessionStatus: () => ({ error: 'No session found for "nope"' }) }))
+
+    const { status, json } = await post(port, MCP_ROUTES.SESSION_STATUS, {
+      sessionId: 'nope',
+    })
+
+    expect(status).toBe(400)
+    expect((json as { error: string }).error).toContain('No session found')
+  })
+
+  it('session_status rejects a missing sessionId', async () => {
+    await start(makeHooks())
+
+    const { status } = await post(port, MCP_ROUTES.SESSION_STATUS, {})
+    expect(status).toBe(400)
+  })
+
+  it('close_session reports ok and passes the id through', async () => {
+    const closed: string[] = []
+    await start(
+      makeHooks({
+        closeSession: ({ sessionId }) => {
+          closed.push(sessionId)
+          return { ok: true }
+        },
+      }),
+    )
+
+    const { status } = await post(port, MCP_ROUTES.CLOSE_SESSION, { sessionId: 'sess-1' })
+
+    expect(status).toBe(200)
+    expect(closed).toEqual(['sess-1'])
+  })
+
+  it('close_session 400s when the session does not resolve', async () => {
+    await start(
+      makeHooks({ closeSession: () => ({ ok: false, error: 'No session found for "gone"' }) }),
+    )
+
+    const { status, json } = await post(port, MCP_ROUTES.CLOSE_SESSION, {
+      sessionId: 'gone',
+    })
+
+    expect(status).toBe(400)
+    expect((json as { error: string }).error).toContain('No session found')
+  })
+
+  it('the new routes are authenticated too', async () => {
+    await start(makeHooks())
+
+    for (const route of [
+      MCP_ROUTES.LIST_SESSIONS,
+      MCP_ROUTES.SESSION_STATUS,
+      MCP_ROUTES.CLOSE_SESSION,
+    ]) {
+      const res = await fetch(`http://127.0.0.1:${port}${route}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 'sess-1' }),
+      })
+      expect(res.status, `${route} must require auth`).toBe(401)
+    }
   })
 
   // ── auth ─────────────────────────────────────────────────────────────────

--- a/electron/mcp.ts
+++ b/electron/mcp.ts
@@ -6,8 +6,24 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
 import { MCP_ROUTES } from './mcp-routes'
 import { MCP_TOKEN_HEADER, tokensMatch } from './mcp-auth'
+import type { SessionStatus } from '../src/types'
 
 export type OpenSessionResult = { id: string; cwd: string }
+
+// What an orchestrator sees for a session it did not necessarily spawn.
+// `status` is the advisory state termhub already derives from Claude Code's
+// own JSONL file (see status-watcher.ts) — previously renderer-only, which
+// forced callers to scrape read_output to guess whether a worker was stuck.
+export type SessionSummary = {
+  id: string
+  name?: string
+  cwd: string
+  cli?: 'claude' | 'codex' | 'gemini'
+  status: SessionStatus
+  model?: string
+  permissionMode?: string
+  repoLabel?: string
+}
 
 export type McpHooks = {
   // Async because the implementation in main.ts serializes spawns and
@@ -32,6 +48,12 @@ export type McpHooks = {
     text?: string
     error?: string
   }
+  listSessions: () => { sessions: SessionSummary[] }
+  getSessionStatus: (req: { sessionId: string }) => {
+    session?: SessionSummary
+    error?: string
+  }
+  closeSession: (req: { sessionId: string }) => { ok: boolean; error?: string }
 }
 
 export type McpHandle = {
@@ -185,6 +207,50 @@ export async function startMcpServer(opts: {
         raw: typeof parsed.raw === 'boolean' ? parsed.raw : undefined,
       })
       respondJson(res, result.error ? 400 : 200, result)
+      return
+    }
+
+    if (req.url === MCP_ROUTES.LIST_SESSIONS && req.method === 'POST') {
+      // No body to parse — the caller wants everything termhub knows about.
+      respondJson(res, 200, opts.hooks.listSessions())
+      return
+    }
+
+    if (req.url === MCP_ROUTES.SESSION_STATUS && req.method === 'POST') {
+      const body = await readBody(req).catch(() => '')
+      let parsed: { sessionId?: unknown }
+      try {
+        parsed = body ? JSON.parse(body) : {}
+      } catch (err) {
+        console.warn('[termhub:mcp] session_status: invalid JSON in request body', err)
+        respondJson(res, 400, { error: 'invalid_json' })
+        return
+      }
+      if (typeof parsed.sessionId !== 'string') {
+        respondJson(res, 400, { error: 'sessionId must be a string' })
+        return
+      }
+      const result = opts.hooks.getSessionStatus({ sessionId: parsed.sessionId })
+      respondJson(res, result.error ? 400 : 200, result)
+      return
+    }
+
+    if (req.url === MCP_ROUTES.CLOSE_SESSION && req.method === 'POST') {
+      const body = await readBody(req).catch(() => '')
+      let parsed: { sessionId?: unknown }
+      try {
+        parsed = body ? JSON.parse(body) : {}
+      } catch (err) {
+        console.warn('[termhub:mcp] close_session: invalid JSON in request body', err)
+        respondJson(res, 400, { error: 'invalid_json' })
+        return
+      }
+      if (typeof parsed.sessionId !== 'string') {
+        respondJson(res, 400, { error: 'sessionId must be a string' })
+        return
+      }
+      const result = opts.hooks.closeSession({ sessionId: parsed.sessionId })
+      respondJson(res, result.ok ? 200 : 400, result)
       return
     }
 

--- a/electron/session-manager.ts
+++ b/electron/session-manager.ts
@@ -193,6 +193,41 @@ export function persistSessions(): void {
 
 // Drop a session from the map. Called by the close IPC handler;
 // term.onExit handles its own cleanup so this isn't called from there.
+// Tear a session down: stop the JSONL watcher, kill both PTYs, drop it from
+// the map, and re-persist. Shared by the renderer's session:close IPC and the
+// MCP close_session tool so the two can't drift.
+//
+// Returns false when the id doesn't resolve. Killing the primary PTY also
+// fires its onExit handler, which deletes from the map and persists again —
+// harmless, and the explicit delete here keeps the teardown correct even if
+// the PTY was already dead and onExit never fires.
+export function closeSession(id: string): boolean {
+  const session = sessions.get(id)
+  if (!session) return false
+
+  console.log(
+    `[termhub:session] closing session ${id.slice(0, 8)} (cli=${session.cli ?? 'shell'}, cwd=${session.cwd})`,
+  )
+
+  if (session.jsonlWatcher) {
+    session.jsonlWatcher.stop()
+    session.jsonlWatcher = null
+  }
+  try {
+    session.term.kill()
+  } catch {
+    // already dead
+  }
+  try {
+    session.shellTerm.kill()
+  } catch {
+    // already dead
+  }
+  deleteSession(id)
+  persistSessions()
+  return true
+}
+
 export function deleteSession(id: string): void {
   sessions.delete(id)
   statusEmitted.delete(id)


### PR DESCRIPTION
## Problem

The MCP surface was `open_session` / `send_input` / `read_output` only, which left an orchestrator unable to answer basic questions about its own fleet:

- **No session discovery.** It only knew ids returned from its own `open_session` calls. Those are lost when the orchestrator session restarts, and it could never see sessions the user opened by hand or that termhub resumed from a prior run.
- **No status.** termhub *already* derives `working` / `awaiting` / `idle` / `failed` from Claude Code's JSONL (`status-watcher.ts`) and renders it as sidebar dots — but the value was renderer-only. Callers had to poll `read_output` and eyeball raw TUI text to guess whether a worker was mid-task or parked on a permission prompt. This was the biggest gap.
- **No teardown.** No way to reap a finished worker.

## Changes

Added across all three processes, per the contract in CLAUDE.md — bridge declares/routes, `mcp.ts` handles + types, `main.ts` implements:

| Tool | Returns |
|---|---|
| `list_sessions` | every session termhub has open, with status |
| `get_session_status` | one session's advisory status, without pulling output |
| `close_session` | terminates the CLI process and its docked shell |

- **`SessionSummary`** is the new wire shape: `id`, `name`, `cwd`, `cli`, `status`, `model`, `permissionMode`, `repoLabel`. Deliberately omits PTY handles, the output buffer, and the JSONL watcher — unserializable, and the buffer has its own tool.
- **`formatSession`** keeps list output to one terse line per session. An orchestrator polling a dozen workers pays for every token.
- **`session-manager.closeSession()`** extracted from the duplicated teardown in `ipc-session.ts`, so the IPC and MCP close paths can't drift.

## Verification

Drove the **built** bridge over stdio against a stub endpoint:

```
registered tools: 6
  - open_session         required=['cwd']
  - send_input           required=['sessionId', 'text']
  - read_output          required=['sessionId']
  - list_sessions        required=[]
  - get_session_status   required=['sessionId']
  - close_session        required=['sessionId']

token reached server: true
sess-aaa  [awaiting]  worker-1  /repo/a  (claude, claude-opus-5, plan)
sess-bbb  [working]  /repo/b  (codex)
```

Plus 15 new unit tests (route handling, unknown-session 400s, empty-list case, auth enforced on the new routes, `formatSession` shaping). **296 tests green**, typecheck and build clean.

## Note

`get_session_status` is only meaningful for `cli: "claude"` sessions — status comes from Claude Code's own session file. codex/gemini sessions report `working` until they exit. The tool description says so; wiring up real status for those runtimes is separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)