### PR TITLE
chore: bump to 1.0.0 for the first tagged release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "termhub",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "private": true,
   "description": "A multi-session terminal manager",
   "license": "MIT",


### PR DESCRIPTION
Prerequisite for tagging `v1.0.0`.

The `release` job in `build.yml` refuses to publish when the tag and `package.json` disagree — artifact filenames are derived from `package.json`, so a mismatch would ship a release whose assets are named for a different version. Bumping has to land before the tag exists.

`0.2.0 → 1.0.0` is a deliberate jump rather than an increment: this is the first build published as an actual downloadable release.

Once merged, tagging `v1.0.0` triggers the Windows + macOS builds and publishes them to a GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)