### PR TITLE
fix: recover the login shell PATH so packaged builds can find claude

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -13,6 +13,7 @@ import { stripAnsi } from './output-buffer'
 import { writeBracketedPasteAndSubmit } from './claude-command'
 import { getMcpConfigPath, getMcpTokenPath, loadConfig } from './config'
 import { MCP_TOKEN_HEADER, getOrCreateToken } from './mcp-auth'
+import { applyLoginShellPath } from './shell-path'
 import { resolveSessionCwd } from './cwd-resolve'
 import { loadPersistedSessions } from './persistence'
 import { isClaudeModelName } from './codex-command'
@@ -235,6 +236,11 @@ function bootstrapSessions(config: Config): void {
 app.whenReady().then(async () => {
   // Remove the native File/Edit/… menu bar entirely.
   Menu.setApplicationMenu(null)
+
+  // Must precede any PTY spawn: cleanEnv() snapshots process.env per session,
+  // and a Finder-launched app starts with a PATH that has no Homebrew,
+  // /usr/local/bin, or version-manager shims — so `claude` is not found.
+  applyLoginShellPath()
 
   const config = loadConfig()
   initBottomShell()

--- a/electron/shell-path.test.ts
+++ b/electron/shell-path.test.ts
@@ -1,0 +1,165 @@
+// Regression coverage for the packaged-app PATH bug: a Finder-launched app on
+// macOS gets /usr/bin:/bin:/usr/sbin:/sbin, so `claude` installed at
+// /opt/homebrew/bin was never found and every session died with
+// "command not found: claude".
+
+import { describe, it, expect, vi } from 'vitest'
+import {
+  extractPathFromShellOutput,
+  mergePaths,
+  resolveLoginShellPath,
+  type ExecFn,
+} from './shell-path'
+
+const S = '__TERMHUB_PATH__'
+const wrap = (p: string) => `${S}${p}${S}`
+
+describe('extractPathFromShellOutput', () => {
+  it('pulls the value from between the sentinels', () => {
+    expect(extractPathFromShellOutput(wrap('/opt/homebrew/bin:/usr/bin'))).toBe(
+      '/opt/homebrew/bin:/usr/bin',
+    )
+  })
+
+  it('ignores shell startup noise around the sentinels', () => {
+    // A chatty rc file prints banners, motd, or `set -x` traces.
+    const out = `Welcome!\n+ some trace\n${wrap('/a:/b')}\nmore noise\n`
+    expect(extractPathFromShellOutput(out)).toBe('/a:/b')
+  })
+
+  it('preserves paths containing spaces', () => {
+    const p = '/Users/alex/Library/Application Support/bin:/usr/bin'
+    expect(extractPathFromShellOutput(wrap(p))).toBe(p)
+  })
+
+  it('returns null when the sentinel is absent', () => {
+    expect(extractPathFromShellOutput('command not found\n')).toBeNull()
+  })
+
+  it('returns null when only the opening sentinel is present', () => {
+    expect(extractPathFromShellOutput(`${S}/a:/b`)).toBeNull()
+  })
+
+  it('returns null when the value is empty or whitespace', () => {
+    expect(extractPathFromShellOutput(wrap(''))).toBeNull()
+    expect(extractPathFromShellOutput(wrap('   '))).toBeNull()
+  })
+})
+
+describe('mergePaths', () => {
+  it('puts login entries first, then unseen current entries', () => {
+    expect(mergePaths('/opt/homebrew/bin:/usr/bin', '/usr/bin:/sbin')).toBe(
+      '/opt/homebrew/bin:/usr/bin:/sbin',
+    )
+  })
+
+  it('deduplicates', () => {
+    expect(mergePaths('/a:/b:/a', '/b:/c')).toBe('/a:/b:/c')
+  })
+
+  it('drops empty segments from a trailing or doubled colon', () => {
+    expect(mergePaths('/a::/b:', '/c')).toBe('/a:/b:/c')
+  })
+
+  it('handles an undefined current PATH', () => {
+    expect(mergePaths('/a:/b', undefined)).toBe('/a:/b')
+  })
+
+  it('never loses an entry Electron had that the login shell lacks', () => {
+    const merged = mergePaths('/opt/homebrew/bin', '/some/electron/only/bin')
+    expect(merged.split(':')).toContain('/some/electron/only/bin')
+  })
+
+  it('recovers the real-world case: homebrew missing from the GUI PATH', () => {
+    const guiPath = '/usr/bin:/bin:/usr/sbin:/sbin'
+    expect(guiPath).not.toContain('/opt/homebrew/bin')
+
+    const merged = mergePaths('/opt/homebrew/bin:/usr/local/bin:/usr/bin', guiPath)
+    expect(merged.split(':')).toContain('/opt/homebrew/bin')
+    // and the original entries survive
+    for (const p of guiPath.split(':')) expect(merged.split(':')).toContain(p)
+  })
+})
+
+describe('resolveLoginShellPath', () => {
+  const exec = (out: string): ExecFn => () => out
+
+  it('returns the parsed PATH from the login shell', () => {
+    const got = resolveLoginShellPath({
+      platform: 'darwin',
+      shell: '/bin/zsh',
+      exec: exec(wrap('/opt/homebrew/bin:/usr/bin')),
+    })
+    expect(got).toBe('/opt/homebrew/bin:/usr/bin')
+  })
+
+  it('is a no-op on Windows — GUI processes get PATH from the registry', () => {
+    const spy = vi.fn()
+    expect(
+      resolveLoginShellPath({ platform: 'win32', shell: 'C:/cmd.exe', exec: spy }),
+    ).toBeNull()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('returns null when $SHELL is unset', () => {
+    // Stub the env rather than passing shell: undefined — that would fall
+    // through to the real process.env.SHELL and exercise nothing.
+    vi.stubEnv('SHELL', '')
+    const spy = vi.fn()
+    expect(resolveLoginShellPath({ platform: 'darwin', exec: spy })).toBeNull()
+    expect(spy).not.toHaveBeenCalled()
+    vi.unstubAllEnvs()
+  })
+
+  it('returns null rather than throwing when the shell fails or times out', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const got = resolveLoginShellPath({
+      platform: 'darwin',
+      shell: '/bin/zsh',
+      exec: () => {
+        throw new Error('ETIMEDOUT')
+      },
+    })
+    expect(got).toBeNull()
+  })
+
+  it('uses an interactive login shell for zsh — PATH is often set in .zshrc', () => {
+    let seen: string[] = []
+    resolveLoginShellPath({
+      platform: 'darwin',
+      shell: '/bin/zsh',
+      exec: (_f, args) => {
+        seen = args
+        return wrap('/a')
+      },
+    })
+    expect(seen[0]).toBe('-ilc')
+  })
+
+  it('asks fish to join PATH explicitly — it stores PATH as a list', () => {
+    let seen: string[] = []
+    resolveLoginShellPath({
+      platform: 'darwin',
+      shell: '/opt/homebrew/bin/fish',
+      exec: (_f, args) => {
+        seen = args
+        return wrap('/a')
+      },
+    })
+    expect(seen).toContain('-l')
+    expect(seen.join(' ')).toContain('string join :')
+  })
+
+  it('passes the shell binary through to exec', () => {
+    let file = ''
+    resolveLoginShellPath({
+      platform: 'darwin',
+      shell: '/bin/bash',
+      exec: (f) => {
+        file = f
+        return wrap('/a')
+      },
+    })
+    expect(file).toBe('/bin/bash')
+  })
+})

--- a/electron/shell-path.ts
+++ b/electron/shell-path.ts
@@ -1,0 +1,121 @@
+// Recovers the user's real PATH on macOS / Linux.
+//
+// A GUI-launched app does not inherit the shell environment. On macOS,
+// `launchctl getenv PATH` is normally unset, so an app started from Finder
+// gets only /usr/bin:/bin:/usr/sbin:/sbin — no /opt/homebrew/bin, no
+// /usr/local/bin, no ~/.local/bin, no nvm shims. cleanEnv() then copies that
+// minimal PATH into every PTY, so `claude` (installed via Homebrew, npm -g, or
+// a version manager) is simply not found, and the session dies with
+// "command not found: claude".
+//
+// This never reproduces under `npm run dev`, because Electron launched from a
+// terminal inherits that terminal's PATH. It only bites the packaged app.
+//
+// The fix is to ask the user's login shell what PATH it would set up, which is
+// what `fix-path` / `shell-env` do on npm. Done here directly to avoid adding a
+// dependency for ~40 lines.
+
+import { execFileSync } from 'node:child_process'
+
+// Wrapping the value lets us find it in output that may also contain shell
+// startup noise (motd, prompt escapes, `set -x` traces from a chatty rc file).
+const SENTINEL = '__TERMHUB_PATH__'
+
+// Exported for tests.
+export function extractPathFromShellOutput(stdout: string): string | null {
+  const first = stdout.indexOf(SENTINEL)
+  if (first === -1) return null
+  const start = first + SENTINEL.length
+  const end = stdout.indexOf(SENTINEL, start)
+  if (end === -1) return null
+  const value = stdout.slice(start, end).trim()
+  return value.length > 0 ? value : null
+}
+
+// Union of the login PATH and whatever we already had, login entries first.
+// A union rather than a replacement: the login shell's PATH is what the user
+// expects `claude` to resolve against, but we must not drop anything Electron
+// itself put there.
+export function mergePaths(
+  loginPath: string,
+  currentPath: string | undefined,
+): string {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const part of [...loginPath.split(':'), ...(currentPath ?? '').split(':')]) {
+    if (part.length === 0 || seen.has(part)) continue
+    seen.add(part)
+    out.push(part)
+  }
+  return out.join(':')
+}
+
+// fish stores PATH as a list, so "$PATH" interpolates space-separated rather
+// than colon-separated. Ask it to join explicitly instead of trying to parse
+// the difference afterwards — macOS paths contain spaces, so splitting output
+// on whitespace is not safe.
+function commandFor(shell: string): { args: string[] } {
+  const name = shell.replace(/\\/g, '/').split('/').pop() ?? ''
+  if (name === 'fish') {
+    return { args: ['-l', '-c', `printf '%s%s%s' '${SENTINEL}' (string join : $PATH) '${SENTINEL}'`] }
+  }
+  // -i matters: on zsh, PATH is commonly set in .zshrc (interactive) rather
+  // than .zprofile, so a non-interactive login shell misses it.
+  return { args: ['-ilc', `printf '%s%s%s' '${SENTINEL}' "$PATH" '${SENTINEL}'`] }
+}
+
+export type ExecFn = (file: string, args: string[]) => string
+
+const defaultExec: ExecFn = (file, args) =>
+  execFileSync(file, args, {
+    encoding: 'utf8',
+    // A chatty or prompting rc file must not hang startup.
+    timeout: 5000,
+    // Startup noise goes to stderr; the sentinel scan handles stdout.
+    stdio: ['ignore', 'pipe', 'ignore'],
+  })
+
+// Returns the login shell's PATH, or null when it can't be determined (or
+// isn't needed). Windows resolves PATH from the registry for GUI processes,
+// so there is nothing to recover there.
+export function resolveLoginShellPath(opts?: {
+  platform?: NodeJS.Platform
+  shell?: string
+  exec?: ExecFn
+}): string | null {
+  const platform = opts?.platform ?? process.platform
+  if (platform === 'win32') return null
+
+  const shell = opts?.shell ?? process.env.SHELL
+  if (!shell) return null
+
+  const exec = opts?.exec ?? defaultExec
+  try {
+    const stdout = exec(shell, commandFor(shell).args)
+    return extractPathFromShellOutput(stdout)
+  } catch (err) {
+    console.warn(
+      `[termhub:path] could not read PATH from login shell ${shell}; ` +
+        'CLI lookups will use the inherited PATH',
+      err,
+    )
+    return null
+  }
+}
+
+// Merge the login shell's PATH into process.env.PATH. Must run before any PTY
+// is spawned, since cleanEnv() snapshots process.env per session.
+export function applyLoginShellPath(): void {
+  const loginPath = resolveLoginShellPath()
+  if (!loginPath) return
+
+  const merged = mergePaths(loginPath, process.env.PATH)
+  if (merged === process.env.PATH) {
+    console.log('[termhub:path] PATH already matches the login shell')
+    return
+  }
+  process.env.PATH = merged
+  console.log(
+    `[termhub:path] merged login shell PATH (${merged.split(':').length} entries)`,
+  )
+}


### PR DESCRIPTION
## The bug

**v1.0.0 is unusable when launched from Finder.** Every session dies with:

```
zsh: command not found: claude
```

A GUI-launched macOS app doesn't inherit the shell environment. `launchctl getenv PATH` is normally unset, so Finder gives the app only `/usr/bin:/bin:/usr/sbin:/sbin` — no `/opt/homebrew/bin`, `/usr/local/bin`, `~/.local/bin`, or version-manager shims. `cleanEnv()` then copies that minimal PATH into every PTY, so neither the spawned `claude` command nor anything the user types by hand can resolve it.

Reproduced directly:

```
$ env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin sh -c 'command -v claude'
claude: NOT FOUND        # what termhub sees
$ which claude
/opt/homebrew/bin/claude # where it actually is
```

**This never reproduces under `npm run dev`** — Electron launched from a terminal inherits that terminal's PATH. It's packaged-only, which is exactly the case CLAUDE.md flags as needing installer testing, and exactly the case that had never been tested.

## The fix

`electron/shell-path.ts` asks the login shell for its PATH and merges it into `process.env.PATH` before any PTY spawns. Same approach as the `fix-path` / `shell-env` npm packages, done directly rather than taking a dependency for ~40 lines.

Details that matter:

- **Union, not replacement.** Login PATH goes first, but nothing Electron already had is dropped.
- **zsh gets `-ilc`.** PATH is commonly set in `.zshrc`, which a non-interactive login shell never reads.
- **fish gets `string join :`.** It stores PATH as a list, so `"$PATH"` interpolates space-separated. Splitting output on whitespace isn't an option — macOS paths contain spaces.
- **Sentinel-delimited output**, so a chatty rc file (motd, banners, `set -x` traces) can't corrupt the value.
- **5s timeout**, and any failure degrades to the inherited PATH rather than blocking startup.
- **No-op on Windows**, where GUI processes get PATH from the registry.

## Verification

Ran the real resolver from a process with the exact Finder PATH:

```
starting PATH (GUI-style): /usr/bin:/bin:/usr/sbin:/sbin
resolved from login shell: OK
homebrew now present: true
claude resolves to: /opt/homebrew/bin/claude
```

19 new tests, including the real-world homebrew-missing case, paths containing spaces, dedup/ordering, and that a shell timeout returns null rather than throwing. **402 total, green**; typecheck and build clean.

## Follow-up

v1.0.0's binaries have this bug. Once this merges, the release needs re-cutting so the published download actually works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)