### PR TITLE
docs: rewrite CLAUDE.md against the current tree, add README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,59 +1,102 @@
 # termhub
 
-termhub is a Windows desktop app for managing many concurrent terminal sessions — primarily Claude Code sessions doing parallel coding work. It exposes those sessions to a parent Claude via an MCP server, so an orchestrator agent can spawn, monitor, and steer sub-sessions as tools.
+termhub is a cross-platform (Windows + macOS) desktop app for managing many concurrent terminal sessions — primarily Claude Code sessions doing parallel coding work. It exposes those sessions to a parent Claude via an MCP server, so an orchestrator agent can spawn, monitor, and steer sub-sessions as tools.
 
-There is no README at the repo root; this file is the orientation doc.
+See `README.md` for install/run instructions. This file is the orientation doc for working *on* termhub.
 
 ## Stack
 
-- **Electron 33** desktop app, packaged via electron-builder (NSIS + portable, Windows x64).
-- **React 18** + **xterm.js** (`@xterm/xterm`, `@xterm/addon-fit`) renderer in `src/`.
-- **Vite 5** for the renderer; **esbuild** for the main + bridge bundles.
+- **Electron 39** desktop app (bundles Node 22), packaged via electron-builder — NSIS + portable for Windows x64, DMG + ZIP for macOS arm64.
+- **React 19** + **xterm.js** (`@xterm/xterm`, `@xterm/addon-fit`, `@xterm/addon-web-links`) renderer in `src/`.
+- **Vite 6** for the renderer; **esbuild** for the main + bridge bundles.
 - **@lydell/node-pty** for PTY handling (Windows-friendly fork — do NOT swap for upstream `node-pty`).
 - **@modelcontextprotocol/sdk** + **zod 4** for the MCP server.
