### PR TITLE
fix(layout): clamp the persisted bottom-pane height on load and resize

### DIFF
--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
+  clampBottomHeight,
   clampHeight,
   clampDimension,
   readPersistedHeight,
@@ -51,6 +52,48 @@ describe('clampHeight', () => {
     // When available is 0 the max is also 0 which is less than min,
     // so the result should equal the minimum (Math.max wins).
     expect(clampHeight(100, BOTTOM_MIN_HEIGHT, BOTTOM_MAX_FRACTION, 0)).toBe(BOTTOM_MIN_HEIGHT)
+  })
+})
+
+// Regression: the persisted height was applied unclamped on load, so a height
+// saved in a tall window squeezed .main-top toward zero in a shorter one.
+// .main-bottom is `flex: 0 0 auto` and cannot shrink, so past the container it
+// spilled and got clipped — the claude terminal appeared cut off by the shell
+// selector. Measured in a 600px container: persisted 500 left the top pane at
+// 96px, and persisted 900 left it at 0 with 304px spilling past .main.
+describe('clampBottomHeight', () => {
+  it('leaves a height that already fits alone', () => {
+    expect(clampBottomHeight(220, 600)).toBe(220)
+  })
+
+  it('caps an oversized persisted height at the max fraction', () => {
+    // 70% of 600 — leaves 180px for the claude pane instead of 96px.
+    expect(clampBottomHeight(500, 600)).toBe(420)
+  })
+
+  it('caps a height larger than the container, which would otherwise spill', () => {
+    expect(clampBottomHeight(900, 600)).toBe(420)
+    expect(clampBottomHeight(900, 600)).toBeLessThan(600)
+  })
+
+  it('raises a too-small height to the minimum', () => {
+    expect(clampBottomHeight(5, 600)).toBe(BOTTOM_MIN_HEIGHT)
+  })
+
+  it('never returns more than the container height', () => {
+    for (const available of [100, 300, 600, 1200, 2000]) {
+      expect(clampBottomHeight(99999, available)).toBeLessThanOrEqual(available)
+    }
+  })
+
+  it('always leaves room for the claude pane', () => {
+    for (const available of [300, 600, 1200]) {
+      expect(available - clampBottomHeight(99999, available)).toBeGreaterThan(0)
+    }
+  })
+
+  it('falls back to the minimum in a degenerate zero-height container', () => {
+    expect(clampBottomHeight(400, 0)).toBe(BOTTOM_MIN_HEIGHT)
   })
 })
 

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -31,6 +31,18 @@ export function clampDimension(
 export const clampHeight = clampDimension
 export const clampWidth = clampDimension
 
+// Clamp a bottom-pane height against the space actually available, with the
+// split's own min/max bound in.
+//
+// This has to run on load and on window resize, not just while dragging.
+// .main-bottom is `flex: 0 0 auto`, so it cannot shrink: a height persisted in
+// a tall window squeezes .main-top toward zero in a shorter one, and past the
+// container it spills and gets clipped by `.main { overflow: hidden }` — which
+// looks like the claude terminal being cut off by the shell selector.
+export function clampBottomHeight(raw: number, available: number): number {
+  return clampDimension(raw, BOTTOM_MIN_HEIGHT, BOTTOM_MAX_FRACTION, available)
+}
+
 /**
  * Read the persisted bottom-terminal height from localStorage.
  * Falls back to `defaultHeight` when the stored value is absent or

--- a/src/useSplitLayout.ts
+++ b/src/useSplitLayout.ts
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import {
+  clampBottomHeight,
   clampHeight,
   readPersistedHeight,
   BOTTOM_MIN_HEIGHT,
@@ -41,6 +42,49 @@ export function useSplitLayout(): UseSplitLayoutResult {
   useEffect(() => {
     bottomHeightRef.current = bottomHeight
   }, [bottomHeight])
+
+  // Re-clamp against the space actually available — on mount and on every
+  // window resize.
+  //
+  // readPersistedHeight deliberately does no clamping; it can't, because it has
+  // no idea how tall the container will be. Without this, a height persisted in
+  // a tall (or maximised) window squeezes .main-top toward zero in a shorter
+  // one — .main-bottom is `flex: 0 0 auto` and cannot shrink — and past the
+  // container it spills and is clipped by `.main { overflow: hidden }`. The
+  // visible symptom is the claude terminal being cut off by the shell selector.
+  //
+  // Layout effect, not a plain effect, so the correction lands before paint
+  // rather than flashing a broken split for a frame.
+  const clampToContainer = useCallback(() => {
+    const container = mainContainerRef.current
+    if (!container) return
+    const available = container.getBoundingClientRect().height
+    if (available <= 0) return
+    setBottomHeight((prev) => {
+      const next = clampBottomHeight(prev, available)
+      if (next === prev) return prev
+      console.info(
+        `[termhub:layout] clamped bottom pane ${prev} -> ${next} for ${Math.round(available)}px of space`,
+      )
+      bottomHeightRef.current = next
+      return next
+    })
+  }, [])
+
+  useLayoutEffect(() => {
+    clampToContainer()
+  }, [clampToContainer])
+
+  useEffect(() => {
+    // Skip while dragging: the drag handler already clamps against a live
+    // measurement, and re-entering here would fight it.
+    const onResize = () => {
+      if (isDraggingRef.current) return
+      clampToContainer()
+    }
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [clampToContainer])
 
   const handleDividerMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault()


### PR DESCRIPTION
## Symptom

The bottom of the claude terminal is cut off by the bottom shell panel and its shell selector.

## Cause

[`readPersistedHeight`](src/layout.ts) returned the stored value **unclamped** — it only checked `Number.isFinite(parsed) && parsed > 0`. `clampHeight` was applied while *dragging* the divider, but never on load and never on window resize.

`.main-bottom` is `flex: 0 0 auto`, so it **cannot shrink**. A height persisted in a tall or maximised window therefore squeezes `.main-top` toward zero in a shorter one, and past the container it spills and is clipped by `.main { overflow: hidden }`.

Measured with the real CSS in a 600px container:

| persisted | claude pane (`.main-top`) | bottom pane | spill past `.main` |
|---|---|---|---|
| 220 (default) | 376 | 220 | 0 |
| 500 | **96** | 500 | 0 |
| 900 | **0** | 900 | **304px** |

## Fix

- **`layout.ts`** — `clampBottomHeight(raw, available)` binds the split's own min/max so callers can't forget them.
- **`useSplitLayout`** — clamps in a **layout** effect on mount (before paint, so a broken split never flashes) and on window resize. The resize handler bails while dragging, since the drag path already clamps against a live measurement.

## Verification

Drove the **real hook** against the **real CSS** with `900` in localStorage:

| | before | after |
|---|---|---|
| claude pane @ 500px viewport | **0px**, 134px spilling | **146px**, spill 0 |
| bottom pane | 630px (can't shrink) | 350px (70% cap) |

Both the mount path and the resize path confirmed via console (`[termhub:layout] clamped bottom pane 630 -> 350 for 500px of space`).

7 new tests on `clampBottomHeight`, including that it never returns more than the container height and always leaves room for the claude pane. **409 tests green**, typecheck and build clean.

## Scope note

This fixes the **geometry** — the claude pane now gets real height. I have not verified that xterm's `fit()` produces the right row count within the corrected space; if content still looks clipped by a row or two, that's a separate issue in the fit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)