### PR TITLE
chore: bump to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "termhub",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "A multi-session terminal manager",
   "license": "MIT",


### PR DESCRIPTION
Ships the login-shell PATH fix from #86.

v1.0.0's binaries can't resolve `claude` when the app is launched from Finder — a GUI-launched macOS app gets `/usr/bin:/bin:/usr/sbin:/sbin` with no Homebrew — which makes them unusable. The release job requires the tag to match `package.json`, so this has to land before `v1.0.1` can be tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)