-- **TypeScript 5.6**, two tsconfigs: `tsconfig.json` (renderer) and `tsconfig.electron.json` (main + bridge).
-- **Testing uses Vitest** (see "Testing" below). No linter or formatter is wired up — don't add one without being asked.
+- **TypeScript 5.6**, two tsconfigs: `tsconfig.json` (renderer) and `tsconfig.electron.json` (main + bridge). Both exclude `.claude`.
+- **Vitest 3** for tests (see "Testing"). No linter or formatter is wired up — don't add one without being asked.
+
+`@types/node` is pinned to **^22** deliberately: Electron 39 bundles Node 22.22.1, so typing against a newer major would describe APIs the runtime doesn't have. Dependabot will keep proposing 25; it should keep being declined until Electron's bundled Node moves.
 
 ## Layout
 
 ```
 electron/
-  main.ts          Electron main. Owns the PTY map, IPC, persistence, and starts the MCP HTTP server.
-  mcp.ts           Internal HTTP endpoint the bridge forwards tool calls to. NOT itself an MCP server.
-  mcp-bridge.ts    Standalone Node subprocess — the actual stdio MCP server claude connects to. Forwards to mcp.ts.
-  preload.ts       Defines the window.termhub API surface (renderer ↔ main IPC bridge).
+  main.ts            Bootstrap only: userData isolation, window creation, MCP
+                     stand-up + open_session queue, session bootstrap, IPC
+                     registration. Session logic lives in the modules below.
+  session-manager.ts The live PTY map and session lifecycle. createSession /
+                     closeSession / find / persist / status emission.
+  persistence.ts     sessions.json read/write (the resume format).
+  config.ts          userData path getters + config.json load/save.
+  status-watcher.ts  Watches Claude Code's ~/.claude/sessions/<pid>.json for
+                     ground-truth session status.
+  attention.ts       Notification + dock badge / taskbar flash decisions.
+  output-buffer.ts   Rolling 256 KB buffer + stripAnsi.
+  mcp.ts             Internal authenticated HTTP endpoint. NOT itself an MCP server.
+  mcp-bridge.ts      Standalone Node subprocess — the actual stdio MCP server
+                     claude connects to. Forwards to mcp.ts.
+  mcp-routes.ts      Route constants shared by the bridge and the HTTP server.
+  mcp-auth.ts        Shared-secret generation / constant-time compare.
+  preload.ts         Defines the window.termhub API surface.
+  ipc-session.ts     Session lifecycle IPC.
+  ipc-app.ts         Window controls, folder picker, clipboard, config open.
+  ipc-discovery.ts   Agent / skill discovery IPC.
+  ipc-pr.ts          Per-session PR tracking IPC.
+  ipc-usage.ts       Token usage IPC.
+  ipc-shell-picker.ts Bottom-shell selection IPC.
+  claude-command.ts / codex-command.ts / gemini-command.ts
+                     Per-runtime argv construction.
+  agents-skills.ts, pr-fetch.ts, usage-fetch.ts, repo-root.ts,
+  shell-detect.ts, cwd-resolve.ts, links.ts, opener.ts, pty-resize.ts
 src/
-  App.tsx          Root component. Owns sessions/active state.
-  Sidebar.tsx      Session list.
-  TerminalView.tsx xterm.js host for the active session.
-  RightPanel.tsx   Inspector sidebar (agents, MCPs, skills).
-  AgentList.tsx, McpList.tsx, SkillList.tsx, CollapsibleSection.tsx
-  types.ts         **The IPC contract** — TermhubApi, Session, Config, AgentDef, SkillDef.
-                   Must stay in sync across preload.ts, main.ts, and consumers.
-  main.tsx         React entry.
-index.html         Vite entry.
-vite.config.mts    Vite config.
+  App.tsx            Root component. Owns sessions/active state and modals.
+  useSessions.ts     Renderer session state + IPC subscriptions.
+  useXterm.ts        xterm instance lifecycle.
+  useToasts.ts / toast-state.ts / Toasts.tsx   User-visible error surface.
+  NewSessionModal.tsx  Session creation dialog (cli, model, agent, mode, prompt).
+  Sidebar.tsx, TerminalView.tsx, BottomTerminal.tsx, RightPanel.tsx,
+  TitleBar.tsx, UsageModal.tsx, ConfirmCloseModal.tsx, ShellPicker.tsx,
+  AgentList.tsx, McpList.tsx, SkillList.tsx, SessionPrPanel.tsx,
+  SessionUsagePanel.tsx, CollapsibleSection.tsx
+  types.ts           **The IPC contract** — TermhubApi, Session, Config,
+                     NewSessionOptions, AgentDef, SkillDef. Must stay in sync
+                     across preload.ts, main.ts, and consumers.
+  useSplitLayout.ts, useSidebarResize.ts, layout.ts, confirm-close.ts,
+  pr-utils.ts, xterm-utils.ts, main.tsx
 ```
 
 ## Architecture (three processes)
 
-1. **Main** (`electron/main.ts`) — owns PTYs, persists sessions, exposes IPC to renderer, runs the HTTP MCP endpoint on the configured port.
+1. **Main** (`electron/main.ts`) — owns PTYs, persists sessions, exposes IPC to renderer, runs the authenticated HTTP MCP endpoint on the configured port.
 2. **Renderer** (`src/`) — React UI, talks to main via `window.termhub.*` (preload-injected).
-3. **MCP bridge** (`electron/mcp-bridge.ts`) — separate Node subprocess spawned by claude as a stdio MCP server. Forwards tool calls over HTTP to main's `/internal/*` endpoints.
+3. **MCP bridge** (`electron/mcp-bridge.ts`) — separate Node subprocess spawned by claude as a stdio MCP server. Forwards tool calls over HTTP to main's `/internal/*` endpoints, authenticating with the token main writes into its env.
 
-When adding or modifying an MCP tool you will typically edit **all three**: the bridge (declare/route the tool), `electron/mcp.ts` (HTTP handler + types), and `electron/main.ts` (the actual implementation that touches PTY/session state).
+When adding or modifying an MCP tool you will typically edit **all three**: the bridge (declare/route the tool), `electron/mcp.ts` (HTTP handler + types), and `electron/main.ts` (the implementation that touches PTY/session state). Add the route constant to `electron/mcp-routes.ts`.
+
+### MCP tools
+
+| Tool | Purpose |
+| --- | --- |
+| `open_session` | Spawn a claude / codex / gemini session |
+| `send_input` | Write to a session's PTY |
+| `read_output` | Read the rolling output buffer |
+| `list_sessions` | Enumerate all sessions with status |
+| `get_session_status` | One session's advisory status |
+| `close_session` | Terminate a session |
+
+`get_session_status` reflects Claude Code's own JSONL status and is only meaningful for `cli: 'claude'` sessions — codex and gemini report `working` until exit.
 
 ## Commands
 
 - `npm run dev` — concurrently runs Vite (port 5173) and Electron with HMR. **The dev loop.**
