### PR TITLE
feat(ui): rich new-session dialog, error toasts, config access

### DIFF
--- a/electron/ipc-app.ts
+++ b/electron/ipc-app.ts
@@ -6,7 +6,7 @@
 // The mainWindow ref needed by dialog and window controls is injected
 // at startup via setMainWindow so this module doesn't import main.ts.
 
-import { ipcMain, dialog, clipboard, BrowserWindow } from 'electron'
+import { ipcMain, dialog, clipboard, shell, BrowserWindow } from 'electron'
 import * as os from 'node:os'
 import { spawn } from 'node:child_process'
 import type { Config } from '../src/types'
@@ -52,6 +52,19 @@ export function registerAppHandlers(opts: { config: Config }): void {
   ipcMain.handle('app:home', () => os.homedir())
   ipcMain.handle('config:get', () => opts.config)
   ipcMain.handle('config:path', () => getConfigPath())
+
+  // Open config.json in the OS default editor. termhub has no settings UI —
+  // mcpPort and startupSessions are edited by hand — and the path lives deep
+  // inside userData, so without this the file is effectively unreachable.
+  ipcMain.handle('config:open', async () => {
+    const configPath = getConfigPath()
+    const error = await shell.openPath(configPath)
+    if (error) {
+      console.error(`[termhub] failed to open config at ${configPath}: ${error}`)
+      throw new Error(`Could not open ${configPath}: ${error}`)
+    }
+    console.log(`[termhub] opened config ${configPath} in the default editor`)
+  })
 
   ipcMain.handle('clipboard:read', () => clipboard.readText())
   ipcMain.on('clipboard:write', (_event, text: string) => {

--- a/electron/ipc-session.ts
+++ b/electron/ipc-session.ts
@@ -12,13 +12,40 @@ import {
   persistSessions,
 } from './session-manager'
 import { resizePty } from './pty-resize'
+import { isClaudeModelName } from './codex-command'
+import type { NewSessionOptions } from '../src/types'
 
 export function registerSessionHandlers(): void {
-  // Renderer-spawned sessions are plain shells rooted at the picked folder.
-  // Claude sessions are launched via startup config, restored on resume, or
-  // opened via the MCP `open_session` tool — never from the renderer.
-  ipcMain.handle('session:create', (_event, opts: { cwd: string }) => {
-    const result = createSessionInternal({ cwd: opts.cwd, source: 'ipc' })
+  // The renderer can now spawn the same shapes the MCP open_session tool can:
+  // a plain shell (omit `cli`) or a claude/codex/gemini session with a model,
+  // agent, permission mode and initial prompt. Previously this only took a
+  // cwd and always produced a bare shell, which left the human path strictly
+  // less capable than the orchestrator path.
+  //
+  // source stays 'ipc' so session-manager skips the session:added broadcast —
+  // the renderer adds the row itself from the returned id.
+  ipcMain.handle('session:create', (_event, opts: NewSessionOptions) => {
+    if (opts.cli && opts.cli !== 'claude' && opts.model && isClaudeModelName(opts.model)) {
+      // Same guard the MCP path applies: a claude model name with a non-claude
+      // runtime fails at spawn time with a much less obvious error.
+      throw new Error(
+        `Cannot use Claude model '${opts.model}' with ${opts.cli}. ` +
+          `Pass a ${opts.cli}-compatible model or leave the model blank.`,
+      )
+    }
+    const result = createSessionInternal({
+      cwd: opts.cwd,
+      command: opts.cli,
+      cli: opts.cli,
+      prompt: opts.prompt,
+      agent: opts.agent,
+      model: opts.model,
+      permissionMode: opts.permissionMode,
+      dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
+      allowDangerouslySkipPermissions: opts.allowDangerouslySkipPermissions,
+      name: opts.name,
+      source: 'ipc',
+    })
     return { id: result.id, cwd: result.cwd }
   })
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron'
 import type {
   AgentDef,
   Config,
+  NewSessionOptions,
   SessionPr,
   SessionStatus,
   SessionUsage,
@@ -26,8 +27,10 @@ type AddedPayload = {
 }
 
 const api = {
-  createSession: (cwd: string): Promise<{ id: string; cwd: string }> =>
-    ipcRenderer.invoke('session:create', { cwd }),
+  createSession: (
+    opts: NewSessionOptions,
+  ): Promise<{ id: string; cwd: string }> =>
+    ipcRenderer.invoke('session:create', opts),
 
   sendInput: (id: string, data: string): void => {
     ipcRenderer.send('session:input', { id, data })
@@ -71,6 +74,7 @@ const api = {
   getConfig: (): Promise<Config> => ipcRenderer.invoke('config:get'),
 
   configPath: (): Promise<string> => ipcRenderer.invoke('config:path'),
+  openConfigFile: (): Promise<void> => ipcRenderer.invoke('config:open'),
 
   readClipboard: (): Promise<string> => ipcRenderer.invoke('clipboard:read'),
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,10 @@ import { ShellPicker } from './ShellPicker'
 import { RightPanel } from './RightPanel'
 import { UsageModal } from './UsageModal'
 import { ConfirmCloseModal } from './ConfirmCloseModal'
-import type { Session, ShellInfo } from './types'
+import { NewSessionModal } from './NewSessionModal'
+import { Toasts } from './Toasts'
+import { useToasts } from './useToasts'
+import type { AgentDef, NewSessionOptions, Session, ShellInfo } from './types'
 import type { TerminalEntry } from './useXterm'
 import { useSessions } from './useSessions'
 import { useSplitLayout } from './useSplitLayout'
@@ -34,6 +37,8 @@ export default function App() {
   const shellTermsRef = useRef(new Map<string, TerminalEntry>())
   const shellPendingDataRef = useRef(new Map<string, string[]>())
 
+  const { toasts, dismiss, reportError } = useToasts()
+
   const {
     sessions,
     statuses,
@@ -47,6 +52,7 @@ export default function App() {
     pendingDataRef,
     shellTermsRef,
     shellPendingDataRef,
+    reportError,
   })
 
   const { bottomHeight, mainContainerRef, handleDividerMouseDown } =
@@ -97,7 +103,7 @@ export default function App() {
         setActiveShellId(id)
       })
       .catch((err: unknown) => {
-        console.error('[termhub] listShells failed:', err)
+        reportError('Could not list shells', err)
       })
   }, [])
 
@@ -120,11 +126,16 @@ export default function App() {
     try {
       await window.termhub.setBottomShell(shellId)
     } catch (err) {
-      console.error('[termhub] setBottomShell failed:', err)
+      reportError('Could not switch shell', err)
     }
-  }, [])
+  }, [reportError])
 
   const [showUsage, setShowUsage] = useState(false)
+  // New-session dialog state. `newSessionCwd` seeds the folder field with
+  // the active session's directory (or $HOME), which is nearly always where
+  // the next session wants to start.
+  const [newSessionCwd, setNewSessionCwd] = useState<string | null>(null)
+  const [agents, setAgents] = useState<AgentDef[]>([])
   // Session id pending close confirmation, or null when no dialog is open.
   const [pendingCloseId, setPendingCloseId] = useState<string | null>(null)
 
@@ -218,6 +229,45 @@ export default function App() {
     return () => cancelAnimationFrame(raf)
   }, [activeId])
 
+  // Open the new-session dialog, seeding the folder from the active session
+  // and refreshing the agent list (agents can be added on disk at any time).
+  const openNewSession = useCallback(async () => {
+    const active = sessions.find((s) => s.id === activeId)
+    let cwd = active?.cwd
+    if (!cwd) {
+      try {
+        cwd = await window.termhub.home()
+      } catch (err) {
+        reportError('Could not resolve the home directory', err)
+        cwd = ''
+      }
+    }
+    try {
+      setAgents(await window.termhub.listAgents())
+    } catch (err) {
+      // Non-fatal: the dialog still works, the agent dropdown is just empty.
+      console.warn('[termhub] listAgents failed; agent picker will be empty', err)
+      setAgents([])
+    }
+    setNewSessionCwd(cwd ?? '')
+  }, [sessions, activeId, reportError])
+
+  const handleCreateSession = useCallback(
+    (opts: NewSessionOptions) => {
+      setNewSessionCwd(null)
+      void newSession(opts)
+    },
+    [newSession],
+  )
+
+  const handleOpenConfig = useCallback(async () => {
+    try {
+      await window.termhub.openConfigFile()
+    } catch (err) {
+      reportError('Could not open config.json', err)
+    }
+  }, [reportError])
+
   const grouped = useMemo(() => groupSessions(sessions), [sessions])
   const activeSession = useMemo(
     () => sessions.find((s) => s.id === activeId) ?? null,
@@ -226,13 +276,13 @@ export default function App() {
 
   return (
     <div className="app">
-      <TitleBar onOpenUsage={() => setShowUsage(true)} />
+      <TitleBar onOpenUsage={() => setShowUsage(true)} onOpenConfig={handleOpenConfig} />
       <div className="app-body" ref={appBodyRef}>
         <Sidebar
           groups={grouped}
           activeId={activeId}
           statuses={statuses}
-          onNew={newSession}
+          onNew={openNewSession}
           onSelect={setActiveId}
           onClose={requestClose}
           onRename={renameSession}
@@ -247,7 +297,7 @@ export default function App() {
           {sessions.length === 0 ? (
             <div className="empty">
               <p>No sessions yet.</p>
-              <button onClick={newSession}>+ New Session</button>
+              <button onClick={openNewSession}>+ New Session</button>
             </div>
           ) : (
             <>
@@ -304,6 +354,15 @@ export default function App() {
           onCancel={handleCancelClose}
         />
       )}
+      {newSessionCwd !== null && (
+        <NewSessionModal
+          initialCwd={newSessionCwd}
+          agents={agents}
+          onCreate={handleCreateSession}
+          onCancel={() => setNewSessionCwd(null)}
+        />
+      )}
+      <Toasts toasts={toasts} onDismiss={dismiss} />
     </div>
   )
 }

--- a/src/NewSessionModal.tsx
+++ b/src/NewSessionModal.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useRef, useState } from 'react'
+import { PERMISSION_MODES, type AgentDef, type NewSessionOptions } from './types'
+
+type Props = {
+  // Pre-resolved so the dialog opens with a sensible cwd already filled in.
+  initialCwd: string
+  agents: AgentDef[]
+  onCreate: (opts: NewSessionOptions) => void
+  onCancel: () => void
+}
+
+type CliChoice = 'shell' | 'claude' | 'codex' | 'gemini'
+
+// Only claude takes an agent / permission mode; codex and gemini ignore both
+// (see the open_session tool description). The dialog hides them rather than
+// offering settings that silently do nothing.
+const CLAUDE_ONLY: CliChoice[] = ['claude']
+
+export function NewSessionModal({ initialCwd, agents, onCreate, onCancel }: Props) {
+  const [cwd, setCwd] = useState(initialCwd)
+  const [cli, setCli] = useState<CliChoice>('claude')
+  const [model, setModel] = useState('')
+  const [agent, setAgent] = useState('')
+  const [permissionMode, setPermissionMode] = useState('')
+  const [name, setName] = useState('')
+  const [prompt, setPrompt] = useState('')
+
+  const overlayRef = useRef<HTMLDivElement>(null)
+  const cwdRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    cwdRef.current?.focus()
+  }, [])
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [onCancel])
+
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === overlayRef.current) onCancel()
+  }
+
+  const pickFolder = async () => {
+    const picked = await window.termhub.pickFolder()
+    if (picked) setCwd(picked)
+  }
+
+  const showClaudeOptions = CLAUDE_ONLY.includes(cli)
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const trimmedCwd = cwd.trim()
+    if (!trimmedCwd) return
+    onCreate({
+      cwd: trimmedCwd,
+      cli: cli === 'shell' ? undefined : cli,
+      model: model.trim() || undefined,
+      agent: showClaudeOptions ? agent.trim() || undefined : undefined,
+      permissionMode: showClaudeOptions ? permissionMode || undefined : undefined,
+      name: name.trim() || undefined,
+      prompt: cli === 'shell' ? undefined : prompt.trim() || undefined,
+    })
+  }
+
+  return (
+    <div ref={overlayRef} onClick={handleOverlayClick} className="modal-overlay">
+      <form
+        className="new-session-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="new-session-title"
+        onSubmit={submit}
+      >
+        <h2 id="new-session-title" className="new-session-title">New session</h2>
+
+        <label className="field">
+          <span className="field-label">Folder</span>
+          <div className="field-row">
+            <input
+              ref={cwdRef}
+              className="field-input"
+              value={cwd}
+              onChange={(e) => setCwd(e.target.value)}
+              placeholder="/path/to/repo"
+              spellCheck={false}
+            />
+            <button type="button" className="field-btn" onClick={pickFolder}>
+              Browse…
+            </button>
+          </div>
+        </label>
+
+        <label className="field">
+          <span className="field-label">Runtime</span>
+          <select
+            className="field-input"
+            value={cli}
+            onChange={(e) => setCli(e.target.value as CliChoice)}
+          >
+            <option value="claude">Claude Code</option>
+            <option value="codex">Codex CLI</option>
+            <option value="gemini">Gemini CLI</option>
+            <option value="shell">Plain shell</option>
+          </select>
+        </label>
+
+        {cli !== 'shell' && (
+          <label className="field">
+            <span className="field-label">Model</span>
+            <input
+              className="field-input"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              placeholder="leave blank for the default"
+              spellCheck={false}
+            />
+          </label>
+        )}
+
+        {showClaudeOptions && (
+          <>
+            <label className="field">
+              <span className="field-label">Agent</span>
+              <select
+                className="field-input"
+                value={agent}
+                onChange={(e) => setAgent(e.target.value)}
+              >
+                <option value="">(none)</option>
+                {agents.map((a) => (
+                  <option key={a.path} value={a.name}>
+                    {a.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="field">
+              <span className="field-label">Permission mode</span>
+              <select
+                className="field-input"
+                value={permissionMode}
+                onChange={(e) => setPermissionMode(e.target.value)}
+              >
+                <option value="">(default)</option>
+                {PERMISSION_MODES.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </>
+        )}
+
+        <label className="field">
+          <span className="field-label">Name</span>
+          <input
+            className="field-input"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="defaults to the folder name"
+          />
+        </label>
+
+        {cli !== 'shell' && (
+          <label className="field">
+            <span className="field-label">Initial prompt</span>
+            <textarea
+              className="field-input field-textarea"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="sent as the first message once the session boots"
+              rows={3}
+            />
+          </label>
+        )}
+
+        <div className="new-session-actions">
+          <button type="submit" className="field-btn field-btn-primary" disabled={!cwd.trim()}>
+            Create
+          </button>
+          <button type="button" className="field-btn" onClick={onCancel}>
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/TitleBar.tsx
+++ b/src/TitleBar.tsx
@@ -2,9 +2,10 @@ import { useEffect, useState } from 'react'
 
 type Props = {
   onOpenUsage: () => void
+  onOpenConfig: () => void
 }
 
-export function TitleBar({ onOpenUsage }: Props) {
+export function TitleBar({ onOpenUsage, onOpenConfig }: Props) {
   const [maximized, setMaximized] = useState(false)
 
   useEffect(() => {
@@ -24,6 +25,18 @@ export function TitleBar({ onOpenUsage }: Props) {
             <rect x="1" y="9" width="3" height="6" rx="1" />
             <rect x="6" y="5" width="3" height="10" rx="1" />
             <rect x="11" y="1" width="3" height="14" rx="1" />
+          </svg>
+        </button>
+        {/* Config button — termhub has no settings UI, so this opens
+            config.json (mcpPort, startupSessions) in the default editor. */}
+        <button
+          className="title-bar-icon-btn"
+          onClick={onOpenConfig}
+          title="Open config.json"
+        >
+          <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3">
+            <circle cx="8" cy="8" r="2.4" />
+            <path d="M8 1.2v2M8 12.8v2M14.8 8h-2M3.2 8h-2M12.8 3.2l-1.4 1.4M4.6 11.4l-1.4 1.4M12.8 12.8l-1.4-1.4M4.6 4.6L3.2 3.2" strokeLinecap="round" />
           </svg>
         </button>
         {/* Window controls */}

--- a/src/Toasts.tsx
+++ b/src/Toasts.tsx
@@ -1,0 +1,38 @@
+import type { Toast } from './toast-state'
+
+type Props = {
+  toasts: Toast[]
+  onDismiss: (id: number) => void
+}
+
+export function Toasts({ toasts, onDismiss }: Props) {
+  if (toasts.length === 0) return null
+
+  return (
+    <div className="toasts" role="region" aria-label="Notifications">
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          className={`toast toast-${t.kind}`}
+          role={t.kind === 'error' ? 'alert' : 'status'}
+        >
+          <div className="toast-body">
+            <span className="toast-message">{t.message}</span>
+            {t.detail && <span className="toast-detail">{t.detail}</span>}
+          </div>
+          <button
+            className="toast-dismiss"
+            onClick={() => onDismiss(t.id)}
+            title="Dismiss"
+            aria-label="Dismiss notification"
+          >
+            <svg width="10" height="10" viewBox="0 0 10 10" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round">
+              <line x1="1" y1="1" x2="9" y2="9" />
+              <line x1="9" y1="1" x2="1" y2="9" />
+            </svg>
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1136,3 +1136,194 @@ body,
   background: rgba(248, 81, 73, 0.28);
   border-color: #f85149;
 }
+
+/* ── New-session dialog ──────────────────────────────────────────────────
+   Shares the backdrop treatment with .confirm-close-overlay; kept as its
+   own class so the confirm dialog's tight max-width doesn't apply here. */
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  overflow-y: auto;
+}
+
+.new-session-dialog {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 20px 24px;
+  max-width: 460px;
+  width: 100%;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.new-session-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.field-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--text-dim);
+}
+
+.field-row {
+  display: flex;
+  gap: 6px;
+}
+
+.field-row .field-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.field-input {
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-size: 12px;
+  font-family: inherit;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.field-input:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.field-textarea {
+  resize: vertical;
+  font-family: inherit;
+  line-height: 1.4;
+}
+
+.field-btn {
+  background: var(--bg-elev);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.field-btn:hover:not(:disabled) {
+  background: var(--hover);
+  border-color: var(--accent);
+}
+
+.field-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.field-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.field-btn-primary {
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 55%, transparent);
+}
+
+.new-session-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
+/* ── Toasts ──────────────────────────────────────────────────────────────
+   Bottom-right stack. Errors persist until dismissed — a session can fail
+   while the user is in another app, and a toast that has already faded is
+   no better than the console line it replaced. */
+
+.toasts {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 1100;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 380px;
+  pointer-events: none;
+}
+
+.toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-left-width: 3px;
+  border-radius: 5px;
+  padding: 9px 10px 9px 11px;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.5);
+}
+
+.toast-error {
+  border-left-color: #f85149;
+}
+
+.toast-info {
+  border-left-color: var(--accent);
+}
+
+.toast-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.toast-message {
+  font-size: 12px;
+  color: var(--text);
+}
+
+.toast-detail {
+  font-size: 11px;
+  color: var(--text-dim);
+  word-break: break-word;
+}
+
+.toast-dismiss {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 2px;
+  line-height: 0;
+  flex-shrink: 0;
+}
+
+.toast-dismiss:hover {
+  color: var(--text);
+}

--- a/src/toast-state.test.ts
+++ b/src/toast-state.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import {
+  addToast,
+  dismissToast,
+  describeError,
+  autoDismissMs,
+  MAX_TOASTS,
+  type Toast,
+} from './toast-state'
+
+const t = (id: number, message = `m${id}`): Toast => ({ id, kind: 'error', message })
+
+describe('addToast', () => {
+  it('appends to the end', () => {
+    expect(addToast([t(1)], t(2)).map((x) => x.id)).toEqual([1, 2])
+  })
+
+  it('does not mutate the input', () => {
+    const initial = [t(1)]
+    addToast(initial, t(2))
+    expect(initial).toHaveLength(1)
+  })
+
+  it('drops the oldest past MAX_TOASTS so the stack cannot cover the app', () => {
+    let list: Toast[] = []
+    for (let i = 1; i <= MAX_TOASTS + 3; i++) list = addToast(list, t(i))
+
+    expect(list).toHaveLength(MAX_TOASTS)
+    // The three oldest were evicted; the newest is still last.
+    expect(list[0].id).toBe(4)
+    expect(list[list.length - 1].id).toBe(MAX_TOASTS + 3)
+  })
+})
+
+describe('dismissToast', () => {
+  it('removes only the matching id', () => {
+    expect(dismissToast([t(1), t(2), t(3)], 2).map((x) => x.id)).toEqual([1, 3])
+  })
+
+  it('is a no-op for an unknown id', () => {
+    expect(dismissToast([t(1)], 99).map((x) => x.id)).toEqual([1])
+  })
+
+  it('handles dismissing the same id twice', () => {
+    const once = dismissToast([t(1), t(2)], 1)
+    expect(dismissToast(once, 1).map((x) => x.id)).toEqual([2])
+  })
+})
+
+describe('describeError', () => {
+  it('uses the message of an Error', () => {
+    expect(describeError(new Error('boom'))).toBe('boom')
+  })
+
+  it('passes a string through', () => {
+    expect(describeError('plain failure')).toBe('plain failure')
+  })
+
+  it('serialises a plain object — IPC can reject with a non-Error', () => {
+    expect(describeError({ code: 'ENOENT' })).toBe('{"code":"ENOENT"}')
+  })
+
+  it('falls back to String() on a value JSON cannot handle', () => {
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+    expect(describeError(circular)).toBe('[object Object]')
+  })
+
+  it('handles null and undefined without throwing', () => {
+    expect(describeError(null)).toBe('null')
+    expect(describeError(undefined)).toBe(undefined as unknown as string)
+  })
+})
+
+describe('autoDismissMs', () => {
+  it('never auto-dismisses errors — the user may have been away', () => {
+    expect(autoDismissMs('error')).toBeNull()
+  })
+
+  it('auto-dismisses info toasts', () => {
+    expect(autoDismissMs('info')).toBeGreaterThan(0)
+  })
+})

--- a/src/toast-state.ts
+++ b/src/toast-state.ts
@@ -1,0 +1,53 @@
+// Toast state, kept as pure reducers so the queue behaviour is testable
+// without mounting React.
+//
+// Before this, ~30 catch sites in the renderer logged to console and nothing
+// else: a failed spawn, a failed PR merge, or a failed shell respawn simply
+// did nothing visible. The one exception was a raw alert() in newSession,
+// which blocks the whole window.
+
+export type ToastKind = 'error' | 'info'
+
+export type Toast = {
+  id: number
+  kind: ToastKind
+  message: string
+  // Optional second line — usually the underlying error text, kept separate
+  // so the headline stays scannable.
+  detail?: string
+}
+
+// Errors stack up when several sessions fail at once; past this we drop the
+// oldest so the stack can't cover the app.
+export const MAX_TOASTS = 4
+
+export function addToast(
+  current: readonly Toast[],
+  toast: Toast,
+): Toast[] {
+  const next = [...current, toast]
+  return next.length > MAX_TOASTS ? next.slice(next.length - MAX_TOASTS) : next
+}
+
+export function dismissToast(current: readonly Toast[], id: number): Toast[] {
+  return current.filter((t) => t.id !== id)
+}
+
+// Normalise whatever landed in a catch block into a displayable detail line.
+// Errors keep their message; everything else is stringified, since a rejected
+// IPC call can reject with a non-Error.
+export function describeError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  if (typeof err === 'string') return err
+  try {
+    return JSON.stringify(err)
+  } catch {
+    return String(err)
+  }
+}
+
+// Auto-dismiss delay. Errors linger — the user may have been away when the
+// session failed — while info messages clear quickly.
+export function autoDismissMs(kind: ToastKind): number | null {
+  return kind === 'error' ? null : 4000
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,32 @@ export type StartupSession = {
   cli?: 'claude' | 'codex' | 'gemini'
 }
 
+// What the renderer can ask for when spawning a session. Mirrors the fields
+// the MCP `open_session` tool accepts, so the new-session dialog and the
+// orchestrator have the same reach. Omit `cli` for a plain shell.
+export type NewSessionOptions = {
+  cwd: string
+  cli?: 'claude' | 'codex' | 'gemini'
+  model?: string
+  agent?: string
+  permissionMode?: string
+  prompt?: string
+  name?: string
+  dangerouslySkipPermissions?: boolean
+  allowDangerouslySkipPermissions?: boolean
+}
+
+// Permission modes accepted by `claude --permission-mode`. Kept here so the
+// dialog and any future validation share one list.
+export const PERMISSION_MODES = [
+  'default',
+  'acceptEdits',
+  'plan',
+  'bypassPermissions',
+  'dontAsk',
+  'auto',
+] as const
+
 export type Config = {
   mcpPort: number
   startupSessions: StartupSession[]
@@ -80,7 +106,7 @@ export type SessionUsage = {
 }
 
 export type TermhubApi = {
-  createSession: (cwd: string) => Promise<{ id: string; cwd: string }>
+  createSession: (opts: NewSessionOptions) => Promise<{ id: string; cwd: string }>
   sendInput: (id: string, data: string) => void
   resize: (id: string, cols: number, rows: number) => void
   close: (id: string) => void
@@ -96,6 +122,7 @@ export type TermhubApi = {
   home: () => Promise<string>
   getConfig: () => Promise<Config>
   configPath: () => Promise<string>
+  openConfigFile: () => Promise<void>
   readClipboard: () => Promise<string>
   writeClipboard: (text: string) => void
   onData: (cb: (id: string, data: string) => void) => () => void

--- a/src/useSessions.ts
+++ b/src/useSessions.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, type MutableRefObject } from 'react'
-import type { Session, SessionStatus } from './types'
+import type { NewSessionOptions, Session, SessionStatus } from './types'
 import type { TerminalEntry } from './useXterm'
 
 type SessionRefs = {
@@ -7,6 +7,9 @@ type SessionRefs = {
   pendingDataRef: MutableRefObject<Map<string, string[]>>
   shellTermsRef: MutableRefObject<Map<string, TerminalEntry>>
   shellPendingDataRef: MutableRefObject<Map<string, string[]>>
+  // Surfaces failures to the user. Injected rather than imported so this
+  // hook stays free of the toast implementation.
+  reportError: (message: string, err: unknown) => void
 }
 
 export type UseSessionsResult = {
@@ -16,7 +19,7 @@ export type UseSessionsResult = {
   setActiveId: (id: string | null | ((prev: string | null) => string | null)) => void
   closeSession: (id: string) => void
   renameSession: (id: string, name: string) => Promise<void>
-  newSession: () => Promise<void>
+  newSession: (opts: NewSessionOptions) => Promise<void>
 }
 
 // Owns the renderer-side session state and the IPC subscription wiring
@@ -28,7 +31,13 @@ export type UseSessionsResult = {
 // / onShellExit / onSessionAdded, then catches up via listSessions and
 // signals appReady so main can begin creating bootstrap sessions.
 export function useSessions(refs: SessionRefs): UseSessionsResult {
-  const { termsRef, pendingDataRef, shellTermsRef, shellPendingDataRef } = refs
+  const {
+    termsRef,
+    pendingDataRef,
+    shellTermsRef,
+    shellPendingDataRef,
+    reportError,
+  } = refs
 
   const [sessions, setSessions] = useState<Session[]>([])
   const [statuses, setStatuses] = useState<Record<string, SessionStatus>>({})
@@ -188,20 +197,26 @@ export function useSessions(refs: SessionRefs): UseSessionsResult {
     }
   }, [])
 
-  const newSession = useCallback(async () => {
-    try {
-      const cwd = await window.termhub.pickFolder()
-      if (!cwd) return
-      const s = await window.termhub.createSession(cwd)
-      setSessions((prev) => [...prev, s])
-      setActiveId(s.id)
-    } catch (err) {
-      console.error('[termhub] newSession failed:', err)
-      alert(
-        `Failed to create session:\n${err instanceof Error ? err.message : String(err)}`,
-      )
-    }
-  }, [])
+  // Options come from NewSessionModal; the folder picker now lives there
+  // rather than being the whole interaction.
+  const newSession = useCallback(
+    async (opts: NewSessionOptions) => {
+      try {
+        const created = await window.termhub.createSession(opts)
+        const session: Session = {
+          ...created,
+          name: opts.name,
+          cli: opts.cli,
+          command: opts.cli,
+        }
+        setSessions((prev) => [...prev, session])
+        setActiveId(created.id)
+      } catch (err) {
+        reportError('Failed to create session', err)
+      }
+    },
+    [reportError],
+  )
 
   return {
     sessions,

--- a/src/useToasts.ts
+++ b/src/useToasts.ts
@@ -1,0 +1,52 @@
+import { useCallback, useRef, useState } from 'react'
+import {
+  addToast,
+  autoDismissMs,
+  describeError,
+  dismissToast,
+  type Toast,
+  type ToastKind,
+} from './toast-state'
+
+export type ToastApi = {
+  toasts: Toast[]
+  dismiss: (id: number) => void
+  notify: (kind: ToastKind, message: string, detail?: string) => void
+  // Convenience for catch blocks: `reportError('Failed to create session', err)`.
+  reportError: (message: string, err: unknown) => void
+}
+
+export function useToasts(): ToastApi {
+  const [toasts, setToasts] = useState<Toast[]>([])
+  const nextId = useRef(1)
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((prev) => dismissToast(prev, id))
+  }, [])
+
+  const notify = useCallback(
+    (kind: ToastKind, message: string, detail?: string) => {
+      const id = nextId.current++
+      setToasts((prev) => addToast(prev, { id, kind, message, detail }))
+      const ms = autoDismissMs(kind)
+      if (ms !== null) {
+        setTimeout(() => {
+          setToasts((prev) => dismissToast(prev, id))
+        }, ms)
+      }
+    },
+    [],
+  )
+
+  const reportError = useCallback(
+    (message: string, err: unknown) => {
+      // Keep the console line too — it carries the stack, which the toast
+      // deliberately doesn't.
+      console.error(`[termhub] ${message}:`, err)
+      notify('error', message, describeError(err))
+    },
+    [notify],
+  )
+
+  return { toasts, dismiss, notify, reportError }
+}


### PR DESCRIPTION
Three related gaps on the human-facing side of the app.

## 1. The MCP path was strictly more capable than the UI path

`newSession()` picked a folder and spawned a **bare shell** — no cli, model, agent, permission mode, name, or initial prompt, all of which `open_session` has offered for months. The orchestrator could do things the user couldn't.

Adds `NewSessionModal` covering the same option set, and widens the `session:create` IPC to accept it (it previously took only a `cwd` and hardcoded a plain shell).

The dialog hides options the chosen runtime ignores — agent and permission mode are Claude-only; a plain shell takes neither a model nor a prompt. It also applies the same claude-model-with-codex guard the MCP path has, so that mistake produces a clear message instead of a confusing spawn failure.

## 2. Errors were invisible

~30 catch sites logged to console and nothing else: a failed spawn, failed shell switch, or failed config open simply did nothing. The one exception was a raw `alert()` in `newSession`, which blocks the whole window.

Adds `toast-state.ts` (pure reducers), `useToasts`, and a `Toasts` component. `reportError` still logs the stack to console *and* shows the message.

- **Errors don't auto-dismiss.** A session can fail while the user is in another app; a toast that already faded is no better than the console line it replaced.
- Info toasts clear after 4s.
- The stack is capped at 4 so it can't cover the app.

## 3. Settings were unreachable

`configPath()` was exposed over IPC but nothing in the renderer called it, so `mcpPort` and `startupSessions` were only reachable by hunting through userData. Adds a `config:open` IPC (`shell.openPath`) and a gear button in the title bar.

The contract was updated across `src/types.ts`, `preload.ts`, and the consumers together, per the CLAUDE.md rule.

## Verification

Rendered `NewSessionModal` and `Toasts` against a stubbed `window.termhub` in an isolated harness and confirmed:

- layout matches the app's existing purple accent theme
- **Claude Code** → all fields
- **Codex/Gemini** → model + prompt kept, agent + permission mode dropped
- **Plain shell** → model, agent, permission mode, and prompt all dropped

**Not run inside the real app** — its startup config spawns live claude sessions on the host.

13 new tests for the toast reducers (eviction past the cap, dismissal idempotence, non-`Error` and circular-reference handling in `describeError`). **324 total, green**; typecheck and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)