### PR TITLE
fix(sidebar): keep the projects-folder button reachable on first run

### DIFF
--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -262,15 +262,21 @@ export function Sidebar({
         <button className="new-btn sidebar-new-btn" onClick={onNew}>
           + New Session
         </button>
-        {reposDir && (
-          <button
-            className="sidebar-anchor-btn"
-            onClick={onChooseReposDir}
-            title={`Projects folder: ${reposDir}`}
-          >
-            {shortenPath(reposDir)}
-          </button>
-        )}
+        {/* Always rendered. The in-list empty state only appears when there
+            are no groups at all, and a first run auto-spawns the startup
+            orchestrator session — so gating this on reposDir left a new user
+            with no way to anchor the sidebar. */}
+        <button
+          className="sidebar-anchor-btn"
+          onClick={onChooseReposDir}
+          title={
+            reposDir
+              ? `Projects folder: ${reposDir}`
+              : 'Choose the folder that holds your projects'
+          }
+        >
+          {reposDir ? shortenPath(reposDir) : 'Choose projects folder…'}
+        </button>
       </div>
 
       {contextMenu && contextSession && (


### PR DESCRIPTION
## The bug

#83 gated the footer anchor button on `reposDir` being set, and the in-list prompt on there being no groups at all. **Those two conditions are never both false for a genuinely new user.**

`DEFAULT_CONFIG.startupSessions` spawns an orchestrator session at launch. So on a first run:

- there's one ad-hoc group → `groups.length === 0` is false → **in-list prompt suppressed**
- `reposDir` is still unset → **footer button suppressed**

Net result: no way to anchor the sidebar from the UI at all. Only a user who thought to close the startup session first would ever find it.

Found while wiping userData to reproduce a real first-run state — which is exactly why that was worth doing rather than reasoning about it.

## The fix

The footer button now always renders: `Choose projects folder…` until an anchor is set, the shortened path after. The in-list empty state is kept for the no-sessions-at-all case.

## On the missing test

This is JSX conditional rendering, and the repo has no React testing library — CLAUDE.md says not to add one unasked, so I didn't. Verified instead by rendering the **exact** first-run state (no `reposDir`, one startup session) in an isolated harness and confirming the button appears.

Worth noting the class of bug: both `sidebar-groups.ts` and `project-discovery.ts` are well covered, and neither had a defect. The gap was in the wiring between them and the UI — the part that isn't unit-testable here.

383 tests still green; typecheck and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)