-- `npm run typecheck` — runs both tsconfigs (`tsc --noEmit && tsc --noEmit -p tsconfig.electron.json`). Run this before declaring any change done.
+- `npm test` — Vitest. Run this before declaring any change done.
+- `npm run typecheck` — both tsconfigs. Run this before declaring any change done.
 - `npm run build` — builds main, bridge, and renderer into `dist/`.
-- `npm run dist:win` — packages NSIS + portable Windows installers.
+- `npm run dist:win` / `npm run dist:mac` — packages installers.
 - `npm start` — full build + run packaged.
 
 ## Testing
 
-Termhub uses **Vitest** for unit tests. Tests are colocated next to the source file as `*.test.ts` or `*.test.tsx`, and run with `npm test` (which executes `vitest run`).
+Tests are colocated as `*.test.ts` next to the source file and run with `npm test`. **26 test files, 361 tests** at time of writing; CI gates every PR on them.
 
 **Work must include tests** at a reasonable level of coverage:
 
@@ -61,62 +104,53 @@ Termhub uses **Vitest** for unit tests. Tests are colocated next to the source f
 - **Bug fixes** ship with a regression test that fails without the fix and passes with it.
 - **Refactors** preserve the existing test surface — update tests to match the new shape rather than deleting them.
 
-**Mid-adoption caveat**: termhub is in the middle of adopting Vitest. Depending on which branch you're on, Vitest may not yet be installed. Check `package.json` first. If absent, bootstrap it as part of your work:
+Do NOT add other test tools (Jest, Mocha, @testing-library, Playwright) without being asked.
 
-```bash
-npm i -D vitest
-# add "test": "vitest run" to scripts
-```
+Three constraints worth knowing before you write a test:
 
-Keep the bootstrap minimal — a proper harness/config PR can follow. Do NOT add other test tools (Jest, Mocha, @testing-library, Playwright) without being asked.
+- **`vite.config.mts` excludes `**/.claude/**`.** Orchestrator subagents leave full source copies under `.claude/worktrees/<branch>/`; without the exclude, vitest runs every worktree's copy of the suite alongside the real one. Don't remove it.
+- **ESM can't spy on module exports** (`vi.spyOn(fs, 'writeFileSync')` throws "Module namespace is not configurable"). Provoke real errors instead — e.g. `persistence.test.ts` puts a regular file where a directory is expected to force `ENOTDIR`. Where a module must be replaced, use `vi.mock` with a factory; `tsconfig.electron.json` is `module: CommonJS`, so **top-level `await import()` won't compile** — use a static import and let `vi.mock` hoist above it.
+- **Anything binding a port must bind `0`** and read the assigned port back off the socket. Fixed ports collide with a running dev instance and with parallel test files.
 
 ## Logging
 
-Logging added is part of the feature — it **ships into `main` and stays there**. It should answer "what is this code doing right now?" for an operator (future you, six months from now) without a debugger attached. **Throwaway `console.log` added to chase a current bug is *not* this kind of logging — strip those before opening the PR.**
+Logging added is part of the feature — it **ships into `main` and stays there**. It should answer "what is this code doing right now?" for an operator without a debugger attached. **Throwaway `console.log` added to chase a current bug is *not* this kind of logging — strip those before opening the PR.**
 
