### PR TITLE
feat: anchor termhub to a projects folder and list them in the sidebar

### DIFF
--- a/electron/ipc-app.ts
+++ b/electron/ipc-app.ts
@@ -12,7 +12,8 @@ import { spawn } from 'node:child_process'
 import type { Config } from '../src/types'
 import { isAllowedExternalUrl } from './links'
 import { openExternalUrl } from './opener'
-import { getConfigPath } from './config'
+import { getConfigPath, saveConfig } from './config'
+import { discoverProjects } from './project-discovery'
 
 let mainWindow: BrowserWindow | null = null
 
@@ -21,6 +22,30 @@ export function setMainWindow(window: BrowserWindow | null): void {
 }
 
 export function registerAppHandlers(opts: { config: Config }): void {
+  // The anchored repos directory. Held on the live config object so a change
+  // takes effect without a restart; persisted so it survives one.
+  ipcMain.handle('projects:getReposDir', () => opts.config.reposDir ?? null)
+
+  ipcMain.handle('projects:list', () => {
+    if (!opts.config.reposDir) return []
+    return discoverProjects(opts.config.reposDir)
+  })
+
+  ipcMain.handle('projects:setReposDir', async () => {
+    if (!mainWindow) return null
+    const result = await dialog.showOpenDialog(mainWindow, {
+      title: 'Choose the folder that holds your projects',
+      defaultPath: opts.config.reposDir ?? os.homedir(),
+      properties: ['openDirectory'],
+    })
+    if (result.canceled || result.filePaths.length === 0) return null
+    const picked = result.filePaths[0]
+    opts.config.reposDir = picked
+    saveConfig(opts.config)
+    console.log(`[termhub:projects] repos directory set to ${picked}`)
+    return picked
+  })
+
   ipcMain.handle('vscode:open', (_event, cwd: string) => {
     return new Promise<void>((resolve, reject) => {
       const proc = spawn('code', [cwd], {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -3,6 +3,7 @@ import type {
   AgentDef,
   Config,
   NewSessionOptions,
+  ProjectDef,
   SessionPr,
   SessionStatus,
   SessionUsage,
@@ -75,6 +76,11 @@ const api = {
 
   configPath: (): Promise<string> => ipcRenderer.invoke('config:path'),
   openConfigFile: (): Promise<void> => ipcRenderer.invoke('config:open'),
+  listProjects: (): Promise<ProjectDef[]> => ipcRenderer.invoke('projects:list'),
+  getReposDir: (): Promise<string | null> =>
+    ipcRenderer.invoke('projects:getReposDir'),
+  setReposDir: (): Promise<string | null> =>
+    ipcRenderer.invoke('projects:setReposDir'),
 
   readClipboard: (): Promise<string> => ipcRenderer.invoke('clipboard:read'),
 

--- a/electron/project-discovery.test.ts
+++ b/electron/project-discovery.test.ts
@@ -1,0 +1,137 @@
+// The rule that matters here is "stop descending at a repo root". Orchestrator
+// subagents create real checkouts under <repo>/.claude/worktrees/<branch>/, each
+// with its own .git — a naive recursive scan finds 18 of them in one real
+// ~/Repos and lists every one as a separate project.
+
+import { describe, it, expect, afterEach } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { discoverProjects } from './project-discovery'
+
+const temps: string[] = []
+
+function tempDir(): string {
+  const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'termhub-proj-')))
+  temps.push(dir)
+  return dir
+}
+
+// Creates <root>/<rel> and marks it a repo with a .git directory.
+function makeRepo(root: string, rel: string): string {
+  const dir = path.join(root, rel)
+  fs.mkdirSync(path.join(dir, '.git'), { recursive: true })
+  return dir
+}
+
+function makeDir(root: string, rel: string): string {
+  const dir = path.join(root, rel)
+  fs.mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+afterEach(() => {
+  while (temps.length) fs.rmSync(temps.pop()!, { recursive: true, force: true })
+})
+
+describe('discoverProjects', () => {
+  it('finds immediate child repos', () => {
+    const anchor = tempDir()
+    makeRepo(anchor, 'alpha')
+    makeRepo(anchor, 'beta')
+
+    expect(discoverProjects(anchor).map((p) => p.label)).toEqual(['alpha', 'beta'])
+  })
+
+  it('returns absolute paths that match Session.repoRoot', () => {
+    const anchor = tempDir()
+    const repo = makeRepo(anchor, 'alpha')
+
+    expect(discoverProjects(anchor)[0].path).toBe(repo)
+  })
+
+  it('finds repos nested one level under a grouping folder', () => {
+    const anchor = tempDir()
+    makeRepo(anchor, 'work/service-a')
+    makeRepo(anchor, 'personal/toy')
+
+    expect(discoverProjects(anchor).map((p) => p.label)).toEqual(['service-a', 'toy'])
+  })
+
+  it('does NOT descend into a repo — worktrees are not separate projects', () => {
+    const anchor = tempDir()
+    const repo = makeRepo(anchor, 'termhub')
+    // Mirrors the real layout an orchestrator subagent leaves behind.
+    fs.mkdirSync(path.join(repo, '.claude', 'worktrees', 'feature-x', '.git'), {
+      recursive: true,
+    })
+    fs.mkdirSync(path.join(repo, '.claude', 'worktrees', 'feature-y', '.git'), {
+      recursive: true,
+    })
+
+    const found = discoverProjects(anchor)
+    expect(found.map((p) => p.label)).toEqual(['termhub'])
+  })
+
+  it('does not treat a vendored checkout inside a repo as a project', () => {
+    const anchor = tempDir()
+    const repo = makeRepo(anchor, 'app')
+    fs.mkdirSync(path.join(repo, 'vendor', 'lib', '.git'), { recursive: true })
+
+    expect(discoverProjects(anchor).map((p) => p.label)).toEqual(['app'])
+  })
+
+  it('skips node_modules and dot-directories', () => {
+    const anchor = tempDir()
+    makeRepo(anchor, 'real')
+    fs.mkdirSync(path.join(anchor, 'node_modules', 'pkg', '.git'), { recursive: true })
+    fs.mkdirSync(path.join(anchor, '.cache', 'thing', '.git'), { recursive: true })
+
+    expect(discoverProjects(anchor).map((p) => p.label)).toEqual(['real'])
+  })
+
+  it('recognises a .git file (worktree pointer) as a repo root', () => {
+    const anchor = tempDir()
+    const dir = makeDir(anchor, 'linked')
+    fs.writeFileSync(path.join(dir, '.git'), 'gitdir: /elsewhere/.git/worktrees/x\n')
+
+    expect(discoverProjects(anchor).map((p) => p.label)).toEqual(['linked'])
+  })
+
+  it('ignores plain directories that are not repos', () => {
+    const anchor = tempDir()
+    makeRepo(anchor, 'repo')
+    makeDir(anchor, 'just-notes')
+
+    expect(discoverProjects(anchor).map((p) => p.label)).toEqual(['repo'])
+  })
+
+  it('respects maxDepth', () => {
+    const anchor = tempDir()
+    makeRepo(anchor, 'a/b/deep')
+
+    expect(discoverProjects(anchor, 2)).toEqual([])
+    expect(discoverProjects(anchor, 3).map((p) => p.label)).toEqual(['deep'])
+  })
+
+  it('sorts by label', () => {
+    const anchor = tempDir()
+    makeRepo(anchor, 'zulu')
+    makeRepo(anchor, 'alpha')
+    makeRepo(anchor, 'mike')
+
+    expect(discoverProjects(anchor).map((p) => p.label)).toEqual([
+      'alpha',
+      'mike',
+      'zulu',
+    ])
+  })
+
+  it('returns [] for a missing anchor rather than throwing', () => {
+    expect(discoverProjects(path.join(tempDir(), 'does-not-exist'))).toEqual([])
+  })
+
+  it('returns [] for an empty anchor', () => {
+    expect(discoverProjects(tempDir())).toEqual([])
+  })
+})

--- a/electron/project-discovery.ts
+++ b/electron/project-discovery.ts
@@ -1,0 +1,81 @@
+// Finds the projects under the user's anchored "repos" directory so the
+// sidebar can list everything they work on, not just what happens to have a
+// live session.
+//
+// The walk stops descending as soon as it finds a repo. That single rule is
+// what keeps git worktrees out: orchestrator subagents create real checkouts
+// under <repo>/.claude/worktrees/<branch>/, each with its own .git, and a
+// naive recursive scan lists all of them as separate projects (18 of them in
+// one real ~/Repos). A worktree belongs to its parent repo, not beside it.
+
+import * as path from 'node:path'
+import * as fs from 'node:fs'
+
+export type ProjectDef = {
+  // Absolute path to the repo root. Matches Session.repoRoot, which is how
+  // the sidebar merges live sessions into their project group.
+  path: string
+  label: string
+}
+
+// Anchor's immediate children are depth 1. The default allows one level of
+// grouping (~/Repos/work/foo) without turning into a full-tree crawl.
+export const DEFAULT_MAX_DEPTH = 2
+
+// Never descend into these. node_modules is the expensive one; dot-directories
+// cover .claude/worktrees along with every other tool's scratch space.
+function isSkippable(name: string): boolean {
+  return name === 'node_modules' || name.startsWith('.')
+}
+
+function isRepo(dir: string): boolean {
+  try {
+    // .git is a directory in a normal checkout and a file in a worktree.
+    // Either marks a repo root.
+    fs.statSync(path.join(dir, '.git'))
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function discoverProjects(
+  anchorDir: string,
+  maxDepth: number = DEFAULT_MAX_DEPTH,
+): ProjectDef[] {
+  const found: ProjectDef[] = []
+
+  function walk(dir: string, depth: number): void {
+    if (depth > maxDepth) return
+    let entries: fs.Dirent[]
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch (err) {
+      // Unreadable directory (permissions, unmounted volume) — skip it rather
+      // than failing the whole scan.
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        console.warn(`[termhub:projects] could not read ${dir}:`, err)
+      }
+      return
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory() || isSkippable(entry.name)) continue
+      const child = path.join(dir, entry.name)
+      if (isRepo(child)) {
+        found.push({ path: child, label: entry.name })
+        // Do NOT descend — nested checkouts under a repo are its worktrees
+        // or vendored copies, not sibling projects.
+        continue
+      }
+      walk(child, depth + 1)
+    }
+  }
+
+  walk(anchorDir, 1)
+  found.sort((a, b) => a.label.localeCompare(b.label))
+  console.log(
+    `[termhub:projects] discovered ${found.length} project(s) under ${anchorDir}`,
+  )
+  return found
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,13 @@ import { ConfirmCloseModal } from './ConfirmCloseModal'
 import { NewSessionModal } from './NewSessionModal'
 import { Toasts } from './Toasts'
 import { useToasts } from './useToasts'
-import type { AgentDef, NewSessionOptions, Session, ShellInfo } from './types'
+import type {
+  AgentDef,
+  NewSessionOptions,
+  ProjectDef,
+  ShellInfo,
+} from './types'
+import { buildSidebarGroups } from './sidebar-groups'
 import type { TerminalEntry } from './useXterm'
 import { useSessions } from './useSessions'
 import { useSplitLayout } from './useSplitLayout'
@@ -136,6 +142,10 @@ export default function App() {
   // the next session wants to start.
   const [newSessionCwd, setNewSessionCwd] = useState<string | null>(null)
   const [agents, setAgents] = useState<AgentDef[]>([])
+  // Projects discovered under the anchored repos directory. These populate the
+  // sidebar even when they have no live session.
+  const [projects, setProjects] = useState<ProjectDef[]>([])
+  const [reposDir, setReposDir] = useState<string | null>(null)
   // Session id pending close confirmation, or null when no dialog is open.
   const [pendingCloseId, setPendingCloseId] = useState<string | null>(null)
 
@@ -268,7 +278,53 @@ export default function App() {
     }
   }, [reportError])
 
-  const grouped = useMemo(() => groupSessions(sessions), [sessions])
+  // Refresh the project list. Cheap enough to re-run on demand; the walk stops
+  // at each repo root so it doesn't crawl whole trees.
+  const refreshProjects = useCallback(async () => {
+    try {
+      const [dir, found] = await Promise.all([
+        window.termhub.getReposDir(),
+        window.termhub.listProjects(),
+      ])
+      setReposDir(dir)
+      setProjects(found)
+    } catch (err) {
+      reportError('Could not list projects', err)
+    }
+  }, [reportError])
+
+  useEffect(() => {
+    void refreshProjects()
+  }, [refreshProjects])
+
+  const handleChooseReposDir = useCallback(async () => {
+    try {
+      const picked = await window.termhub.setReposDir()
+      if (picked) await refreshProjects()
+    } catch (err) {
+      reportError('Could not set the projects folder', err)
+    }
+  }, [refreshProjects, reportError])
+
+  // Start a session in a specific project: same dialog as + New Session, with
+  // the folder already filled in.
+  const handleNewInProject = useCallback(
+    async (cwd: string) => {
+      try {
+        setAgents(await window.termhub.listAgents())
+      } catch (err) {
+        console.warn('[termhub] listAgents failed; agent picker will be empty', err)
+        setAgents([])
+      }
+      setNewSessionCwd(cwd)
+    },
+    [],
+  )
+
+  const grouped = useMemo(
+    () => buildSidebarGroups(projects, sessions),
+    [projects, sessions],
+  )
   const activeSession = useMemo(
     () => sessions.find((s) => s.id === activeId) ?? null,
     [sessions, activeId],
@@ -283,7 +339,10 @@ export default function App() {
           activeId={activeId}
           statuses={statuses}
           onNew={openNewSession}
+          onNewInProject={handleNewInProject}
           onSelect={setActiveId}
+          reposDir={reposDir}
+          onChooseReposDir={handleChooseReposDir}
           onClose={requestClose}
           onRename={renameSession}
           style={{ width: leftCollapsed ? SIDEBAR_COLLAPSED_WIDTH : leftWidth }}
@@ -371,13 +430,4 @@ export default function App() {
 // map key is the group key (repoRoot or cwd); Sidebar reads the label
 // from the first session in the group via session.repoLabel or derives
 // it from the cwd.
-function groupSessions(sessions: Session[]): Map<string, Session[]> {
-  const m = new Map<string, Session[]>()
-  for (const s of sessions) {
-    const key = s.repoRoot ?? s.cwd
-    const list = m.get(key) ?? []
-    list.push(s)
-    m.set(key, list)
-  }
-  return m
-}
+

--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { CSSProperties } from 'react'
 import type { Session, SessionStatus } from './types'
+import type { SidebarGroup } from './sidebar-groups'
 
 type ContextMenu = {
   sessionId: string
@@ -9,13 +10,19 @@ type ContextMenu = {
 }
 
 type Props = {
-  groups: Map<string, Session[]>
+  groups: SidebarGroup[]
   activeId: string | null
   statuses: Record<string, SessionStatus>
   onNew: () => void
+  // Start a session in a specific project — opens the new-session dialog with
+  // the folder pre-filled.
+  onNewInProject: (cwd: string) => void
   onSelect: (id: string) => void
   onClose: (id: string) => void
   onRename: (id: string, name: string) => Promise<void>
+  // Null when the user hasn't anchored a repos directory yet.
+  reposDir: string | null
+  onChooseReposDir: () => void
   style?: CSSProperties
   isCollapsed?: boolean
   onToggleCollapse?: () => void
@@ -33,9 +40,12 @@ export function Sidebar({
   activeId,
   statuses,
   onNew,
+  onNewInProject,
   onSelect,
   onClose,
   onRename,
+  reposDir,
+  onChooseReposDir,
   style,
   isCollapsed,
   onToggleCollapse,
@@ -48,7 +58,8 @@ export function Sidebar({
 
   // Find the session object from context menu id
   const contextSession = contextMenu
-    ? [...groups.values()].flat().find((s) => s.id === contextMenu.sessionId) ?? null
+    ? groups.flatMap((g) => g.sessions).find((s) => s.id === contextMenu.sessionId) ??
+      null
     : null
 
   // Close context menu on outside click or Escape
@@ -139,15 +150,49 @@ export function Sidebar({
         ‹
       </button>
       <div className="groups">
-        {[...groups.entries()].map(([groupKey, list]) => {
-          const first = list[0]
-          const label = first?.repoLabel ?? shortenPath(first?.cwd ?? groupKey)
-          const titleAttr = first?.repoRoot ?? first?.cwd ?? groupKey
+        {groups.length === 0 && (
+          <div className="sidebar-empty">
+            {reposDir ? (
+              <p>No projects found in {shortenPath(reposDir)}.</p>
+            ) : (
+              <p>Anchor termhub to the folder that holds your projects.</p>
+            )}
+            <button className="new-btn" onClick={onChooseReposDir}>
+              Choose projects folder…
+            </button>
+          </div>
+        )}
+        {groups.map((group) => {
+          const { key: groupKey, label, sessions: list } = group
+          const titleAttr = groupKey
           return (
           <div className="group" key={groupKey}>
             <div className="group-title" title={titleAttr}>
-              {label}
+              <span className="group-title-label">{label}</span>
+              {group.isProject && (
+                <button
+                  className="group-add-btn"
+                  title={`New session in ${label}`}
+                  aria-label={`New session in ${label}`}
+                  onClick={() => onNewInProject(groupKey)}
+                >
+                  +
+                </button>
+              )}
             </div>
+            {group.isProject && list.length === 0 && (
+              <ul className="group-list">
+                <li
+                  className="item item--dormant"
+                  onClick={() => onNewInProject(groupKey)}
+                  title={`Start a session in ${label}`}
+                >
+                  <span className="item-label item-label--dormant">
+                    No sessions — click to start one
+                  </span>
+                </li>
+              </ul>
+            )}
             <ul className="group-list">
               {list.map((s, idx) => {
                 const status = statuses[s.id] ?? 'idle'
@@ -217,6 +262,15 @@ export function Sidebar({
         <button className="new-btn sidebar-new-btn" onClick={onNew}>
           + New Session
         </button>
+        {reposDir && (
+          <button
+            className="sidebar-anchor-btn"
+            onClick={onChooseReposDir}
+            title={`Projects folder: ${reposDir}`}
+          >
+            {shortenPath(reposDir)}
+          </button>
+        )}
       </div>
 
       {contextMenu && contextSession && (

--- a/src/sidebar-groups.test.ts
+++ b/src/sidebar-groups.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import { buildSidebarGroups } from './sidebar-groups'
+import type { ProjectDef, Session } from './types'
+
+const project = (label: string, path = `/repos/${label}`): ProjectDef => ({ path, label })
+
+const session = (id: string, over: Partial<Session> = {}): Session => ({
+  id,
+  cwd: '/repos/alpha',
+  repoRoot: '/repos/alpha',
+  repoLabel: 'alpha',
+  ...over,
+})
+
+describe('buildSidebarGroups', () => {
+  it('lists a discovered project even with no sessions — that is the point', () => {
+    const groups = buildSidebarGroups([project('alpha')], [])
+
+    expect(groups).toEqual([
+      { key: '/repos/alpha', label: 'alpha', sessions: [], isProject: true },
+    ])
+  })
+
+  it('merges a session into its project by repoRoot', () => {
+    const s = session('s1')
+    const groups = buildSidebarGroups([project('alpha')], [s])
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].sessions).toEqual([s])
+    expect(groups[0].isProject).toBe(true)
+  })
+
+  it('groups a worktree session under its parent project', () => {
+    // detectRepoRoot resolves a worktree back to the main checkout, so the
+    // session carries the parent repoRoot even though its cwd is nested.
+    const s = session('s1', {
+      cwd: '/repos/alpha/.claude/worktrees/feature-x',
+      repoRoot: '/repos/alpha',
+    })
+    const groups = buildSidebarGroups([project('alpha')], [s])
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].key).toBe('/repos/alpha')
+    expect(groups[0].sessions).toEqual([s])
+  })
+
+  it('creates an ad-hoc group for a session outside the anchor', () => {
+    const outside = session('s1', {
+      cwd: '/elsewhere/thing',
+      repoRoot: '/elsewhere/thing',
+      repoLabel: 'thing',
+    })
+    const groups = buildSidebarGroups([project('alpha')], [outside])
+
+    expect(groups.map((g) => [g.label, g.isProject])).toEqual([
+      ['alpha', true],
+      ['thing', false],
+    ])
+  })
+
+  it('falls back to the cwd basename when a stray session has no repo label', () => {
+    const loose = session('s1', {
+      cwd: '/tmp/scratch',
+      repoRoot: undefined,
+      repoLabel: undefined,
+    })
+    const groups = buildSidebarGroups([], [loose])
+
+    expect(groups[0].label).toBe('scratch')
+    expect(groups[0].key).toBe('/tmp/scratch')
+  })
+
+  it('sorts projects before ad-hoc groups, each alphabetically', () => {
+    const groups = buildSidebarGroups(
+      [project('zulu'), project('alpha')],
+      [
+        session('s1', { cwd: '/x/yankee', repoRoot: '/x/yankee', repoLabel: 'yankee' }),
+        session('s2', { cwd: '/x/bravo', repoRoot: '/x/bravo', repoLabel: 'bravo' }),
+      ],
+    )
+
+    expect(groups.map((g) => g.label)).toEqual(['alpha', 'zulu', 'bravo', 'yankee'])
+  })
+
+  it('ordering does not depend on session activity', () => {
+    // A sidebar that reorders as sessions start and stop is hard to build
+    // muscle memory against, so a busy project must not jump to the top.
+    const projects = [project('alpha'), project('beta')]
+    const idle = buildSidebarGroups(projects, []).map((g) => g.label)
+    const busy = buildSidebarGroups(projects, [
+      session('s1', { cwd: '/repos/beta', repoRoot: '/repos/beta', repoLabel: 'beta' }),
+    ]).map((g) => g.label)
+
+    expect(busy).toEqual(idle)
+  })
+
+  it('keeps multiple sessions in one project group, in order', () => {
+    const a = session('s1')
+    const b = session('s2')
+    const groups = buildSidebarGroups([project('alpha')], [a, b])
+
+    expect(groups[0].sessions.map((s) => s.id)).toEqual(['s1', 's2'])
+  })
+
+  it('returns [] when there are no projects and no sessions', () => {
+    expect(buildSidebarGroups([], [])).toEqual([])
+  })
+
+  it('still works with no anchor configured — sessions only', () => {
+    const s = session('s1')
+    const groups = buildSidebarGroups([], [s])
+
+    expect(groups).toEqual([
+      { key: '/repos/alpha', label: 'alpha', sessions: [s], isProject: false },
+    ])
+  })
+})

--- a/src/sidebar-groups.ts
+++ b/src/sidebar-groups.ts
@@ -1,0 +1,62 @@
+import type { ProjectDef, Session } from './types'
+
+// One row-group in the sidebar. A group is either a discovered project (which
+// may have zero live sessions — that's the point) or an ad-hoc group for a
+// session running somewhere outside the anchored repos directory.
+export type SidebarGroup = {
+  key: string
+  label: string
+  sessions: Session[]
+  // Discovered under the anchor directory. Drives the "start a session here"
+  // affordance on empty groups, and the ordering below.
+  isProject: boolean
+}
+
+function basename(p: string): string {
+  const parts = p.replace(/\\/g, '/').split('/').filter(Boolean)
+  return parts[parts.length - 1] ?? p
+}
+
+// Merge discovered projects with live sessions into the sidebar's row model.
+//
+// Sessions land in a project group when their repoRoot matches the project
+// path. That's what makes worktree sessions behave: detectRepoRoot resolves a
+// worktree back to the main checkout, so a session running in
+// <repo>/.claude/worktrees/foo groups under <repo> rather than spawning a
+// group of its own.
+//
+// Projects sort first (alphabetically), then non-project groups. Ordering is
+// deliberately independent of session activity — a sidebar that reorders
+// itself as sessions start and stop is hard to build muscle memory against.
+export function buildSidebarGroups(
+  projects: readonly ProjectDef[],
+  sessions: readonly Session[],
+): SidebarGroup[] {
+  const byKey = new Map<string, SidebarGroup>()
+
+  for (const p of projects) {
+    byKey.set(p.path, { key: p.path, label: p.label, sessions: [], isProject: true })
+  }
+
+  for (const s of sessions) {
+    const key = s.repoRoot ?? s.cwd
+    const existing = byKey.get(key)
+    if (existing) {
+      existing.sessions.push(s)
+      continue
+    }
+    byKey.set(key, {
+      key,
+      label: s.repoLabel ?? basename(s.cwd),
+      sessions: [s],
+      isProject: false,
+    })
+  }
+
+  const groups = [...byKey.values()]
+  groups.sort((a, b) => {
+    if (a.isProject !== b.isProject) return a.isProject ? -1 : 1
+    return a.label.localeCompare(b.label)
+  })
+  return groups
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -268,14 +268,91 @@ body,
 }
 
 .group-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   padding: 4px 12px;
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.07em;
   color: var(--text-dim);
+}
+
+.group-title-label {
+  flex: 1;
+  min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* Per-project "start a session here" affordance. Hidden until the group is
+   hovered so a sidebar full of projects isn't a wall of + buttons. */
+.group-add-btn {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 2px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+
+.group:hover .group-add-btn,
+.group-add-btn:focus-visible {
+  opacity: 1;
+}
+
+.group-add-btn:hover {
+  color: var(--accent);
+}
+
+/* A discovered project with nothing running in it. */
+.item--dormant {
+  cursor: pointer;
+}
+
+.item-label--dormant {
+  color: var(--text-dim);
+  font-style: italic;
+  font-size: 11px;
+}
+
+.sidebar-empty {
+  padding: 16px 12px;
+  color: var(--text-dim);
+  font-size: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.sidebar-empty p {
+  margin: 0;
+  line-height: 1.4;
+}
+
+.sidebar-anchor-btn {
+  width: 100%;
+  margin-top: 6px;
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 11px;
+  font-family: inherit;
+  text-align: left;
+  padding: 2px 0 0;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sidebar-anchor-btn:hover {
+  color: var(--accent);
 }
 
 .group-list {

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,8 +73,18 @@ export const PERMISSION_MODES = [
   'auto',
 ] as const
 
+// A git repo discovered under the anchored repos directory. `path` matches
+// Session.repoRoot so the sidebar can merge live sessions into their project.
+export type ProjectDef = {
+  path: string
+  label: string
+}
+
 export type Config = {
   mcpPort: number
+  // Anchor directory scanned for projects to list in the sidebar. Unset means
+  // the user hasn't chosen one yet and the sidebar shows only live sessions.
+  reposDir?: string
   startupSessions: StartupSession[]
   bottomTerminal?: {
     shellId?: string
@@ -123,6 +133,11 @@ export type TermhubApi = {
   getConfig: () => Promise<Config>
   configPath: () => Promise<string>
   openConfigFile: () => Promise<void>
+  listProjects: () => Promise<ProjectDef[]>
+  getReposDir: () => Promise<string | null>
+  // Opens the folder picker and persists the choice; returns the new anchor,
+  // or null if the user cancelled.
+  setReposDir: () => Promise<string | null>
   readClipboard: () => Promise<string>
   writeClipboard: (text: string) => void
   onData: (cb: (id: string, data: string) => void) => () => void


### PR DESCRIPTION
## Problem

The sidebar only showed repos that happened to have a live session, so starting work on a project meant **+ New Session → browse the filesystem**, every single time. Nothing in the app knew what projects you actually work on.

## What this adds

Point termhub at the folder that holds your projects; it lists them all, session or not. Projects with nothing running show as dormant rows you can click to start into.

```
FOUNDRY-TOOLKIT
  No sessions — click to start one
LEDGER
  ● ledger #1
TERMHUB                            +
  ● orchestrator
  ● feat-x
SCRATCH
  ● scratch #1
```

## The load-bearing detail

`electron/project-discovery.ts` walks the anchor for git repos (default depth 2, so `~/Repos/work/foo` still resolves) — and **stops descending once it finds a repo**.

That single rule is what makes this usable here. Orchestrator subagents create real checkouts under `<repo>/.claude/worktrees/<branch>/`, each with its own `.git`. A naive recursive scan finds **18 of them** in a real `~/Repos` and lists every one as a separate project. A worktree belongs to its parent, not beside it. `node_modules` and dot-directories are skipped too.

`src/sidebar-groups.ts` then merges projects with live sessions by `repoRoot` — which is what makes worktree *sessions* land under their parent, since `detectRepoRoot` already resolves a worktree back to the main checkout. Sessions outside the anchor keep their own ad-hoc group.

Ordering is projects-first then alphabetical, **deliberately independent of session activity**. A sidebar that reshuffles as sessions start and stop is impossible to build muscle memory against.

## Interaction

Clicking a dormant project (or the hover `+` on any project header) opens the new-session dialog with the folder **pre-filled** rather than spawning immediately. The default startup agent runs with `bypassPermissions`, so a stray click shouldn't start a real process.

`reposDir` lives in `config.json` and is set through a folder picker, so it survives restarts. Unset shows a first-run prompt; once set, the anchor appears in the footer and clicking it re-picks.

Contract updated across `src/types.ts`, `preload.ts`, and `ipc-app.ts` together.

## Verification

- Ran discovery against the **real `~/Repos`**: 6 projects found, all 18 worktree `.git` entries excluded.
- Rendered the sidebar against stubbed data in an isolated harness and confirmed: a worktree session groups under its parent, an outside-the-anchor session sorts last, the hover `+` appears, and the first-run empty state reads correctly.
- 22 new tests (13 discovery, 11 grouping — including an explicit guarantee that ordering doesn't depend on activity). **383 total, green**; typecheck and build clean.

Not run inside the real app — its startup config spawns live claude sessions on the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)