### PR TITLE
ci: publish a GitHub Release on v* tags; bump to 0.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,3 +101,76 @@ jobs:
           name: termhub-macos-zip
           path: release/*-mac.zip
           if-no-files-found: error
+
+  # Turns a v* tag into an actual downloadable release. Without this the
+  # installers only existed as workflow artifacts, which expire and require
+  # a GitHub login plus digging through Actions to reach.
+  release:
+    name: Publish GitHub Release
+    needs: [build-windows, build-macos]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Verify tag matches package.json version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(node -p "require('./package.json').version")
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Tag v$TAG does not match package.json version $PKG."
+            echo "Artifact filenames are derived from package.json, so a mismatch"
+            echo "would publish a release whose assets are named for another version."
+            exit 1
+          fi
+          echo "Tag and package.json agree on $PKG."
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -la artifacts
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat > notes.md <<'NOTES'
+          ## Downloads
+
+          | Platform | File |
+          | --- | --- |
+          | Windows (installer) | `*-setup.exe` |
+          | Windows (portable) | `*-portable.exe` |
+          | macOS (Apple silicon) | `*-arm64.dmg` |
+
+          ### macOS: first launch
+
+          These builds are **not signed with an Apple Developer ID and not
+          notarized**, so Gatekeeper will refuse the first launch. After
+          dragging TermHub to Applications, clear the quarantine flag:
+
+          ```bash
+          xattr -dr com.apple.quarantine /Applications/TermHub.app
+          ```
+
+          Only Apple silicon (arm64) macOS builds are produced.
+
+          ### Windows
+
+          The installer is unsigned, so SmartScreen shows a warning on first
+          run — choose "More info" then "Run anyway".
+          NOTES
+
+          gh release create "$GITHUB_REF_NAME" \
+            --title "TermHub $GITHUB_REF_NAME" \
+            --notes-file notes.md \
+            --generate-notes \
+            artifacts/*

--- a/electron/mcp-bridge.ts
+++ b/electron/mcp-bridge.ts
@@ -15,6 +15,7 @@ import { z } from 'zod'
 import { MCP_ROUTES } from './mcp-routes'
 import { MCP_TOKEN_HEADER } from './mcp-auth'
 import type { SessionSummary } from './mcp'
+import pkg from '../package.json'
 
 const port = Number.parseInt(process.env.TERMHUB_PORT ?? '7787', 10)
 const baseUrl = `http://127.0.0.1:${port}`
@@ -44,7 +45,10 @@ export function formatSession(s: SessionSummary): string {
 async function main() {
   const server = new McpServer({
     name: 'termhub',
-    version: '0.1.0',
+    // Read from package.json rather than a literal — esbuild inlines it at
+    // bundle time, and a hardcoded string here silently drifted from the
+    // real version.
+    version: pkg.version,
   })
 
   server.registerTool(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "termhub",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "A multi-session terminal manager",
   "license": "MIT",


### PR DESCRIPTION
## Problem

`build.yml` uploaded installers as **workflow artifacts** and stopped there. Artifacts expire, require a GitHub login, and mean digging through the Actions tab — so there was no practical way to install termhub short of building it yourself. `version` had also been pinned at `0.1.0` since the first commit.

## Changes

- **New `release` job**, gated on `refs/tags/v*`, `needs` both build jobs. Pulls their artifacts and publishes them on a GitHub Release via `gh release create` — no new third-party action.
- **Tag/version guard.** The job first checks the tag matches `package.json`. Artifact filenames are derived from `package.json`, so a mismatch would publish a release whose assets are named for a different version. Better to fail loudly.
- **Release notes carry the macOS Gatekeeper workaround** (`xattr -dr com.apple.quarantine`) and the Windows SmartScreen note.
- **0.1.0 → 0.2.0**, reflecting the MCP session tools, endpoint auth, attention signalling, and new-session dialog added since.
- **`mcp-bridge.ts`** read its version from a hardcoded `'0.1.0'` literal that had *already* drifted. Now imports `package.json` (esbuild inlines it).

## On macOS signing

I flagged the unsigned/un-notarized mac build in the review, and I've **left the signing config untouched**. Producing a properly signed build needs an Apple Developer ID — that's your decision and your certificate, not something to guess at in config, and changing it blind risks destabilising a mac build that currently works. The release notes document the workaround instead. Happy to wire up signing + notarization if you want to supply the credentials as repo secrets.

## Verification

- Workflow YAML parses; job graph is `build-windows`, `build-macos`, `release` with the intended `needs`/`if`/`permissions`.
- Tag check accepts `v0.2.0` and rejects `v9.9.9` against the current `package.json`.
- Built bridge reports `serverInfo: {name: termhub, version: 0.2.0}`.

**The release job cannot run on this PR** — it only fires on a tag. First real exercise will be the first `v0.2.0` tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)