-What good logging looks like:
+- **Use levels.** `console.error` for failures, `console.warn` for recoverable surprises, `console.info` / `console.log` for state changes worth knowing, `console.debug` for finer traces.
+- **Log at boundaries, not in loops.** IPC handler entry, PTY spawn / exit, MCP request, session lifecycle events. Not per-render or per-keystroke.
+- **Lines must be self-contained.** Include the session id, operation, relevant state.
+- **Errors include cause.** `console.error('paste failed', err)` — pass the actual `Error`, not just a string.
+- **Never log**: clipboard contents, full PTY output buffers, full input prompts, the MCP token, anything that could leak credentials.
 
-- **Use levels.** `console.error` for failures, `console.warn` for recoverable surprises, `console.info` / `console.log` for state changes worth knowing, `console.debug` for finer traces. Don't ship everything at the same level.
-- **Log at boundaries, not in loops.** IPC handler entry, PTY spawn / exit, MCP request, session lifecycle events. Not inside per-render or per-keystroke paths.
-- **Lines must be self-contained.** Include the session id, operation, relevant state. A reader shouldn't have to grep surrounding context to make sense of a single line.
-- **Errors include cause.** `console.error('paste failed', err)` — pass the actual `Error`, not just a string. The stack matters.
-- **No throwaway noise.** "Here", "got x", "starting", "done" without context don't pass the bar. If you wouldn't want to read this six months from now, don't ship it.
-- **Never log**: clipboard contents, full PTY output buffers, full input prompts, anything that could leak credentials.
+**Format**: no logger framework. Use `console.*` with a component prefix like `[termhub:mcp]` (see `electron/mcp.ts`). Don't introduce a logger library.
 
-**Format**: termhub has no logger framework. Use `console.*` with a component prefix like `[termhub:mcp]` (see `electron/mcp.ts` for the established pattern). Pick a prefix that identifies your component (e.g. `[termhub:session]`, `[termhub:status]`). Don't introduce a logger library.
-
-## Conventions
-
-- 2-space indent, single quotes, **no semicolons** (match existing source).
-- Imports: relative for local, bare for npm.
-- Filenames: PascalCase for React components, lowercase for non-component TS.
-- React: function components + hooks only.
-- Output buffer in main is capped at 256 KB rolling — don't change without thinking through the `read_output` contract.
+User-facing failures in the renderer go through `reportError` from `useToasts` — it logs the stack to console *and* shows the user a toast. A bare `console.error` in the renderer means the user sees nothing.
 
 ## Hot / sensitive areas
 
 - **@lydell/node-pty native binding.** Listed in electron-builder's `asarUnpack`. Repackaging or version bumps need installer testing.
 - **The TermhubApi contract in `src/types.ts`.** Drift between preload, main, and renderer manifests as silent IPC failures. Update all three together.
-- **`stripAnsi` in `electron/main.ts`.** Lossy by design — heavy TUI redraws (claude's input box) don't reconstruct perfectly. Don't try to make it perfect; just don't regress on plain text.
-- **MCP wire shape.** Bridge and HTTP server in `mcp.ts` must agree on schemas. zod schemas are the source of truth.
-- **Session persistence** lives in `main.ts`. Format changes need a migration path or a reset.
-
-## Likely tasks
-
-- MCP tool additions or refinements (open_session, read_output, send_input, …) — touches bridge + mcp.ts + main.ts.
-- UI work in `src/` (sidebar, terminal view, inspector panels).
-- Session lifecycle features (persistence, restoration, naming, model picker).
-- Packaging / installer tweaks.
+- **`stripAnsi` in `electron/output-buffer.ts`.** Lossy by design — heavy TUI redraws (claude's input box) don't reconstruct perfectly. Don't try to make it perfect; just don't regress on plain text.
+- **MCP wire shape.** Bridge and HTTP server must agree on schemas and routes. zod schemas are the source of truth.
+- **Session persistence** in `persistence.ts`. Format changes need a migration path or a reset; the loader tolerates partial entries on purpose.
+- **The paste path** (`useXterm.ts`, `claude-command.ts`). Has a long history of double-paste / dropped-input regressions. Change carefully and test by hand.
+- **The MCP token.** `mcp-config.json` and `userData/mcp-token` are `0600` because they carry it. Don't widen those, don't log it.
 
 ## Branch discipline
 
-**Do not create a new branch or worktree until your current PR has been confirmed merged.** Pushing your branch and opening a PR doesn't end your responsibility for that branch — it's yours until it lands on `main`. Anything that follows up on the same change (CI failures, review feedback, extra commits the user asks for) goes to the **same branch** as new commits. Only after the PR is merged (visible on `main`, branch deleted) should you start a new branch / worktree.
+**Do not create a new branch or worktree until your current PR has been confirmed merged.** Pushing your branch and opening a PR doesn't end your responsibility for it — it's yours until it lands on `main`. Follow-ups on the same change (CI failures, review feedback, extra commits) go to the **same branch** as new commits. Only after the PR is merged should you start a new branch / worktree.
 
 If the user redirects you to different work before the PR merges, **ask** — they may want fresh commits on the same branch rather than a new one.
+
+## Releases
+
+Tagging `v<version>` triggers the `release` job in `.github/workflows/build.yml`, which publishes the Windows and macOS artifacts to a GitHub Release. **The tag must match `package.json`'s version** — the job fails loudly otherwise, because artifact filenames are derived from it. Bump `package.json` first, merge, then tag.
+
+Builds are unsigned and un-notarized; the generated release notes carry the Gatekeeper / SmartScreen workarounds.
 
 ## Working norms
 
 - Never commit unless explicitly asked.
 - Tests are required — see "Testing". Don't add other test tools, linters, or formatters unless asked.
 - When in doubt about how to wire something across processes, read `src/types.ts` first. It is the contract.
-- Run `npm run typecheck` before reporting work complete.
+- Run `npm run typecheck` and `npm test` before reporting work complete.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,116 @@
+# termhub
+
+A desktop app for running many terminal sessions side by side — built for driving a fleet of [Claude Code](https://claude.com/claude-code) sessions doing parallel work.
+
+Every session is also exposed to a parent Claude over MCP, so an orchestrator agent can spawn workers, watch their status, steer them, and reap them as ordinary tool calls.
+
+> Personal project, developed in the open. Windows x64 and macOS (Apple silicon).
+
+## What it does
+
+- **Many sessions, one window.** A sidebar of live sessions grouped by repo, each with its own terminal and a docked shell underneath for your own manual work.
+- **Status at a glance.** Sessions are marked *working*, *awaiting you*, *idle*, or *failed*, read from Claude Code's own session file rather than guessed from terminal output.
+- **Tells you when it needs you.** A session that blocks on a permission prompt raises an OS notification and a dock badge / taskbar flash. Clicking through takes you straight to that session.
+- **Orchestration over MCP.** A parent Claude can `open_session`, `send_input`, `read_output`, `list_sessions`, `get_session_status`, and `close_session`.
+- **Multiple runtimes.** Claude Code, the OpenAI Codex CLI, the Gemini CLI, or a plain shell.
+- **PR and token tracking.** Per-session branch/PR state with CI status, plus context-window and cumulative token usage read from session transcripts.
+
+## Install
+
+Grab the latest build from [Releases](../../releases).
+
+| Platform | File |
+| --- | --- |
+| Windows | `TermHub-<version>-x64-setup.exe`, or `-portable.exe` for no-install |
+| macOS (Apple silicon) | `TermHub-<version>-arm64.dmg` |
+
+### macOS: first launch
+
+Builds are **not signed with an Apple Developer ID and not notarized**, so Gatekeeper refuses the first launch. After dragging TermHub to Applications:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/TermHub.app
+```
+
+### Windows
+
+The installer is unsigned, so SmartScreen warns on first run — choose **More info** → **Run anyway**.
+
+## Build from source
+
+Requires Node 22 (matching the Node that Electron 39 bundles).
+
+```bash
+npm install
+npm run dev
+```
+
+Other scripts:
+
+| Command | What it does |
+| --- | --- |
+| `npm run dev` | Vite on :5173 + Electron with HMR — the dev loop |
+| `npm test` | Vitest |
+| `npm run typecheck` | Both tsconfigs (renderer + electron) |
+| `npm run build` | Bundles main, bridge, and renderer into `dist/` |
+| `npm run dist:win` / `npm run dist:mac` | Packages installers into `release/` |
+
+## Configuration
+
+Settings live in `config.json` under Electron's userData directory. The gear icon in the title bar opens it in your default editor; there's no settings UI yet.
+
+| Path | |
+| --- | --- |
+| Windows | `%APPDATA%\termhub\config.json` |
+| macOS | `~/Library/Application Support/termhub/config.json` |
+
+```jsonc
+{
+  // Port for the internal MCP endpoint. Dev builds use 7788 so they can run
+  // alongside a packaged instance on 7787.
+  "mcpPort": 7787,
+
+  // Sessions spawned at startup.
+  "startupSessions": [
+    {
+      "cwd": "/Users/you",
+      "command": "claude",
+      "agent": "orchestrator",
+      "permissionMode": "bypassPermissions",
+      "name": "orchestrator"
+    }
+  ]
+}
+```
+
+Dev builds keep their own userData directory (`termhub-dev`), so running `npm run dev` won't disturb an installed copy's sessions or config.
+
+Alongside `config.json`, termhub writes:
+
+- `sessions.json` — session metadata for resume-on-restart
+- `mcp-config.json` — the MCP server definition for claude to load (`0600`)
+- `mcp-token` — shared secret for the internal endpoint (`0600`)
+
+## Connecting the MCP server
+
+termhub writes an MCP server definition to `mcp-config.json` in its userData directory on every launch. Point claude at it:
+
+```bash
+claude --mcp-config "$HOME/Library/Application Support/termhub/mcp-config.json"
+```
+
+The internal HTTP endpoint binds `127.0.0.1` **and** requires a shared secret, which termhub places in the bridge's environment. Other local processes can't spawn sessions through it.
+
+## Architecture
+
+Three processes:
+
+- **Main** — owns the PTYs, persists sessions, serves the authenticated internal HTTP endpoint.
+- **Renderer** — React + xterm.js, talks to main through a preload-injected `window.termhub`.
+- **MCP bridge** — a standalone Node subprocess that claude spawns as a stdio MCP server; forwards tool calls to main over HTTP.
+
+`src/types.ts` is the contract between all three. See [CLAUDE.md](CLAUDE.md) for the full developer orientation.
+
+## License
+
+MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
## Why this matters more than it looks

`CLAUDE.md` is loaded into context at the start of **every** agent session, so its inaccuracies compound into every future piece of work. What it claimed vs. reality:

| Claim | Reality |
| --- | --- |
| "a Windows desktop app" | macOS support landed in #66/#67 |
| Electron 33, React 18, Vite 5 | Electron **39.8.9**, React **19**, Vite **6.4** |
| "Vitest may not yet be installed — bootstrap it as part of your work" | 26 test files, 361 tests, CI gates on them |
| `main.ts` owns "the PTY map, IPC, persistence" | moved to `session-manager.ts` / `ipc-*.ts` / `persistence.ts` in #42/#43; `main.ts` has been ~350 lines of bootstrap since |
| `stripAnsi` is in `main.ts` | it's in `output-buffer.ts` |
| "There is no README at the repo root" | there is now |

An agent reading the old file would have tried to `npm i -D vitest` into a repo that already has it, and gone looking for the PTY map in the wrong file.

## CLAUDE.md

Rewritten against the actual tree: full `electron/` and `src/` module map, the six MCP tools, the release process, and **three testing constraints that have each already cost time**:

- the `**/.claude/**` vitest exclude (and why removing it breaks the suite)
- ESM's refusal to spy on module exports, plus the CommonJS ban on top-level `await import()`
- ephemeral port binding for anything that listens

It also records *why* `@types/node` is pinned to `^22`, so the next person doesn't "fix" it.

## README

What the app does, install (with the Gatekeeper and SmartScreen workarounds), build-from-source, `config.json` with real per-platform paths, and how to point claude at the MCP server.

## Verified, not assumed

- userData paths checked against the directories that actually exist on disk (`~/Library/Application Support/termhub` and `termhub-dev`)
- artifact filenames derived from the electron-builder `artifactName` templates in `package.json`
- `claude --mcp-config` confirmed against `claude --help`
- Electron's bundled Node (22.22.1) confirmed via `process.versions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)